### PR TITLE
fix: from in url

### DIFF
--- a/src/components/@atoms/NameDetailItem/NameDetailItem.test.tsx
+++ b/src/components/@atoms/NameDetailItem/NameDetailItem.test.tsx
@@ -41,10 +41,7 @@ describe('NameDetailitem', () => {
         <div>child</div>
       </NameDetailItem>,
     )
-    expect(screen.getByText('truncatedName').closest('a')).toHaveAttribute(
-      'href',
-      '/tld/name?from=currentpath',
-    )
+    expect(screen.getByText('truncatedName').closest('a')).toHaveAttribute('href', '/tld/name')
   })
   it('should show zorb when there is no avatar', () => {
     mockUseZorb.mockReturnValue('zorb')

--- a/src/components/@atoms/NameDetailItem/NameDetailItem.tsx
+++ b/src/components/@atoms/NameDetailItem/NameDetailItem.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router'
 import { ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
@@ -138,7 +137,6 @@ export const NameDetailItem = ({
   onClick?: () => void
   children: ReactNode
 }) => {
-  const router = useRouter()
   const { avatar } = useAvatar(name, network)
   const zorb = useZorb(name, 'name')
 
@@ -148,16 +146,7 @@ export const NameDetailItem = ({
   }
 
   return (
-    <OptionalLink
-      active={mode !== 'select'}
-      href={{
-        pathname: `/profile/${name}`,
-        query: {
-          from: router.asPath,
-        },
-      }}
-      passHref
-    >
+    <OptionalLink active={mode !== 'select'} href={`/profile/${name}`} passHref>
       <NameItemWrapper
         $disabled={disabled}
         $highlight={mode === 'select' && selected}

--- a/src/components/@atoms/OptionalLink/OptionalLink.tsx
+++ b/src/components/@atoms/OptionalLink/OptionalLink.tsx
@@ -1,12 +1,12 @@
 import { ComponentProps } from 'react'
 
-import BaseLink from '../BaseLink'
+import { BaseLinkWithHistory } from '../BaseLink'
 
-type Props = ComponentProps<typeof BaseLink> & { active?: boolean }
+type Props = ComponentProps<typeof BaseLinkWithHistory> & { active?: boolean }
 
 export const OptionalLink = ({ children, active, ...props }: Props) => {
   if (!active) {
     return <>{children}</>
   }
-  return <BaseLink {...props}>{children}</BaseLink>
+  return <BaseLinkWithHistory {...props}>{children}</BaseLinkWithHistory>
 }

--- a/src/components/pages/profile/[name]/Profile.tsx
+++ b/src/components/pages/profile/[name]/Profile.tsx
@@ -13,6 +13,7 @@ import { useRecentTransactions } from '@app/hooks/transactions/useRecentTransact
 import { useChainId } from '@app/hooks/useChainId'
 import { useNameDetails } from '@app/hooks/useNameDetails'
 import { useProtectedRoute } from '@app/hooks/useProtectedRoute'
+import { useQueryParameterState } from '@app/hooks/useQueryParameterState'
 import { useRouterWithHistory } from '@app/hooks/useRouterWithHistory'
 import { useSelfAbilities } from '@app/hooks/useSelfAbilities'
 import { Content } from '@app/layouts/Content'
@@ -168,17 +169,7 @@ const ProfileContent = ({ nameDetails, isSelf, isLoading, name }: Props) => {
     ]
   }, [isSelf, normalisedName, valid, name, t])
 
-  const tab = (router.query.tab as Tab) || 'profile'
-  const setTab = (newTab: Tab) => {
-    const url = new URL(router.asPath, window.location.origin)
-    for (const [key, value] of Object.entries(router.query)) {
-      url.searchParams.set(key, value as string)
-    }
-    url.searchParams.set('tab', newTab)
-    router._replace(url.toString(), undefined, {
-      shallow: true,
-    })
-  }
+  const [tab, setTab] = useQueryParameterState<Tab>('tab', 'profile')
   const visibileTabs = isWrapped ? tabs : tabs.filter((_tab) => _tab !== 'permissions')
 
   const selfAbilities = useSelfAbilities(address, name)

--- a/src/components/pages/profile/[name]/tabs/MoreTab/Ownership.tsx
+++ b/src/components/pages/profile/[name]/tabs/MoreTab/Ownership.tsx
@@ -6,7 +6,7 @@ import { useAccount, useQueryClient } from 'wagmi'
 import { Button, Helper, Tag, Typography, mq } from '@ensdomains/thorin'
 
 import AeroplaneSVG from '@app/assets/Aeroplane.svg'
-import BaseLink from '@app/components/@atoms/BaseLink'
+import { BaseLinkWithHistory } from '@app/components/@atoms/BaseLink'
 import { cacheableComponentStyles } from '@app/components/@atoms/CacheableComponent'
 import { DisabledButtonWithTooltip } from '@app/components/@molecules/DisabledButtonWithTooltip'
 import { AvatarWithZorb } from '@app/components/AvatarWithZorb'
@@ -129,7 +129,7 @@ const Owner = ({ address, label }: ReturnType<typeof useOwners>[0]) => {
   const network = useChainId()
 
   return (
-    <BaseLink passHref href={`/address/${address}`}>
+    <BaseLinkWithHistory passHref href={`/address/${address}`}>
       <OwnerContainer as="a">
         <OwnerDetailContainer>
           <AvatarWithZorb
@@ -152,7 +152,7 @@ const Owner = ({ address, label }: ReturnType<typeof useOwners>[0]) => {
         </OwnerDetailContainer>
         <Tag colorStyle="accentSecondary">{t(label)}</Tag>
       </OwnerContainer>
-    </BaseLink>
+    </BaseLinkWithHistory>
   )
 }
 

--- a/src/hooks/useQueryParameterState.ts
+++ b/src/hooks/useQueryParameterState.ts
@@ -15,10 +15,25 @@ export const useQueryParameterState = <T extends string | number>(
     getInitialValue(router.query[parameter] as string, defaultValue),
   )
   const setState = (value: T) => {
+    const visibleSearchParams = new URLSearchParams(window.location.search)
     const url = new URL(router.asPath, window.location.href)
-    if (value && value !== defaultValue) url.searchParams.set(parameter, value.toString())
-    else url.searchParams.delete(parameter)
-    router.replace(url.toString(), undefined, { shallow: true })
+    const visibleUrl = new URL(router.asPath, window.location.href)
+
+    for (const [key, queryVal] of Object.entries(router.query)) {
+      // eslint-disable-next-line no-continue
+      if (key === parameter) continue
+      url.searchParams.set(key, queryVal as string)
+      if (visibleSearchParams.has(key)) {
+        visibleUrl.searchParams.set(key, queryVal as string)
+      }
+    }
+
+    if (value && value !== defaultValue) {
+      url.searchParams.set(parameter, value.toString())
+      visibleUrl.searchParams.set(parameter, value.toString())
+    }
+
+    router.replace(url.toString(), visibleUrl.toString(), { shallow: true })
     _setState(value)
   }
   return [state, setState]

--- a/src/hooks/useQueryParameterState.ts
+++ b/src/hooks/useQueryParameterState.ts
@@ -41,10 +41,8 @@ export const useQueryParameterState = <T extends string | number>(
   }
 
   useEffect(() => {
-    if (paramValue) {
-      _setState(getInitialValue(paramValue, defaultValue))
-    }
+    _setState(getInitialValue(paramValue, defaultValue))
   }, [defaultValue, paramValue, router.isReady])
 
-  return [state, setState]
+  return [paramValue ? state : defaultValue, setState]
 }


### PR DESCRIPTION
the `from` query as well as some other queries that are meant to be hidden from the user are sometimes visible in the browser's url bar. not only does it look ugly, but it also can lead to unexpected behaviour if a user copies a link with hidden queries (such as the back button showing when there is no previous history on the site).

- when replacing the url, `useQueryParameterState` now uses separate `url` and `visibleUrl` objects for corresponding search params.
- profile tabs now use `useQueryParameterState`
- added `BaseLinkWithHistory` to be used in more places so back button is available more consistently (mobile only)