### PR TITLE
Page flashes registration page when clicking "view name" in Complete.tsx

### DIFF
--- a/e2e/specs/stateless/08_registerName.spec.js
+++ b/e2e/specs/stateless/08_registerName.spec.js
@@ -129,8 +129,8 @@ describe('Register Name', () => {
     cy.findByTestId('finish-button').click()
     cy.findByTestId('transaction-modal-confirm-button').click()
     cy.confirmMetamaskTransaction()
-    cy.findByTestId('view-name').click()
     cy.wait(10000)
+    cy.findByTestId('view-name').click()
     cy.findByTestId('address-profile-button-eth').should('contain.text', '0x3C4...293BC')
   })
   it('should allow registering a premium name', () => {
@@ -149,7 +149,7 @@ describe('Register Name', () => {
     cy.findByTestId('finish-button').click()
     cy.findByTestId('transaction-modal-confirm-button').click()
     cy.confirmMetamaskTransaction()
-    cy.wait(1000)
+    cy.wait(10000)
     cy.findByTestId('view-name').click()
     cy.findByTestId('address-profile-button-eth').should('contain.text', '0x3C4...293BC')
   })

--- a/e2e/specs/stateless/08_registerName.spec.js
+++ b/e2e/specs/stateless/08_registerName.spec.js
@@ -90,6 +90,9 @@ describe('Register Name', () => {
 
     // should show the correct details on completion
     cy.findByTestId('invoice-item-0-amount').should('contain.text', '0.0032 ETH')
+
+    cy.findByTestId('view-name').click()
+    cy.findByTestId('address-profile-button-eth').should('contain.text', '0x3C4...293BC')
   })
   it('should not direct to the registration page on search, and show all records from registration', () => {
     cy.visit('/')
@@ -146,6 +149,7 @@ describe('Register Name', () => {
     cy.findByTestId('finish-button').click()
     cy.findByTestId('transaction-modal-confirm-button').click()
     cy.confirmMetamaskTransaction()
+    cy.wait(1000)
     cy.findByTestId('view-name').click()
     cy.findByTestId('address-profile-button-eth').should('contain.text', '0x3C4...293BC')
   })

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:watch": "jest --env=./custom-test-env.js --watch",
     "test:coverage": "jest --env=./custom-test-env.js --coverage",
     "synpress:start": "synpress run -cf ./e2e/synpress.config.js",
-    "synpress:standalone": "SECRET_WORDS=\"test test test test test test test test test test test junk\" PASSWORD=TestMetaMask NETWORK_NAME=localhost TRANSACTION_WAIT_TIME=5000 synpress run -ne -cf ./e2e/synpress.config.js --spec ./e2e/specs/stateless/01_settings.spec.js",
+    "synpress:standalone": "SECRET_WORDS=\"test test test test test test test test test test test junk\" PASSWORD=TestMetaMask NETWORK_NAME=localhost TRANSACTION_WAIT_TIME=5000 synpress run -ne -cf ./e2e/synpress.config.js --spec ./e2e/specs/stateless/08_registerName.spec.js",
     "synpress:local": "synpress run -ne -cf ./e2e/synpress.config.js",
     "synpress:stateful": "NETWORK_NAME=mainnet synpress run -cf ./e2e/synpress-stateful.config.js",
     "synpress:ci": "pnpm synpress:start --parallel --record --key aab18385-26dc-4b7c-8631-e91bc79f2ab2 --ci-build-id $CI_BUILD_ID --group stateless",

--- a/src/components/pages/profile/[name]/registration/Registration.tsx
+++ b/src/components/pages/profile/[name]/registration/Registration.tsx
@@ -222,9 +222,9 @@ const Registration = ({ nameDetails, isLoading }: Props) => {
         cleanupFlow(registerKey)
       }
     }
-    router.events.on('routeChangeStart', handleRouteChange)
+    router.events.on('routeChangeComplete', handleRouteChange)
     return () => {
-      router.events.off('routeChangeStart', handleRouteChange)
+      router.events.off('routeChangeComplete', handleRouteChange)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, step, selected, router.asPath])

--- a/src/components/pages/profile/[name]/registration/Registration.tsx
+++ b/src/components/pages/profile/[name]/registration/Registration.tsx
@@ -216,6 +216,7 @@ const Registration = ({ nameDetails, isLoading }: Props) => {
 
   useEffect(() => {
     const handleRouteChange = (e: string) => {
+      console.log('route change', e, 'router.asPath', router.asPath, 'step', step)
       if (e !== router.asPath && step === 'complete') {
         dispatch({ name: 'clearItem', selected })
         cleanupFlow(commitKey)

--- a/src/components/pages/profile/[name]/registration/Registration.tsx
+++ b/src/components/pages/profile/[name]/registration/Registration.tsx
@@ -216,7 +216,6 @@ const Registration = ({ nameDetails, isLoading }: Props) => {
 
   useEffect(() => {
     const handleRouteChange = (e: string) => {
-      console.log('route change', e, 'router.asPath', router.asPath, 'step', step)
       if (e !== router.asPath && step === 'complete') {
         dispatch({ name: 'clearItem', selected })
         cleanupFlow(commitKey)

--- a/src/hooks/useBasicName.ts
+++ b/src/hooks/useBasicName.ts
@@ -44,6 +44,7 @@ export const useBasicName = (name?: string | null, normalised?: boolean) => {
         return Promise.all([ens.getOwner('', 'registry')])
       }
 
+      console.log('getBasicName', normalisedName)
       const labels = normalisedName.split('.')
       if (validation.isETH && validation.is2LD) {
         if (validation.isShort) {
@@ -63,7 +64,7 @@ export const useBasicName = (name?: string | null, normalised?: boolean) => {
       enabled: !!(ens.ready && name && isValid),
     },
   )
-
+  console.log('useBasicName', batchData)
   const [ownerData, _wrapperData, expiryData, priceData] = batchData || []
 
   const wrapperData = useMemo(() => {

--- a/src/hooks/useBasicName.ts
+++ b/src/hooks/useBasicName.ts
@@ -44,7 +44,6 @@ export const useBasicName = (name?: string | null, normalised?: boolean) => {
         return Promise.all([ens.getOwner('', 'registry')])
       }
 
-      console.log('getBasicName', normalisedName)
       const labels = normalisedName.split('.')
       if (validation.isETH && validation.is2LD) {
         if (validation.isShort) {
@@ -64,7 +63,6 @@ export const useBasicName = (name?: string | null, normalised?: boolean) => {
       enabled: !!(ens.ready && name && isValid),
     },
   )
-  console.log('useBasicName', batchData)
   const [ownerData, _wrapperData, expiryData, priceData] = batchData || []
 
   const wrapperData = useMemo(() => {

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -28,8 +28,6 @@ export default function Page() {
 
   const isLoading = detailsLoading || primaryLoading || accountLoading || initial
 
-  console.log('profile')
-
   if (isViewingExpired && gracePeriodEndDate && gracePeriodEndDate > new Date()) {
     router.push(`/profile/${name}`)
     return null

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -28,6 +28,8 @@ export default function Page() {
 
   const isLoading = detailsLoading || primaryLoading || accountLoading || initial
 
+  console.log('profile')
+
   if (isViewingExpired && gracePeriodEndDate && gracePeriodEndDate > new Date()) {
     router.push(`/profile/${name}`)
     return null


### PR DESCRIPTION
Source of issue is that the registrationData is cleared when the router changes. In situations where changing routes takes time, the screen will flash to the registration pricing page since it has no data. Solution is to change the event to cleanup on complete.