### PR TITLE
feat: grace period message in name item

### DIFF
--- a/deploy/00_register_legacy.ts
+++ b/deploy/00_register_legacy.ts
@@ -282,6 +282,12 @@ const names: Name[] = [
     customDuration: 5011200,
   },
   {
+    label: 'grace-period-starting-soon',
+    namedOwner: 'owner',
+    namedAddr: 'owner',
+    customDuration: 12900600,
+  },
+  {
     label: 'unwrapped-with-wrapped-subnames',
     namedOwner: 'owner',
     namedAddr: 'owner',

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -107,6 +107,17 @@
     "expiredInMonths_other": "Expired {{count}} months ago",
     "expiredInYears_one": "Expired {{count}} year ago",
     "expiredInYears_other": "Expired {{count}} years ago",
+    "gracePeriod": {
+      "expiresInYears_one": "Grace period expires in {{count}} year",
+      "expiresInYears_other": "Grace period expires in {{count}} years",
+      "expiresInMonths_one": "Grace period expires in {{count}} month",
+      "expiresInMonths_other": "Grace period expires in {{count}} months",
+      "expiresInDays_one": "Grace period expires in {{count}} day",
+      "expiresInDays_other": "Grace period expires in {{count}} days",
+      "expiresInHours_one": "Grace period expires in {{count}} hour",
+      "expiresInHours_other": "Grace period expires in {{count}} hours",
+      "expiresInHours_zero": "Grace period expires in less than an hour"
+    },
     "extend": "Extend",
     "send": "Send",
     "transfer": "Transfer",

--- a/src/components/@atoms/ExpiryComponents/ExpiryComponents.test.tsx
+++ b/src/components/@atoms/ExpiryComponents/ExpiryComponents.test.tsx
@@ -42,8 +42,16 @@ describe('ShortExpiry', () => {
     expect(screen.getByTestId('short-expiry')).toHaveAttribute('data-color', 'orange')
   })
 
-  it('show be red if expired', () => {
+  it('should be red if expired', () => {
     render(<ShortExpiry expiry={expired} />)
+    expect(screen.getByTestId('short-expiry')).toHaveAttribute('data-color', 'red')
+  })
+  it('should be red if expiring in less than 24 hours', () => {
+    render(<ShortExpiry expiry={hourExpired} />)
+    expect(screen.getByTestId('short-expiry')).toHaveAttribute('data-color', 'red')
+  })
+  it('should be red if expired for less than 90 days and has grace period', () => {
+    render(<ShortExpiry expiry={expired} hasGracePeriod />)
     expect(screen.getByTestId('short-expiry')).toHaveAttribute('data-color', 'red')
   })
   it('should show year units if expiry is more than a year away', () => {
@@ -62,9 +70,9 @@ describe('ShortExpiry', () => {
     render(<ShortExpiry expiry={expired} />)
     expect(screen.getByText('name.expiredInDays.1')).toBeVisible()
   })
-  it('should not inverse numbers if expired for less than 90 days and has grace period', () => {
+  it('should show grace period message if expired for less than 90 days and has grace period', () => {
     render(<ShortExpiry expiry={expired} hasGracePeriod />)
-    expect(screen.getByText('name.expiresInDays.88')).toBeVisible()
+    expect(screen.getByText('name.gracePeriod.expiresInMonths.2')).toBeVisible()
   })
   it('should always show red text for inversed numbers', () => {
     render(<ShortExpiry expiry={yearExpired} />)


### PR DESCRIPTION
previously we used the end of the grace period as the "real" expiry date in the name detail item (for 2ld .eths)
this meant that messaging regarding the expiry was inconsistent. 

this pr adds a new message specifically for when a name is in grace period, and uses normal expiry terminology for 2ld .eths before the grace period.

e.g.:
- expires in 97 days (grey) -> expires in 7 days (orange)
- expires in 7 days (orange) -> grace period ends in 7 days (red)