### PR TITLE
fix: fix caching issues

### DIFF
--- a/e2e/specs/stateless/07_profileEditor.spec.js
+++ b/e2e/specs/stateless/07_profileEditor.spec.js
@@ -163,7 +163,9 @@ describe('Profile Editor', () => {
         // Update and add records to test migration records merge
         cy.contains('Edit profile').click()
         cy.findByTestId('warning-overlay').should('be.visible')
-        cy.findByTestId('warning-overlay-secondary-action').should('have.text', 'Edit profile').click()
+        cy.findByTestId('warning-overlay-secondary-action')
+          .should('have.text', 'Edit profile')
+          .click()
         cy.findByTestId('profile-record-input-description')
           .get('textarea')
           .type('{selectall}{backspace}new name')

--- a/e2e/specs/stateless/12_updateResolver.spec.js
+++ b/e2e/specs/stateless/12_updateResolver.spec.js
@@ -44,16 +44,6 @@ describe('Update Resolver', () => {
         cy.confirmMetamaskTransaction()
         cy.findByTestId('transaction-modal-complete-button').click()
         cy.wait(10000)
-
-        // This is only needed on cypress, not sure why!
-        cy.reload()
-        cy.findByTestId('edit-resolver-button').click()
-        cy.findByTestId('update-button').click()
-        cy.findByTestId('transaction-modal-confirm-button').click()
-        cy.confirmMetamaskTransaction()
-        cy.findByTestId('transaction-modal-complete-button').click()
-        cy.wait(10000)
-
         cy.findByTestId('name-details-text').should('have.text', newResolver)
       })
     })

--- a/src/components/@molecules/DogFood.tsx
+++ b/src/components/@molecules/DogFood.tsx
@@ -50,7 +50,7 @@ export const DogFood = (
         return ''
       }
     },
