### PR TITLE
feat: learn more links

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -160,7 +160,7 @@ export const Header = () => {
   const statefulRoutes = isConnected
     ? dropdownRoutes
     : breakpoints.lg
-    ? dropdownRoutes.slice(3)
+    ? dropdownRoutes.slice(4)
     : dropdownRoutes
 
   let RouteItems: ReactNode

--- a/src/components/pages/profile/[name]/details/SubnamesTab.tsx
+++ b/src/components/pages/profile/[name]/details/SubnamesTab.tsx
@@ -192,7 +192,9 @@ export const SubnamesTab = ({
         <AddSubnamesCard>
           <Typography>
             {t('details.tabs.subnames.addSubname.title')}{' '}
-            <Outlink href="#">{t('details.tabs.subnames.addSubname.learn')}</Outlink>
+            <Outlink href="/faq/managing-a-name#what-is-the-difference-between-a-name-and-a-subname">
+              {t('details.tabs.subnames.addSubname.learn')}
+            </Outlink>
           </Typography>
           <Button
             data-testid="add-subname-action"

--- a/src/pages/faq/[slug].tsx
+++ b/src/pages/faq/[slug].tsx
@@ -4,7 +4,7 @@ import { GetStaticPropsContext } from 'next'
 import Link from 'next/link'
 import { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
-import styled, { css } from 'styled-components'
+import styled, { DefaultTheme, css, keyframes } from 'styled-components'
 
 import { LinkSVG, Typography, mq } from '@ensdomains/thorin'
 
@@ -56,21 +56,37 @@ const OptionLinks = styled(Card)(
   `,
 )
 
+const targetKeyframes = ({ theme }: { theme: DefaultTheme }) => keyframes`
+  0% {
+    background-color: rgba(${theme.shadesRaw.foreground}, 0.05);
+  }
+
+  100% {
+    background-color: rgba(${theme.shadesRaw.foreground}, 0);
+  }
+`
+
 const OptionFAQ = styled(Card)(
   ({ theme }) => css`
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     justify-content: flex-start;
-    gap: ${theme.space['6']};
+    gap: ${theme.space['4']};
 
-    padding: ${theme.space['4']};
+    padding: ${theme.space['2']};
 
     & > div {
       display: flex;
       flex-direction: column;
       align-items: stretch;
       justify-content: flex-start;
+      padding: ${theme.space['2']};
+
+      &:target {
+        border-radius: ${theme.radii.extraLarge};
+        animation: 0.5s ease-in-out 1s 1 normal both running ${targetKeyframes};
+      }
 
       li {
         list-style: disc;
@@ -106,7 +122,7 @@ const OptionFAQ = styled(Card)(
     }
 
     ${mq.md.min(css`
-      padding: ${theme.space['6']};
+      padding: ${theme.space['6']} ${theme.space['4']};
     `)}
   `,
 )

--- a/src/pages/faq/[slug].tsx
+++ b/src/pages/faq/[slug].tsx
@@ -6,7 +6,7 @@ import { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
-import { Typography, mq } from '@ensdomains/thorin'
+import { LinkSVG, Typography, mq } from '@ensdomains/thorin'
 
 import { Card } from '@app/components/Card'
 import { faqOptions } from '@app/constants/faq'
@@ -62,7 +62,7 @@ const OptionFAQ = styled(Card)(
     flex-direction: column;
     align-items: flex-start;
     justify-content: flex-start;
-    gap: ${theme.space['4']};
+    gap: ${theme.space['6']};
 
     padding: ${theme.space['4']};
 
@@ -83,13 +83,9 @@ const OptionFAQ = styled(Card)(
         list-style: circle;
       }
 
-      a {
+      & > div:last-of-type a {
         color: ${theme.colors.accent};
         text-decoration: underline;
-      }
-
-      & > div:first-of-type {
-        font-weight: ${theme.fontWeights.bold};
       }
     }
 
@@ -115,11 +111,41 @@ const OptionFAQ = styled(Card)(
   `,
 )
 
+const Question = styled(Typography)(
+  ({ theme }) => css`
+    text-decoration: none;
+    color: ${theme.colors.text};
+    font-weight: ${theme.fontWeights.bold};
+    font-size: ${theme.fontSizes.large};
+    & > svg {
+      display: inline-block;
+      vertical-align: text-bottom;
+      width: ${theme.space['5']};
+      height: ${theme.space['5']};
+      stroke-width: ${theme.space['0.75']};
+      margin-left: ${theme.space['2']};
+      color: ${theme.colors.grey};
+
+      opacity: 0;
+      transition: opacity 0.15s ease-in-out;
+    }
+
+    &:hover > svg,
+    &:active > svg {
+      opacity: 1;
+    }
+  `,
+)
+
 function Page({ slug }: { slug: string }) {
   const currentOption = faqOptions.find((option) => option.slug === slug)!
   const { t } = useTranslation('faq')
   const questions = t(currentOption.title, { returnObjects: true }) as Record<string, string>
-  const questionArray = Object.entries(questions)
+  const questionArray = Object.entries(questions).map(([question, answer]) => [
+    question,
+    answer,
+    question.replace(/\s/g, '-').replace(/\?/g, '').toLowerCase(),
+  ])
 
   return (
     <Content title={t('title')}>
@@ -143,9 +169,12 @@ function Page({ slug }: { slug: string }) {
               <Typography>{t(`option.${currentOption.title}`)}</Typography>
             </div>
             <>
-              {questionArray.map(([question, answer]) => (
-                <div key={question}>
-                  <Typography>{question}</Typography>
+              {questionArray.map(([question, answer, id]) => (
+                <div key={question} id={id}>
+                  <Question href={`#${id}`} as="a">
+                    {question}
+                    <LinkSVG />
+                  </Question>
                   <Typography>
                     <Markdown>{answer}</Markdown>
                   </Typography>

--- a/src/transaction-flow/input/SendName-flow.tsx
+++ b/src/transaction-flow/input/SendName-flow.tsx
@@ -175,7 +175,9 @@ export const SendName = ({ data, dispatch, onDismiss }: Props) => {
     <>
       <Typography variant="extraLarge">{t('details.sendName.title')}</Typography>
       <Typography style={{ textAlign: 'center' }}>{t('details.sendName.description')}</Typography>
-      <Outlink href="">{t('details.sendName.learnMore')}</Outlink>
+      <Outlink href="/faq/managing-a-name#what-are-managers-and-owners">
+        {t('details.sendName.learnMore')}
+      </Outlink>
       {canSendOwner && (
         <SwitchBox>
           <TextContainer>

--- a/src/transaction-flow/intro/ChangePrimaryName.tsx
+++ b/src/transaction-flow/intro/ChangePrimaryName.tsx
@@ -24,7 +24,9 @@ export const ChangePrimaryName = () => {
       <Typography>
         {t('tabs.profile.actions.setAsPrimaryName.description')}{' '}
         <span>
-          <Outlink href="#">{t('action.learnMore', { ns: 'common' })}</Outlink>
+          <Outlink href="/faq/managing-a-name#what-is-a-primary-ens-name">
+            {t('action.learnMore', { ns: 'common' })}
+          </Outlink>
         </span>
       </Typography>
     </DescriptionWrapper>

--- a/src/transaction-flow/intro/MigrateAndUpdateResolver.tsx
+++ b/src/transaction-flow/intro/MigrateAndUpdateResolver.tsx
@@ -1,7 +1,9 @@
-import { Outlink } from '@app/components/Outlink'
-import { Typography } from '@ensdomains/thorin'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
+
+import { Typography } from '@ensdomains/thorin'
+
+import { Outlink } from '@app/components/Outlink'
 
 const DescriptionWrapper = styled(Typography)(
   ({ theme }) => css`
@@ -25,7 +27,9 @@ export const MigrateAndUpdateResolver = () => {
           {t('intro.migrateAndUpdateResolver.title')}
           &nbsp;
           <span>
-            <Outlink href="#">{t('intro.migrateAndUpdateResolver.link')}</Outlink>
+            <Outlink href="/faq/managing-a-name#what-is-a-resolver">
+              {t('intro.migrateAndUpdateResolver.link')}
+            </Outlink>
           </span>
         </Typography>
         <Typography color="textSecondary" weight="bold">

--- a/src/transaction-flow/intro/WrapName.tsx
+++ b/src/transaction-flow/intro/WrapName.tsx
@@ -40,7 +40,9 @@ export const WrapName = ({ name }: { name: string }) => {
         <Typography>
           {t('details.wrap.description')}{' '}
           <span>
-            <Outlink href="#">{t('action.learnMore', { ns: 'common' })}</Outlink>
+            <Outlink href="/faq/managing-a-name#what-is-the-name-wrapper">
+              {t('action.learnMore', { ns: 'common' })}
+            </Outlink>
           </span>
         </Typography>
       </DescriptionWrapper>


### PR DESCRIPTION
- removed duplicate FAQ links in navigation
- tweaked styling to increase space between FAQs
- made FAQs clickable to create hyperlinks
- added `:target` styling for FAQs so the user knows which has been linked
- resolved all learn more links:
  - Name ownership (transfer flow, send flow): Point to FAQ "What are Managers and Owners?"
  - Primary Name: Point to FAQ "What is a primary ENS name?"
  - Subnames (subname flow): Point to FAQ "What is the difference between a name and a subname?"
  - Resolver upgrade (resolver upgrade flow) Point to FAQ "What is a Resolver?"
  - Name wrapper (wrap name flow): Point to FAQ "What is the Name Wrapper?"