### PR TITLE
NightSky overflows border-radius on Safari

### DIFF
--- a/src/assets/NightSky.tsx
+++ b/src/assets/NightSky.tsx
@@ -8,6 +8,7 @@ const Container = styled.div(
     height: 100%;
     overflow: hidden;
     border-radius: ${theme.radii['2xLarge']};
+    isolation: isolate; // Safari to clip svgs to border radius
 
     & > * {
       position: relative;


### PR DESCRIPTION
NightSky overflows border radius on Safari

![IMG_B42134F8C766-1](https://user-images.githubusercontent.com/1967258/230818604-34276ee5-3c37-4459-960e-74c7b6e0a9cb.jpeg)