-    { enabled: inputWatch?.includes('.') },
+    { enabled: !!inputWatch?.includes('.') },
   )
   const finalValue = inputWatch?.includes('.') ? ethNameAddress : inputWatch
   useEffect(() => { 

--- a/src/components/@molecules/TransactionDialogManager/stage/TransactionStageModal.tsx
+++ b/src/components/@molecules/TransactionDialogManager/stage/TransactionStageModal.tsx
@@ -276,7 +276,7 @@ export const TransactionStageModal = ({
     isLoading: requestLoading,
     error: _requestError,
   } = useQuery(
-    ['prepareTx', txKey, currentStep],
+    ['prepareTx', txKey, currentStep, transaction.name],
     async () => {
       const populatedTransaction = await transactions[transaction.name].transaction(
         signer as JsonRpcSigner,
@@ -304,7 +304,7 @@ export const TransactionStageModal = ({
   const requestError = _requestError as TxError | null
   useInvalidateOnBlock({
     enabled: !!transaction && !!signer && !!ens,
-    queryKey: ['prepareTx', txKey, currentStep],
+    queryKey: ['prepareTx', txKey, currentStep, transaction.name],
   })
 
   const {

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -107,7 +107,6 @@ export const Notifications = () => {
   useEffect(() => {
     if (currentNotification) {
       queryClient.invalidateQueries()
-      queryClient.resetQueries({ exact: false, queryKey: ['getSubnames'] })
     }
   }, [currentNotification, queryClient])
 

--- a/src/hooks/useHasSubnames.ts
+++ b/src/hooks/useHasSubnames.ts
@@ -54,8 +54,6 @@ export const useHasSubnames = (name: string) => {
     },
   )
 
-  console.log(status, isFetched, isFetchedAfterMount)
-
   return {
     hasSubnames,
     isLoading,

--- a/src/hooks/useHasSubnames.ts
+++ b/src/hooks/useHasSubnames.ts
@@ -50,7 +50,6 @@ export const useHasSubnames = (name: string) => {
     },
     {
       enabled: !!(ready && name && isSubname),
-      refetchOnMount: 'always',
     },
   )
 

--- a/src/hooks/useHasSubnames.ts
+++ b/src/hooks/useHasSubnames.ts
@@ -13,6 +13,7 @@ export const useHasSubnames = (name: string) => {
   const { getSubnames, ready } = useEns()
 
   const isSubname = name && name.split('.').length > 2
+  const enabled = !!(ready && name && isSubname)
 
   const {
     data: hasSubnames,
@@ -49,13 +50,13 @@ export const useHasSubnames = (name: string) => {
       return false
     },
     {
-      enabled: !!(ready && name && isSubname),
+      enabled,
     },
   )
 
   return {
     hasSubnames,
     isLoading,
-    isCachedData: status === 'success' && isFetched && !isFetchedAfterMount,
+    isCachedData: enabled && status === 'success' && isFetched && !isFetchedAfterMount,
   }
 }

--- a/src/hooks/useHasSubnames.ts
+++ b/src/hooks/useHasSubnames.ts
@@ -24,7 +24,7 @@ export const useHasSubnames = (name: string) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     isFetching: _isFetching,
   } = useQuery(
-    ['getSubnames', name],
+    ['graph', 'getSubnames', name],
     async () => {
       let cursor: Subnames = []
       let done = false
@@ -50,8 +50,11 @@ export const useHasSubnames = (name: string) => {
     },
     {
       enabled: !!(ready && name && isSubname),
+      refetchOnMount: 'always',
     },
   )
+
+  console.log(status, isFetched, isFetchedAfterMount)
 
   return {
     hasSubnames,

--- a/src/hooks/usePrimary.ts
+++ b/src/hooks/usePrimary.ts
@@ -21,7 +21,6 @@ export const usePrimary = (address: string, skip?: any): Result => {
     ['getName', address],
     async () => {
       const res = await getName(address)
-      console.log('getName', res)
       if (!res || !res.name || !res.match) return null
       return {
         ...res,
@@ -33,6 +32,6 @@ export const usePrimary = (address: string, skip?: any): Result => {
       cacheTime: 60,
     },
   )
-  console.log('usePrimary', data)
+
   return { name: data?.name || null, beautifiedName: data?.beautifiedName || null, loading, status }
 }

--- a/src/hooks/usePrimary.ts
+++ b/src/hooks/usePrimary.ts
@@ -21,6 +21,7 @@ export const usePrimary = (address: string, skip?: any): Result => {
     ['getName', address],
     async () => {
       const res = await getName(address)
+      console.log('getName', res)
       if (!res || !res.name || !res.match) return null
       return {
         ...res,
@@ -32,6 +33,6 @@ export const usePrimary = (address: string, skip?: any): Result => {
       cacheTime: 60,
     },
   )
-
+  console.log('usePrimary', data)
   return { name: data?.name || null, beautifiedName: data?.beautifiedName || null, loading, status }
 }

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -19,7 +19,7 @@ export const useProfile = (name: string, skip?: any) => {
     isFetched,
     // don't remove this line, it updates the isCachedData state (for some reason) but isn't needed to verify it
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    isFetching: _isFetching,
+    isFetching,
   } = useQuery(
     ['graph', 'getProfile', name],
     () =>
@@ -46,6 +46,7 @@ export const useProfile = (name: string, skip?: any) => {
     profile: returnProfile,
     loading: !ready || loading,
     status,
+    isFetching,
     isCachedData: status === 'success' && isFetched && !isFetchedAfterMount,
   }
 }

--- a/src/hooks/useResolverStatus.ts
+++ b/src/hooks/useResolverStatus.ts
@@ -54,6 +54,7 @@ type Result = {
     isMigratedProfileEqual: boolean
   }
   loading: boolean
+  isFetching: boolean
 }
 
 export const useResolverStatus = (name: string, skip?: boolean, options?: Options): Result => {
@@ -62,7 +63,7 @@ export const useResolverStatus = (name: string, skip?: boolean, options?: Option
   // Profile resolver address check
   const latestResolverAddress = useContractAddress('PublicResolver')
 
-  const { profile, loading: profileLoading } = useProfile(name, !name || skip)
+  const { profile, loading: profileLoading, isFetching } = useProfile(name, !name || skip)
   const profileResolverAddress = profile?.resolverAddress
 
   const { data: status, isLoading: loading } = useQuery(
@@ -119,5 +120,6 @@ export const useResolverStatus = (name: string, skip?: boolean, options?: Option
   return {
     status,
     loading: profileLoading || loading,
+    isFetching,
   }
 }

--- a/src/hooks/useSubnameInfiniteQuery.ts
+++ b/src/hooks/useSubnameInfiniteQuery.ts
@@ -20,7 +20,7 @@ export const useSubnameInfiniteQuery = (
 ) => {
   const { getSubnames } = useEns()
 
-  const queryKey = ['getSubnames', name, orderBy, orderDirection, search]
+  const queryKey = ['graph', 'getSubnames', 'infinite', name, orderBy, orderDirection, search]
   const { data, isLoading, isFetching, fetchNextPage, hasNextPage, refetch } = useInfiniteQuery(
     queryKey,
     async ({ pageParam }) => {

--- a/src/transaction-flow/input/ProfileEditor/ProfileEditor-flow.tsx
+++ b/src/transaction-flow/input/ProfileEditor/ProfileEditor-flow.tsx
@@ -215,7 +215,11 @@ const ProfileEditor = ({ data = {}, transactions = [], dispatch, onDismiss }: Pr
 
   const resolverAddress = useContractAddress('PublicResolver')
 
-  const { status, loading: statusLoading } = useResolverStatus(name, profileLoading, {
+  const {
+    status,
+    loading: statusLoading,
+    isFetching,
+  } = useResolverStatus(name, profileLoading, {
     skipCompare: resumable,
   })
 
@@ -399,7 +403,7 @@ const ProfileEditor = ({ data = {}, transactions = [], dispatch, onDismiss }: Pr
                 trailing={
                   <SubmitButton
                     control={control}
-                    disabled={hasErrors}
+                    disabled={hasErrors || isFetching}
                     previousRecords={existingRecords}
                     canEdit={canEditRecordsWhenWrapped}
                   />

--- a/src/utils/SyncProvider.tsx
+++ b/src/utils/SyncProvider.tsx
@@ -78,7 +78,7 @@ export const SyncProvider = ({ children }: { children: React.ReactNode }) => {
         const waitingForBlock = findTransactionHigherThanBlock(data)
         if (waitingForBlock) return
         queryClient.invalidateQueries({ exact: false, queryKey: ['graph'], refetchType: 'all' })
-        queryClient.resetQueries({ exact: false, queryKey: ['getSubnames'] })
+        queryClient.resetQueries({ exact: false, queryKey: ['getSubnames', 'infinite'] })
       },
     },
   )

--- a/src/utils/SyncProvider.tsx
+++ b/src/utils/SyncProvider.tsx
@@ -77,8 +77,13 @@ export const SyncProvider = ({ children }: { children: React.ReactNode }) => {
         if (!data) return
         const waitingForBlock = findTransactionHigherThanBlock(data)
         if (waitingForBlock) return
-        queryClient.invalidateQueries({ exact: false, queryKey: ['graph'], refetchType: 'all' })
-        queryClient.resetQueries({ exact: false, queryKey: ['getSubnames', 'infinite'] })
+        queryClient.resetQueries({ exact: false, queryKey: ['getSubnames', 'infinite'] }).then(() =>
+          queryClient.invalidateQueries({
+            exact: false,
+            queryKey: ['graph'],
+            refetchType: 'all',
+          }),
+        )
       },
     },
   )


### PR DESCRIPTION
previously, any `getSubname` query was reset once a graph sync happened. 
the reset is used for `useSubnameInfiniteQuery()` to reset the page and all page data, but the `useHasSubnames()` query also has `getSubnames` in the query key and thus also gets reset.
the reset was not only useless for `useHasSubnames()` but it would also occasionally trigger *after* the query was invalidated, meaning it would reset the newly fetched data, and would not refetch.

changes:
- removed query reset from `Notifications.tsx` as it is already elsewhere and provides the same functionality
- added `graph` to the query key of both `useHasSubnames()` and `useSubnameInfiniteQuery()` to refetch
- added `infinite` to the query reset call in `SyncProvider` so that `useHasSubnames()` is not included
- invalidate graph queries only after the `getSubnames` infinite query has been reset, thus allowing the infinite query to be refetched (this was another bug i found related to this)

**update:**
the extra speed that this change added revealed a bug in the caching of transaction requests in transaction dialogs.
the transaction request `useQuery()` hook had a query key that was not unique enough, so previous transactions in the dialog could potentially be reused (albeit momentarily). 
to combat this i changed the query key to include these extra identifiers: 
- transaction name
  - while `txKey` is the transaction flow key, the transaction name is the name of the transaction func being run
- transaction data
  - the data for the transaction function
  - this alongside the transaction name are the most important parts of uniqueness of a transaction
- chain name
  - will prevent collisions between data of each chain
  - generally this won't be very useful since we aren't a multichain app (-testnet), but it's just there for safety
- address
  - some actions can be performed by any address so this prevents multiple addresses sharing the same transaction request