### PR TITLE
Fix transactions section in settings

### DIFF
--- a/src/components/pages/profile/settings/PrimarySection.tsx
+++ b/src/components/pages/profile/settings/PrimarySection.tsx
@@ -72,7 +72,7 @@ export const PrimarySection = () => {
           />
         </ItemWrapper>
       ) : (
-        <Typography data-testid="primary-section-text">
+        <Typography data-testid="primary-section-text" fontVariant="bodyBold" color="grey">
           {isLoading ? t('section.primary.loading') : t('section.primary.noName')}
         </Typography>
       )}

--- a/src/components/pages/profile/settings/TransactionSection.test.tsx
+++ b/src/components/pages/profile/settings/TransactionSection.test.tsx
@@ -1,6 +1,7 @@
-import { mockFunction, render, screen } from '@app/test-utils'
+import { mockFunction, render, screen, waitFor } from '@app/test-utils'
 
 import { act } from '@testing-library/react'
+import React from 'react'
 
 import type { Transaction } from '@app/hooks/transactions/transactionStore'
 import { useClearRecentTransactions } from '@app/hooks/transactions/useClearRecentTransactions'
@@ -32,6 +33,14 @@ describe('TransactionSection', () => {
   mockUseChainName.mockReturnValue('mainnet')
   mockUseClearRecentTransactions.mockReturnValue(mockClearTransactions)
 
+  beforeAll(() => {
+    Element.prototype.getBoundingClientRect = () =>
+      ({
+        width: 300,
+        height: 300,
+      } as any)
+  })
+
   it('should render', () => {
     mockUseRecentTransactions.mockReturnValue([])
     render(<TransactionSection />)
@@ -39,22 +48,28 @@ describe('TransactionSection', () => {
     expect(screen.getByText('section.transaction.title')).toBeVisible()
     expect(screen.getByText('section.transaction.noRecentTransactions')).toBeVisible()
   })
-  it('should only show 4 transactions on initial render', () => {
+
+  it('should only show 5 transactions on initial render', () => {
     mockUseRecentTransactions.mockReturnValue(Array.from({ length: 9 }, makeRecentTransaction()))
     render(<TransactionSection />)
-    expect(screen.getAllByTestId('transaction-confirmed')).toHaveLength(4)
+    expect(screen.getAllByTestId('transaction-confirmed')).toHaveLength(5)
   })
-  it('should have correct height when "View More" button is visiable', () => {
+
+  it('should have correct height when "View More" button is visiable', async () => {
     mockUseRecentTransactions.mockReturnValue(Array.from({ length: 9 }, makeRecentTransaction()))
     render(<TransactionSection />)
     const element = screen.getByTestId('transaction-section-container')
-    expect(element).toHaveStyle(`height: calc( 5 * 4.5rem );`)
+    await waitFor(() => {
+      expect(element).toHaveStyle(`height: 300px;`)
+    })
   })
-  it('should have correct height when "View More" button is NOT visiable', () => {
+  it('should have correct height when "View More" button is NOT visiable', async () => {
     mockUseRecentTransactions.mockReturnValue(Array.from({ length: 4 }, makeRecentTransaction()))
     render(<TransactionSection />)
     const element = screen.getByTestId('transaction-section-container')
-    expect(element).toHaveStyle(`height: calc( 4 * 4.5rem );`)
+    await waitFor(() => {
+      expect(element).toHaveStyle(`height: 300px;`)
+    })
   })
   it('should not show View More button if there is less than 5 transactions', () => {
     mockUseRecentTransactions.mockReturnValue(Array.from({ length: 4 }, makeRecentTransaction()))

--- a/src/components/pages/profile/settings/TransactionSection.tsx
+++ b/src/components/pages/profile/settings/TransactionSection.tsx
@@ -77,6 +77,9 @@ const StyledOutlink = styled(Outlink)<{ $error: boolean }>(
   ({ theme, $error }) =>
     $error &&
     css`
+      > div {
+        color: ${theme.colors.red};
+      }
       color: ${theme.colors.red};
     `,
 )

--- a/src/components/pages/profile/settings/TransactionSection.tsx
+++ b/src/components/pages/profile/settings/TransactionSection.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
-import { Button, Spinner, Typography } from '@ensdomains/thorin'
+import { Button, Spinner, Typography, mq } from '@ensdomains/thorin'
 
 import { useClearRecentTransactions } from '@app/hooks/transactions/useClearRecentTransactions'
 import { useRecentTransactions } from '@app/hooks/transactions/useRecentTransactions'
@@ -18,21 +18,17 @@ const TransactionSectionContainer = styled.div<{
   $transactionLength: number
   $hasViewMore: boolean
 }>(
-  ({ theme, $transactionLength, $hasViewMore }) => css`
+  ({ $transactionLength }) => css`
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     width: 100%;
-    height: ${theme.space['13']};
     overflow: hidden;
     transition: 0.2s all ease-in-out, 0s justify-content 0s linear, 0s color 0s linear;
     ${$transactionLength &&
     css`
       justify-content: flex-end;
-      height: calc(
-        ${$hasViewMore ? $transactionLength + 1 : $transactionLength} * ${theme.space['18']}
-      );
       background-color: transparent;
     `}
   `,
@@ -45,10 +41,10 @@ const RecentTransactionsMessage = styled(Typography)(
 )
 
 const TransactionContainer = styled(Card)(
-  ({ theme }) => css`
+  ({ theme, onClick }) => css`
     width: 100%;
     min-height: ${theme.space['18']};
-    padding: 0 ${theme.space['3']};
+    padding: ${theme.space['3']};
     flex-direction: row;
     justify-content: space-between;
     gap: ${theme.space['3']};
@@ -56,6 +52,12 @@ const TransactionContainer = styled(Card)(
     border: none;
     border-bottom: 1px solid ${theme.colors.border};
     border-radius: ${theme.radii.none};
+
+    ${onClick &&
+    css`
+      cursor: pointer;
+    `}
+
     &:last-of-type {
       border: none;
     }
@@ -64,6 +66,7 @@ const TransactionContainer = styled(Card)(
 
 const TransactionInfoContainer = styled.div(
   ({ theme }) => css`
+    flex: 1;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -84,12 +87,20 @@ const StyledOutlink = styled(Outlink)<{ $error: boolean }>(
     `,
 )
 
-const ContinueContainer = styled.div(
-  ({ theme }) => css`
+const ContinueContainer = styled.div(({ theme }) => [
+  css`
     max-width: ${theme.space['48']};
-    width: ${theme.space.full};
+    width: fit-content;
+    button {
+      padding: 0 ${theme.space['4']};
+    }
   `,
-)
+  mq.sm.min(css`
+    button {
+      padding: 0 ${theme.space['8']};
+    }
+  `),
+])
 
 const ViewMoreInner = styled(Typography)(
   ({ theme }) => css`
@@ -183,13 +194,13 @@ export const TransactionSection = () => {
                       </StyledOutlink>
                     </TransactionInfoContainer>
                   </InfoContainer>
-                  <ContinueContainer>
-                    {resumable && (
+                  {resumable && (
+                    <ContinueContainer>
                       <Button size="small" onClick={() => resumeTransactionFlow(key)}>
                         Continue
                       </Button>
-                    )}
-                  </ContinueContainer>
+                    </ContinueContainer>
+                  )}
                 </TransactionContainer>
               )
             })}

--- a/src/components/pages/profile/settings/TransactionSection.tsx
+++ b/src/components/pages/profile/settings/TransactionSection.tsx
@@ -16,24 +16,18 @@ import { Outlink } from '../../../Outlink'
 import { SectionContainer } from './Section'
 
 const TransactionSectionContainer = styled.div<{
-  $transactionLength: number
-  $hasViewMore: boolean
   $height: string
 }>(
-  ({ $transactionLength, $height }) => css`
+  ({ $height }) => css`
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
     width: 100%;
     overflow: hidden;
     height: ${$height};
-    transition: 0.2s all ease-in-out, 0s justify-content 0s linear, 0s color 0s linear;
-    ${$transactionLength &&
-    css`
-      justify-content: flex-end;
-      background-color: transparent;
-    `}
+    transition: 0.2s all ease-in-out;
+    justify-content: flex-end;
+    background-color: transparent;
   `,
 )
 
@@ -173,7 +167,7 @@ export const TransactionSection = () => {
     return () => {
       window.removeEventListener('resize', onResize)
     }
-  })
+  }, [])
 
   useEffect(() => {
     const _height = ref.current?.getBoundingClientRect().height || 0
@@ -200,12 +194,7 @@ export const TransactionSection = () => {
       }
       fill
     >
-      <TransactionSectionContainer
-        $transactionLength={visibleTransactions.length}
-        $hasViewMore={hasViewMore}
-        $height={height}
-        data-testid="transaction-section-container"
-      >
+      <TransactionSectionContainer $height={height} data-testid="transaction-section-container">
         <TransactionSectionInner ref={ref}>
           {transactions.length > 0 ? (
             <>

--- a/src/hooks/useDebouncedCallback.ts
+++ b/src/hooks/useDebouncedCallback.ts
@@ -12,6 +12,7 @@ export default function useDebouncedCallback<T extends (...args: any[]) => Retur
       clearTimeout(timerId.current)
       timerId.current = setTimeout(() => func(...args), wait)
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [func, wait, ...deps],
   ) as T
 }

--- a/src/hooks/useThrottledCallback.ts
+++ b/src/hooks/useThrottledCallback.ts
@@ -1,0 +1,25 @@
+import { DependencyList, useCallback, useRef } from 'react'
+
+export default function useThrottledCallback<T extends (...args: any[]) => ReturnType<T>>(
+  func: T,
+  wait = 300,
+  deps: DependencyList = [],
+): T {
+  const lastRan = useRef(Date.now())
+  const timerId = useRef<NodeJS.Timer>()
+
+  return useCallback(
+    (...args: Parameters<T>) => {
+      const now = Date.now()
+      clearTimeout(timerId.current)
+      if (now - lastRan.current >= wait) {
+        lastRan.current = now
+        func(...args)
+      } else {
+        timerId.current = setTimeout(() => func(...args), wait)
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [func, wait, ...deps],
+  ) as T
+}


### PR DESCRIPTION
Latest Update
* Updated the "No primary name set" to match the "No recent transactions" style

Update Outlink red styling
* Go to settings
* Create a failed transaction
* Etherscan link should be red

Transaction List items
* If there is no continue button, do not render container div
* Add padding and remove set height restrictions