### PR TITLE
fix: other field values in profile editor

### DIFF
--- a/src/components/@molecules/AddRecordButton/AddRecordButton.test.tsx
+++ b/src/components/@molecules/AddRecordButton/AddRecordButton.test.tsx
@@ -106,4 +106,18 @@ describe('AddRecordButton', () => {
 
     expect(mockHandleAddRecord).toHaveBeenCalledWith('another')
   })
+
+  it('should call onAddRecord with form safe input value', async () => {
+    render(<AddRecordButton createable onAddRecord={mockHandleAddRecord} />)
+
+    fireEvent.click(screen.getByTestId('add-record-button-button'))
+
+    const input = await screen.findByTestId('add-record-button-input')
+    await userEvent.type(input, 'com.example')
+
+    const submit = await screen.findByText('action.add')
+    fireEvent.click(submit)
+
+    expect(mockHandleAddRecord).toHaveBeenCalledWith('com\u2024example')
+  })
 })

--- a/src/components/@molecules/AddRecordButton/AddRecordButton.tsx
+++ b/src/components/@molecules/AddRecordButton/AddRecordButton.tsx
@@ -6,6 +6,7 @@ import styled, { css, useTheme } from 'styled-components'
 import { Button, CloseSVG, Input, PlusSVG, SearchSVG } from '@ensdomains/thorin'
 
 import UnsupportedSVG from '@app/assets/Unsupported.svg'
+import { formSafeKey } from '@app/utils/editor'
 
 const Container = styled.div<{ $state: TransitionState }>(
   ({ theme, $state }) => css`
@@ -348,7 +349,7 @@ export const AddRecordButton = ({
 
   const handleInputAction = () => {
     if (inputActionType === 'create' && onAddRecord) {
-      onAddRecord(inputValue)
+      onAddRecord(formSafeKey(inputValue))
     }
     toggle(false)
     setInputValue('')
@@ -394,6 +395,7 @@ export const AddRecordButton = ({
             type="button"
             $accented={inputActionType === 'create'}
             onClick={handleInputAction}
+            data-testid="add-record-button-input-action"
           >
             {inputActionType === 'create'
               ? t('action.add', { ns: 'common' })


### PR DESCRIPTION
previously when using the profile editor, keys entered in the other tab were not converted to a form safe key before being added to the form. this meant that keys with a dot in them would be incorrectly parsed as a separate group, which would then be shown to the user as "[object Object]"

example:
![custom-record-registration-saving](https://user-images.githubusercontent.com/11844316/212572437-c72a3414-da03-4687-8a5b-c3d81ce50088.gif)

now before a key is added to the form, it is converted to a form safe value which allows the key to include dots