### PR TITLE
fix: correct expiry in more tab

### DIFF
--- a/src/components/pages/profile/[name]/tabs/MoreTab/MoreTab.test.tsx
+++ b/src/components/pages/profile/[name]/tabs/MoreTab/MoreTab.test.tsx
@@ -121,5 +121,17 @@ describe('MoreTab', () => {
       })
       expect(screen.queryByText(`Miscellaneous-expiry:${date.toString()}`)).not.toBeInTheDocument()
     })
+    it('should use registrar expiry if available', () => {
+      const registrarExpiry = new Date(Date.now() + 1000)
+      const wrapperExpiry = new Date(Date.now() + 2000)
+      renderHelper({
+        name: 'test.eth',
+        isWrapped: true,
+        pccExpired: false,
+        wrapperData: { expiryDate: wrapperExpiry } as any,
+        expiryDate: registrarExpiry,
+      })
+      expect(screen.getByText(`Miscellaneous-expiry:${registrarExpiry.toString()}`)).toBeVisible()
+    })
   })
 })

--- a/src/components/pages/profile/[name]/tabs/MoreTab/MoreTab.tsx
+++ b/src/components/pages/profile/[name]/tabs/MoreTab/MoreTab.tsx
@@ -54,7 +54,7 @@ const MoreTab = ({ name, nameDetails, selfAbilities }: Props) => {
         expiryDate={validateExpiry(
           name,
           wrapperData,
-          wrapperData?.expiryDate || expiryDate,
+          expiryDate || wrapperData?.expiryDate,
           pccExpired,
         )}
         name={name}


### PR DESCRIPTION
this fix is significantly more simple than i thought it would be lol
registrar expiry is now the default expiry, with the wrapper expiry being the fallback

ref: FET-1049