### PR TITLE
Gracefully display com.twitter when leading "@"

### DIFF
--- a/src/utils/getSocialData.ts
+++ b/src/utils/getSocialData.ts
@@ -4,9 +4,9 @@ export const getSocialData = (iconKey: string, value: string) => {
       return {
         icon: 'twitter',
         color: '#65C5FC',
-        value: `@${value}`,
+        value: `@${value.replace(/^\@/, '')}`,
         type: 'link',
-        urlFormatter: `https://twitter.com/${value}`,
+        urlFormatter: `https://twitter.com/${value.replace(/^\@/, '')}`,
       }
     case 'com.github':
       return {


### PR DESCRIPTION
Love the new app!

# Issue
Users who write their `com.twitter` entry with leading "@" will see "@@" in the UI.

# Fix
Enhance display logic to ensure the "@" symbol always appears exactly once in the UI.

# Before
![image](https://user-images.githubusercontent.com/3518037/176607178-e4c619f9-cce3-4af5-82ed-0254f8dc3808.png)

# After
![image](https://user-images.githubusercontent.com/3518037/176607111-bea74f72-2624-459d-a38e-758bad4f9de4.png)


# Author
Patched authored by cory.eth (Cory Gabrielsen) (@cory_eth).