### PR TITLE
fix: dynamic load contenthash utils in transactions

### DIFF
--- a/src/transaction-flow/transaction/extendNames.ts
+++ b/src/transaction-flow/transaction/extendNames.ts
@@ -1,6 +1,6 @@
 import type { JsonRpcSigner } from '@ethersproject/providers'
-import { BigNumber } from 'ethers'
-import { TFunction } from 'react-i18next'
+import type { BigNumber } from 'ethers'
+import type { TFunction } from 'react-i18next'
 
 import { HelperProps, PublicENS, Transaction, TransactionDisplayItem } from '@app/types'
 import { makeDisplay } from '@app/utils/currency'

--- a/src/transaction-flow/transaction/migrateProfileWithSync.ts
+++ b/src/transaction-flow/transaction/migrateProfileWithSync.ts
@@ -1,13 +1,11 @@
 import type { JsonRpcSigner } from '@ethersproject/providers'
-import { TFunction } from 'react-i18next'
+import type { TFunction } from 'react-i18next'
 
-import { RecordOptions } from '@ensdomains/ensjs/utils/recordHelpers'
+import type { RecordOptions } from '@ensdomains/ensjs/utils/recordHelpers'
 
 import { Profile, PublicENS, RecordItem, Transaction, TransactionDisplayItem } from '@app/types'
 import { recordItemToKeyValue } from '@app/utils/editor'
 import { recordOptionsToToupleList } from '@app/utils/records'
-
-import { contentHashToString } from '../../utils/contenthash'
 
 type Data = {
   name: string
@@ -94,6 +92,11 @@ export const syncRecords = (
 }
 
 const transaction = async (signer: JsonRpcSigner, ens: PublicENS, data: Data) => {
+  // dynamic import for large dependency
+  const contentHashToString = await import('../../utils/contenthash').then(
+    (m) => m.contentHashToString,
+  )
+
   const profile = await ens.getProfile(data.name)
   if (!profile) throw new Error('No profile found')
   if (!profile.records) throw new Error('No records found')


### PR DESCRIPTION
previously all contenthash utils were bundled into the app via the migrateProfileWithSync transaction.
now within the transaction it is dynamically imported so it can be avoided on first load