### PR TITLE
fix: names table tweaks

### DIFF
--- a/src/components/@molecules/NameTableHeader/NameTableHeader.tsx
+++ b/src/components/@molecules/NameTableHeader/NameTableHeader.tsx
@@ -182,16 +182,16 @@ export const NameTableHeader = ({
                 id="sort-by"
               />
               <DirectionButton
-                $active={sortDirection === 'desc'}
-                onClick={() => onSortDirectionChange?.('desc')}
-              >
-                <UpDirectionSVG />
-              </DirectionButton>
-              <DirectionButton
                 $active={sortDirection === 'asc'}
                 onClick={() => onSortDirectionChange?.('asc')}
               >
                 <DownDirectionSVG />
+              </DirectionButton>
+              <DirectionButton
+                $active={sortDirection === 'desc'}
+                onClick={() => onSortDirectionChange?.('desc')}
+              >
+                <UpDirectionSVG />
               </DirectionButton>
             </TableHeaderLeftControlsContainer>
           )}

--- a/src/components/pages/my/names/MyNames.test.tsx
+++ b/src/components/pages/my/names/MyNames.test.tsx
@@ -30,7 +30,7 @@ const expectQuery = (address: string, page: number) => {
     address,
     sort: {
       type: 'expiryDate',
-      orderDirection: 'desc',
+      orderDirection: 'asc',
     },
     page,
     resultsPerPage: 10,

--- a/src/components/pages/my/names/MyNames.tsx
+++ b/src/components/pages/my/names/MyNames.tsx
@@ -66,7 +66,7 @@ const MyNames = () => {
   const [sortType, setSortType] = useQueryParameterState<SortType>('sort', 'expiryDate')
   const [sortDirection, setSortDirection] = useQueryParameterState<SortDirection>(
     'direction',
-    'desc',
+    'asc',
   )
   const [searchQuery, setSearchQuery] = useQueryParameterState<string>('search', '')
 

--- a/src/hooks/useNamesFromAddress.test.ts
+++ b/src/hooks/useNamesFromAddress.test.ts
@@ -117,6 +117,30 @@ describe('useNamesFromAddress', () => {
         new Date(Date.now() + 60 * 60 * 24 * 1000 * 5).getDate(),
       )
     })
+    it('should show names without expiry at top when sorting by asc expiryDate', async () => {
+      const names = [...Array.from({ length: 5 }, makeNameItem(false)), makeNameItem(true)(null, 5)]
+
+      mockGetNames.mockResolvedValue(names)
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useNamesFromAddress({
+          page: 1,
+          resultsPerPage: 5,
+          sort: {
+            orderDirection: 'asc',
+            type: 'expiryDate',
+          },
+          address: '0x123',
+        }),
+      )
+      await waitForNextUpdate()
+      const first = result.current.currentPage![0]
+      const last = result.current.currentPage![4]
+      expect(first.expiryDate).toBeUndefined()
+      expect(last.expiryDate?.getDate()).toBe(
+        new Date(Date.now() + 60 * 60 * 24 * 1000 * 3).getDate(),
+      )
+    })
     it('should sort by label name', async () => {
       const names = Array.from({ length: 10 }, makeNameItem(false))
 

--- a/src/hooks/useNamesFromAddress.test.ts
+++ b/src/hooks/useNamesFromAddress.test.ts
@@ -91,8 +91,8 @@ describe('useNamesFromAddress', () => {
         new Date(Date.now() - 60 * 60 * 24 * 1000 * 5).getDate(),
       )
     })
-    it('should sort by expiry date', async () => {
-      const names = Array.from({ length: 10 }, makeNameItem(false))
+    it('should sort by expiry date (descending)', async () => {
+      const names = [...Array.from({ length: 9 }, makeNameItem(false)), makeNameItem(true)(null, 9)]
 
       mockGetNames.mockResolvedValue(names)
 
@@ -109,16 +109,18 @@ describe('useNamesFromAddress', () => {
       )
       await waitForNextUpdate()
       const first = result.current.currentPage![0]
+      const second = result.current.currentPage![1]
       const last = result.current.currentPage![4]
-      expect(first.expiryDate?.getDate()).toBe(
-        new Date(Date.now() + 60 * 60 * 24 * 1000 * 9).getDate(),
+      expect(first.expiryDate).toBeUndefined()
+      expect(second.expiryDate?.getDate()).toBe(
+        new Date(Date.now() + 60 * 60 * 24 * 1000 * 8).getDate(),
       )
       expect(last.expiryDate?.getDate()).toBe(
         new Date(Date.now() + 60 * 60 * 24 * 1000 * 5).getDate(),
       )
     })
     it('should show names without expiry at top when sorting by asc expiryDate', async () => {
-      const names = [...Array.from({ length: 5 }, makeNameItem(false)), makeNameItem(true)(null, 5)]
+      const names = [...Array.from({ length: 9 }, makeNameItem(false)), makeNameItem(true)(null, 9)]
 
       mockGetNames.mockResolvedValue(names)
 
@@ -136,9 +138,11 @@ describe('useNamesFromAddress', () => {
       await waitForNextUpdate()
       const first = result.current.currentPage![0]
       const last = result.current.currentPage![4]
-      expect(first.expiryDate).toBeUndefined()
+      expect(first.expiryDate?.getDate()).toBe(
+        new Date(Date.now() + 60 * 60 * 24 * 1000 * 0).getDate(),
+      )
       expect(last.expiryDate?.getDate()).toBe(
-        new Date(Date.now() + 60 * 60 * 24 * 1000 * 3).getDate(),
+        new Date(Date.now() + 60 * 60 * 24 * 1000 * 4).getDate(),
       )
     })
     it('should sort by label name', async () => {

--- a/src/hooks/useNamesFromAddress.ts
+++ b/src/hooks/useNamesFromAddress.ts
@@ -126,12 +126,7 @@ export const useNamesFromAddress = ({
         (a.registrationDate?.getTime() || a.createdAt?.getTime() || 0)
     }
     if (sort.orderDirection === 'asc') {
-      return (a: Name, b: Name) => {
-        if (!a.expiryDate) {
-          return 1
-        }
-        return (a.expiryDate?.getTime() || 0) - (b.expiryDate?.getTime() || 0)
-      }
+      return (a: Name, b: Name) => (a.expiryDate?.getTime() || 0) - (b.expiryDate?.getTime() || 0)
     }
     return (a: Name, b: Name) => (b.expiryDate?.getTime() || 0) - (a.expiryDate?.getTime() || 0)
   }, [sort.orderDirection, sort.type])

--- a/src/hooks/useNamesFromAddress.ts
+++ b/src/hooks/useNamesFromAddress.ts
@@ -126,9 +126,11 @@ export const useNamesFromAddress = ({
         (a.registrationDate?.getTime() || a.createdAt?.getTime() || 0)
     }
     if (sort.orderDirection === 'asc') {
-      return (a: Name, b: Name) => (a.expiryDate?.getTime() || 0) - (b.expiryDate?.getTime() || 0)
+      return (a: Name, b: Name) =>
+        (a.expiryDate?.getTime() || Infinity) - (b.expiryDate?.getTime() || Infinity)
     }
-    return (a: Name, b: Name) => (b.expiryDate?.getTime() || 0) - (a.expiryDate?.getTime() || 0)
+    return (a: Name, b: Name) =>
+      (b.expiryDate?.getTime() || Infinity) - (a.expiryDate?.getTime() || Infinity)
   }, [sort.orderDirection, sort.type])
 
   useEffect(() => {

--- a/src/pages/address.tsx
+++ b/src/pages/address.tsx
@@ -80,7 +80,7 @@ const Page = () => {
   const [sortType, setSortType] = useQueryParameterState<SortType>('sort', 'expiryDate')
   const [sortDirection, setSortDirection] = useQueryParameterState<SortDirection>(
     'direction',
-    'desc',
+    'asc',
   )
   const [searchQuery, setSearchQuery] = useQueryParameterState<string>('search', '')
 


### PR DESCRIPTION
changes:
- expiry sorting is now correct. previously it was inconsistent when sorting by ascending order.
- set the default value of expiry to be infinity instead of 0
  - more technically correct
  - means that expiring names will show first when sorting by ascending expiryDate order, rather than names with no expiry
- set ascending as default for sorting
- made the ascending button the left button

Fixes FET-1046 and FET-931