### PR TITLE
Fix uri encoded names

### DIFF
--- a/src/hooks/useValidate.ts
+++ b/src/hooks/useValidate.ts
@@ -10,7 +10,7 @@ export const useValidate = (input: string, skip?: any) => {
   useEffect(() => {
     if (!skip) {
       try {
-        const normalisedName = validateName(input)
+        const normalisedName = validateName(decodeURIComponent(input))
         setNormalisedName(normalisedName)
 
         const inputType = parseInputType(normalisedName)


### PR DESCRIPTION
- previously, URI encoded names were not decoded before being normalised. this would display them as invalid
- now the names are decoded before being normalised