### PR TITLE
fix: address showing as invalid in search

### DIFF
--- a/src/components/@molecules/SearchInput/SearchInput.test.tsx
+++ b/src/components/@molecules/SearchInput/SearchInput.test.tsx
@@ -1,4 +1,4 @@
-import { mockFunction, render, screen } from '@app/test-utils'
+import { mockFunction, render, screen, userEvent } from '@app/test-utils'
 
 import { act, waitFor } from '@testing-library/react'
 
@@ -205,5 +205,48 @@ describe('SearchInput', () => {
 
     expect(screen.getByText('test2.eth')).toBeInTheDocument()
     expect(screen.queryByText('test3.eth')).not.toBeInTheDocument()
+  })
+  it('should show address search as valid', async () => {
+    mockUseBreakpoint.mockReturnValue({
+      xs: true,
+      sm: true,
+      md: true,
+      lg: false,
+      xl: false,
+    })
+    render(<SearchInput />)
+    act(() => {
+      screen.getByTestId('search-input-box').focus()
+    })
+    await waitFor(() => screen.getByTestId('search-input-results'), {
+      timeout: 500,
+    })
+    await userEvent.type(
+      screen.getByTestId('search-input-box'),
+      '0xb6E040C9ECAaE172a89bD561c5F73e1C48d28cd9',
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId('search-input-results')).toHaveAttribute('data-error', 'false'),
+    )
+  })
+  it('should show invalid search as invalid', async () => {
+    mockUseBreakpoint.mockReturnValue({
+      xs: true,
+      sm: true,
+      md: true,
+      lg: false,
+      xl: false,
+    })
+    render(<SearchInput />)
+    act(() => {
+      screen.getByTestId('search-input-box').focus()
+    })
+    await waitFor(() => screen.getByTestId('search-input-results'), {
+      timeout: 500,
+    })
+    await userEvent.type(screen.getByTestId('search-input-box'), '.')
+    await waitFor(() =>
+      expect(screen.getByTestId('search-input-results')).toHaveAttribute('data-error', 'true'),
+    )
   })
 })

--- a/src/components/@molecules/SearchInput/SearchInput.tsx
+++ b/src/components/@molecules/SearchInput/SearchInput.tsx
@@ -38,9 +38,8 @@ const Container = styled.div<{ $size: 'medium' | 'extraLarge' }>(
 
 const SearchResultsContainer = styled.div<{
   $state: TransitionState
-  $error?: boolean
 }>(
-  ({ theme, $state, $error }) => css`
+  ({ theme, $state }) => css`
     position: absolute;
     width: 100%;
     height: min-content;
@@ -49,8 +48,10 @@ const SearchResultsContainer = styled.div<{
     background-color: #f7f7f7;
     box-shadow: 0 2px 12px ${theme.colors.border};
     border-radius: ${theme.radii.extraLarge};
-    border: ${theme.borderWidths.px} ${theme.borderStyles.solid}
-      ${$error ? theme.colors.red : theme.colors.border};
+    border: ${theme.borderWidths.px} ${theme.borderStyles.solid} ${theme.colors.border};
+    &[data-error='true'] {
+      border-color: ${theme.colors.red};
+    }
 
     overflow: hidden;
 
@@ -437,8 +438,8 @@ export const SearchInput = ({
       }}
       onMouseLeave={() => inputVal === '' && setSelected(-1)}
       $state={state}
-      $error={!isValid && inputVal !== ''}
       data-testid="search-input-results"
+      data-error={!isValid && !inputIsAddress && inputVal !== ''}
     >
       {searchItems.map((item, index) => (
         <SearchResult

--- a/src/components/@molecules/SearchInput/SearchResult.test.tsx
+++ b/src/components/@molecules/SearchInput/SearchResult.test.tsx
@@ -82,4 +82,18 @@ describe('SearchResult', () => {
     fireEvent.click(element)
     expect(baseMockData.clickCallback).toHaveBeenCalledWith(0)
   })
+  it('should show address as clickable', () => {
+    mockUsePrimary.mockReturnValue({
+      loading: false,
+      name: null,
+      status: 'success',
+    })
+    const mockData: ComponentProps<typeof SearchResult> = {
+      ...baseMockData,
+      type: 'address',
+      value: '0xb6E040C9ECAaE172a89bD561c5F73e1C48d28cd9',
+    }
+    render(<SearchResult {...mockData} />)
+    expect(screen.getByTestId('search-result-address')).toHaveStyle('cursor: pointer')
+  })
 })

--- a/src/components/@molecules/SearchInput/SearchResult.tsx
+++ b/src/components/@molecules/SearchInput/SearchResult.tsx
@@ -341,7 +341,7 @@ export const SearchResult = ({
 
   if (type === 'address') {
     return (
-      <SearchItem data-testid="search-result-address" {...props}>
+      <SearchItem data-testid="search-result-address" $clickable {...props}>
         <AddressResultItem address={input} />
       </SearchItem>
     )

--- a/src/components/ProfileSnippet.test.tsx
+++ b/src/components/ProfileSnippet.test.tsx
@@ -1,3 +1,5 @@
+import '@app/test-utils'
+
 import { getUserDefinedUrl } from './ProfileSnippet'
 
 describe('getUserDefinedUrl', () => {


### PR DESCRIPTION
after previous changes with validation logic in the search input, address searches became "invalid" because they were no longer covered under the same `isValid` variable. also, address items did not have pointer cursor set.

changes:
- added logic for the component to not show error state if `inputIsAddress` is true
- added `$clickable` prop to address items for pointer cursor

Fixes FET-1093