### PR TITLE
fix: /my/profile redirect

### DIFF
--- a/src/components/pages/profile/[name]/Profile.tsx
+++ b/src/components/pages/profile/[name]/Profile.tsx
@@ -143,7 +143,7 @@ const ProfileContent = ({ nameDetails, isSelf, isLoading, name }: Props) => {
       url.searchParams.set(key, value as string)
     }
     url.searchParams.set('tab', newTab)
-    router.replace(url.toString(), undefined, {
+    router._replace(url.toString(), undefined, {
       shallow: true,
     })
   }

--- a/src/hooks/useRouterWithHistory.ts
+++ b/src/hooks/useRouterWithHistory.ts
@@ -5,6 +5,13 @@ import { getDestination } from '@app/routes'
 export const useRouterWithHistory = () => {
   const router = useRouter()
 
+  const _replace = router.replace
+
+  const replace = (pathname: string) => {
+    const destination = getDestination(pathname)
+    router.replace(destination)
+  }
+
   const push = (pathname: string, query?: Record<string, any>) => {
     const destination = getDestination({ pathname, query })
     router.push(destination)
@@ -17,5 +24,5 @@ export const useRouterWithHistory = () => {
     router.push(destination, typeof destination === 'string' ? undefined : destination.pathname)
   }
 
-  return { ...router, push, pushWithHistory }
+  return { ...router, push, pushWithHistory, replace, _replace }
 }

--- a/src/hooks/useRouterWithHistory.ts
+++ b/src/hooks/useRouterWithHistory.ts
@@ -5,7 +5,7 @@ import { getDestination } from '@app/routes'
 export const useRouterWithHistory = () => {
   const router = useRouter()
 
-  const _replace = router.replace
+  const _replace = router?.replace
 
   const replace = (pathname: string) => {
     const destination = getDestination(pathname)


### PR DESCRIPTION
previously would redirect to `/profile/:name` instead of `/:name`
fixed by using getDestination in router.replace