### PR TITLE
fix flaky position on avatar load

### DIFF
--- a/src/components/@molecules/ProfileEditor/Avatar/AvatarCrop.tsx
+++ b/src/components/@molecules/ProfileEditor/Avatar/AvatarCrop.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable no-multi-assign */
+import { debounce } from 'lodash'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
@@ -176,46 +177,49 @@ export const CropComponent = ({
     }
   }, [])
 
-  const handleImageLoad = useCallback(() => {
-    const image = imageRef.current
-    const { size, cropSize, max, ctx } = getVars(canvasRef.current!)
-    const { width: iw, height: ih } = image
-    const ir = iw / ih
+  const handleImageLoad = useCallback(
+    debounce(() => {
+      const image = imageRef.current
+      const { size, cropSize, max, ctx } = getVars(canvasRef.current!)
+      const { width: iw, height: ih } = image
+      const ir = iw / ih
 
-    let x: number
-    let y: number
-    let w: number
-    let h: number
-    if (ir > 1) {
-      h = cropSize
-      w = h * ir
-      x = (size - w) / 2
-      y = max
-    } else if (ir < 1) {
-      w = cropSize
-      h = w / ir
-      x = max
-      y = (size - h) / 2
-    } else {
-      // eslint-disable-next-line no-multi-assign
-      w = h = cropSize
-      // eslint-disable-next-line no-multi-assign
-      x = y = max
-    }
-    ctx!.drawImage(image, x, y, w, h)
-    coordinatesRef.current = {
-      x,
-      y,
-      w,
-      h,
-      oW: w,
-      oH: h,
-      mx: 0,
-      my: 0,
-      moving: false,
-    }
-    window.requestAnimationFrame(draw)
-  }, [draw])
+      let x: number
+      let y: number
+      let w: number
+      let h: number
+      if (ir > 1) {
+        h = cropSize
+        w = h * ir
+        x = (size - w) / 2
+        y = max
+      } else if (ir < 1) {
+        w = cropSize
+        h = w / ir
+        x = max
+        y = (size - h) / 2
+      } else {
+        // eslint-disable-next-line no-multi-assign
+        w = h = cropSize
+        // eslint-disable-next-line no-multi-assign
+        x = y = max
+      }
+      ctx!.drawImage(image, x, y, w, h)
+      coordinatesRef.current = {
+        x,
+        y,
+        w,
+        h,
+        oW: w,
+        oH: h,
+        mx: 0,
+        my: 0,
+        moving: false,
+      }
+      window.requestAnimationFrame(draw)
+    }, 100),
+    [draw],
+  )
 
   const handleMoveStart = (e: MouseEvent | TouchEvent) => {
     e.preventDefault()


### PR DESCRIPTION
When user picks avatar image with file picker multiple times, the loaded image appears in wrong position and size.
This PR avoid the side effect by debouncing the load callback function.

![flaky-avatar-load](https://user-images.githubusercontent.com/2774845/202936492-f12b1c37-90ec-4a34-a5fe-da2246e04a62.gif)
