### PR TITLE
fix: add back button to record input

### DIFF
--- a/src/components/pages/profile/[name]/registration/steps/Profile/AddProfileRecordView.test.tsx
+++ b/src/components/pages/profile/[name]/registration/steps/Profile/AddProfileRecordView.test.tsx
@@ -190,4 +190,17 @@ describe('AddProfileRecordView', () => {
       }
     }
   })
+
+  it('should not show dismiss button by default', async () => {
+    result.current.reset({ records: [] })
+    render(<AddProfileRecordView control={result.current.control} onClose={() => {}} />)
+    expect(screen.queryByTestId('dismiss-dialog-btn')).not.toBeInTheDocument()
+    expect(screen.getByTestId('add-profile-records-close')).toBeInTheDocument()
+  })
+
+  it('should show dismiss button if specified', async () => {
+    result.current.reset({ records: [] })
+    render(<AddProfileRecordView control={result.current.control} showDismiss onClose={() => {}} />)
+    expect(screen.getByTestId('dismiss-dialog-btn')).toBeInTheDocument()
+  })
 })

--- a/src/components/pages/profile/[name]/registration/steps/Profile/AddProfileRecordView.tsx
+++ b/src/components/pages/profile/[name]/registration/steps/Profile/AddProfileRecordView.tsx
@@ -132,9 +132,10 @@ type Props = {
   control: Control<ProfileEditorForm, any>
   onAdd?: (records: ProfileRecord[]) => void
   onClose?: () => void
+  showDismiss?: boolean
 }
 
-export const AddProfileRecordView = ({ control, onAdd, onClose }: Props) => {
+export const AddProfileRecordView = ({ control, onAdd, onClose, showDismiss }: Props) => {
   const { t, i18n } = useTranslation('register')
 
   const currentRecords = useWatch({ control, name: 'records' })
@@ -369,20 +370,36 @@ export const AddProfileRecordView = ({ control, onAdd, onClose }: Props) => {
         </OptionsContainer>
       </Content>
       <FooterWrapper>
-        <Button
-          size="medium"
-          onClick={() => onAdd?.(selectedRecords)}
-          count={selectedRecords.length}
-          fullWidthContent
-          disabled={selectedRecords.length === 0}
-          data-testid="add-profile-records-button"
-        >
-          {t('action.add', { ns: 'common' })}
-        </Button>
+        <Dialog.Footer
+          leading={
+            !showDismiss &&
+            onClose && (
+              <Button
+                data-testid="add-profile-records-close"
+                onClick={() => onClose()}
+                colorStyle="accentSecondary"
+              >
+                {t('action.back', { ns: 'common' })}
+              </Button>
+            )
+          }
+          trailing={
+            <Button
+              size="medium"
+              onClick={() => onAdd?.(selectedRecords)}
+              count={selectedRecords.length}
+              fullWidthContent
+              disabled={selectedRecords.length === 0}
+              data-testid="add-profile-records-button"
+            >
+              {t('action.add', { ns: 'common' })}
+            </Button>
+          }
+        />
       </FooterWrapper>
-      {onClose && (
+      {onClose && showDismiss && (
         <DismissButtonWrapper>
-          <DismissDialogButton onClick={onClose} />
+          <DismissDialogButton data-testid="dismiss-dialog-btn" onClick={onClose} />
         </DismissButtonWrapper>
       )}
     </Container>

--- a/src/components/pages/profile/[name]/registration/steps/Profile/Profile.tsx
+++ b/src/components/pages/profile/[name]/registration/steps/Profile/Profile.tsx
@@ -218,6 +218,7 @@ const Profile = ({ nameDetails, callback, registrationData, resolverExists }: Pr
         return (
           <AddProfileRecordView
             control={control}
+            showDismiss
             onAdd={(newRecords) => {
               addRecords(newRecords)
               setModalOpen(false)


### PR DESCRIPTION
ref: FET-1006

go to edit a profile of a name you own and when adding a new profile record, you should now see a close button in the dialog footer, but no top right dismiss button (cross icon)