### PR TITLE
fix arrow in safari

### DIFF
--- a/src/components/@molecules/SearchInput/SearchResults.tsx
+++ b/src/components/@molecules/SearchInput/SearchResults.tsx
@@ -32,6 +32,7 @@ const SearchItem = styled.div<{
     &:last-of-type {
       border-bottom: 0;
     }
+    position: relative;
     opacity: 0.6;
     ${$clickable &&
     css`


### PR DESCRIPTION
fixes this:
<img width="118" alt="Screen Shot 2022-06-23 at 6 26 45 pm" src="https://user-images.githubusercontent.com/11844316/175253363-f422e228-c62e-4d17-82e9-ca51b825531e.png">

