### PR TITLE
fix: various issues related to connection

### DIFF
--- a/src/components/pages/my/names/MyNames.tsx
+++ b/src/components/pages/my/names/MyNames.tsx
@@ -48,7 +48,7 @@ const TabWrapperWithButtons = styled(TabWrapper)(
 const MyNames = () => {
   const { t } = useTranslation('names')
   const router = useRouter()
-  const { address: _address, isConnecting, isReconnecting } = useAccount()
+  const { address: _address } = useAccount()
   const address = (router.query.address as string) || (_address as string)
   const isSelf = true
   const chainId = useChainId()
@@ -122,8 +122,7 @@ const MyNames = () => {
     [mode],
   )
 
-  const loading =
-    isConnecting || isReconnecting || namesLoading || namesStatus === 'loading' || !router.isReady
+  const loading = namesLoading || namesStatus === 'loading' || !router.isReady
 
   useProtectedRoute('/', loading ? true : address && address !== '')
 

--- a/src/components/pages/profile/[name]/registration/steps/Pricing/Pricing.tsx
+++ b/src/components/pages/profile/[name]/registration/steps/Pricing/Pricing.tsx
@@ -456,7 +456,7 @@ const Pricing = ({
 
   const [years, setYears] = useState(registrationData.years)
   const [reverseRecord, setReverseRecord] = useState(
-    registrationData.reverseRecord || !hasPrimaryName,
+    registrationData.started ? registrationData.reverseRecord : !hasPrimaryName,
   )
 
   const hasPendingMoonpayTransaction = moonpayTransactionStatus === 'pending'
@@ -525,19 +525,21 @@ const Pricing = ({
           />
         )
       )}
-      <PaymentChoice
-        {...{
-          paymentMethodChoice,
-          setPaymentMethodChoice,
-          address,
-          breakpoints,
-          reverseRecord,
-          setReverseRecord,
-          hasEnoughEth: true,
-          hasPendingMoonpayTransaction,
-          hasFailedMoonpayTransaction,
-        }}
-      />
+      {address && (
+        <PaymentChoice
+          {...{
+            paymentMethodChoice,
+            setPaymentMethodChoice,
+            address,
+            breakpoints,
+            reverseRecord,
+            setReverseRecord,
+            hasEnoughEth: true,
+            hasPendingMoonpayTransaction,
+            hasFailedMoonpayTransaction,
+          }}
+        />
+      )}
       <MobileFullWidth>
         <ActionButton
           {...{

--- a/src/components/pages/profile/[name]/registration/steps/Pricing/Pricing.tsx
+++ b/src/components/pages/profile/[name]/registration/steps/Pricing/Pricing.tsx
@@ -207,6 +207,50 @@ const OutlinedContainerTitle = styled(Typography)(
   gridAreaStyle,
 )
 
+const EthInnerCheckbox = ({
+  address,
+  hasPrimaryName,
+  reverseRecord,
+  setReverseRecord,
+  started,
+}: {
+  address: string
+  hasPrimaryName: boolean
+  reverseRecord: boolean
+  setReverseRecord: (val: boolean) => void
+  started: boolean
+}) => {
+  const { t } = useTranslation('register')
+  const breakpoints = useBreakpoint()
+
+  useEffect(() => {
+    if (!started) {
+      setReverseRecord(!hasPrimaryName)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setReverseRecord])
+
+  return (
+    <CheckboxWrapper $name="checkbox">
+      <Field hideLabel label={t('steps.pricing.primaryName')} inline reverse disabled={!address}>
+        {(ids) => (
+          <Toggle
+            {...ids?.content}
+            disabled={!address}
+            size={breakpoints.sm ? 'large' : 'medium'}
+            checked={reverseRecord}
+            onChange={(e) => {
+              e.stopPropagation()
+              setReverseRecord(e.target.checked)
+            }}
+            data-testid="primary-name-toggle"
+          />
+        )}
+      </Field>
+    </CheckboxWrapper>
+  )
+}
+
 const PaymentChoice = ({
   paymentMethodChoice,
   setPaymentMethodChoice,
@@ -214,19 +258,21 @@ const PaymentChoice = ({
   hasPendingMoonpayTransaction,
   hasFailedMoonpayTransaction,
   address,
-  breakpoints,
+  hasPrimaryName,
   reverseRecord,
   setReverseRecord,
+  started,
 }: {
   paymentMethodChoice: PaymentMethod | ''
   setPaymentMethodChoice: Dispatch<SetStateAction<PaymentMethod | ''>>
   hasEnoughEth: boolean
   hasPendingMoonpayTransaction: boolean
   hasFailedMoonpayTransaction: boolean
-  address?: string
-  breakpoints: ReturnType<typeof useBreakpoint>
+  address: string
+  hasPrimaryName: boolean
   reverseRecord: boolean
   setReverseRecord: (reverseRecord: boolean) => void
+  started: boolean
 }) => {
   const { t } = useTranslation('register')
 
@@ -265,29 +311,9 @@ const PaymentChoice = ({
                 <OutlinedContainerTitle $name="title">
                   {t('steps.pricing.primaryName')}
                 </OutlinedContainerTitle>
-                <CheckboxWrapper $name="checkbox">
-                  <Field
-                    hideLabel
-                    label={t('steps.pricing.primaryName')}
-                    inline
-                    reverse
-                    disabled={!address}
-                  >
-                    {(ids) => (
-                      <Toggle
-                        {...ids?.content}
-                        disabled={!address}
-                        size={breakpoints.sm ? 'large' : 'medium'}
-                        checked={reverseRecord}
-                        onChange={(e) => {
-                          e.stopPropagation()
-                          setReverseRecord(e.target.checked)
-                        }}
-                        data-testid="primary-name-toggle"
-                      />
-                    )}
-                  </Field>
-                </CheckboxWrapper>
+                <EthInnerCheckbox
+                  {...{ address, hasPrimaryName, reverseRecord, setReverseRecord, started }}
+                />
                 <OutlinedContainerDescription $name="description">
                   {t('steps.pricing.primaryNameMessage')}
                 </OutlinedContainerDescription>
@@ -447,7 +473,6 @@ const Pricing = ({
 }: Props) => {
   const { t } = useTranslation('register')
 
-  const breakpoints = useBreakpoint()
   const { normalisedName, gracePeriodEndDate, beautifiedName } = nameDetails
 
   const { address } = useAccountSafely()
@@ -455,7 +480,7 @@ const Pricing = ({
   const resolverAddress = useContractAddress('PublicResolver')
 
   const [years, setYears] = useState(registrationData.years)
-  const [reverseRecord, setReverseRecord] = useState(
+  const [reverseRecord, setReverseRecord] = useState(() =>
     registrationData.started ? registrationData.reverseRecord : !hasPrimaryName,
   )
 
@@ -530,13 +555,14 @@ const Pricing = ({
           {...{
             paymentMethodChoice,
             setPaymentMethodChoice,
-            address,
-            breakpoints,
-            reverseRecord,
-            setReverseRecord,
             hasEnoughEth: true,
             hasPendingMoonpayTransaction,
             hasFailedMoonpayTransaction,
+            hasPrimaryName,
+            address,
+            reverseRecord,
+            setReverseRecord,
+            started: registrationData.started,
           }}
         />
       )}

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -15,8 +15,7 @@ export default function Page() {
 
   const initial = useInitial()
 
-  const { address, isConnecting, isReconnecting } = useAccount()
-  const accountLoading = isConnecting || isReconnecting
+  const { address } = useAccount()
 
   const primary = usePrimary(address as string, !address)
   const { name: ensName, loading: primaryLoading } = primary
@@ -26,7 +25,7 @@ export default function Page() {
   const nameDetails = useNameDetails(name)
   const { isLoading: detailsLoading, registrationStatus, gracePeriodEndDate } = nameDetails
 
-  const isLoading = detailsLoading || primaryLoading || accountLoading || initial
+  const isLoading = detailsLoading || primaryLoading || initial
 
   if (isViewingExpired && gracePeriodEndDate && gracePeriodEndDate > new Date()) {
     router.push(`/profile/${name}`)

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -14,13 +14,12 @@ export default function Page() {
 
   const initial = useInitial()
 
-  const { address, isConnecting, isReconnecting } = useAccount()
-  const accountLoading = isConnecting || isReconnecting
+  const { address } = useAccount()
 
   const nameDetails = useNameDetails(name)
   const { isLoading: detailsLoading, registrationStatus } = nameDetails
 
-  const isLoading = detailsLoading || accountLoading || initial
+  const isLoading = detailsLoading || initial
 
   if (!isLoading && registrationStatus !== 'available' && registrationStatus !== 'premium') {
     let redirect = true

--- a/src/utils/EnsProvider.test.tsx
+++ b/src/utils/EnsProvider.test.tsx
@@ -1,0 +1,154 @@
+/* eslint-disable no-promise-executor-return, func-names */
+import type { PartialMockedFunction } from '@app/test-utils'
+
+import { RenderHookOptions, act, renderHook } from '@testing-library/react-hooks'
+import { getProvider } from '@wagmi/core'
+
+const mockSetProvider = jest.fn()
+const getName = async function () {
+  return 'test.eth'
+}
+const somethingSync = function () {
+  return 'sync'
+}
+const mockEns = {
+  getName,
+  somethingSync,
+  setProvider: mockSetProvider,
+}
+
+jest.mock('@wagmi/core')
+jest.mock('@ensdomains/ensjs', () => {
+  return {
+    ENS: jest.fn().mockImplementation(() => {
+      return mockEns
+    }),
+  }
+})
+
+const { EnsProvider, useEns } = require('./EnsProvider')
+
+const mockGetProvider = getProvider as unknown as jest.MockedFunction<
+  PartialMockedFunction<typeof getProvider>
+>
+
+const renderHookHelper = <TProps, TResult>(
+  callback: (props: TProps) => TResult,
+  options?: Omit<RenderHookOptions<TProps>, 'wrapper'>,
+) => renderHook(callback, { wrapper: EnsProvider as any, ...options })
+
+describe('<EnsProvider />', () => {
+  const providerMock = { network: { chainId: 1 } }
+  beforeEach(() => {
+    jest.resetAllMocks()
+    mockGetProvider.mockReturnValue(providerMock)
+    mockSetProvider.mockResolvedValue(undefined)
+  })
+  it('should set the initial chain on render', async () => {
+    const { result, waitForNextUpdate } = renderHookHelper(() => useEns())
+    await waitForNextUpdate()
+    expect(result.current.ready).toBe(true)
+    expect(mockSetProvider).toHaveBeenCalledWith(providerMock)
+  })
+  it('should run setProvider() when the chain id changes and a function is called', async () => {
+    const { result, waitForNextUpdate } = renderHookHelper(() => useEns())
+    await waitForNextUpdate()
+    expect(result.current.ready).toBe(true)
+    expect(mockSetProvider).toHaveBeenCalledWith(providerMock)
+    const providerMock2 = { network: { chainId: 2 } }
+    mockGetProvider.mockReturnValue(providerMock2)
+    await act(async () => {
+      const fnResult = await result.current.getName()
+      expect(fnResult).toBe('test.eth')
+    })
+    expect(mockSetProvider).toHaveBeenCalledWith(providerMock2)
+  })
+  it('should wait for the setProvider() promise to resolve before calling the function', async () => {
+    jest.useFakeTimers()
+    const { result, waitForNextUpdate } = renderHookHelper(() => useEns())
+    await waitForNextUpdate()
+    expect(result.current.ready).toBe(true)
+    expect(mockSetProvider).toHaveBeenCalledWith(providerMock)
+    const providerMock2 = { network: { chainId: 2 } }
+    mockGetProvider.mockReturnValue(providerMock2)
+    mockSetProvider.mockClear()
+    mockSetProvider.mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      return undefined
+    })
+    await act(async () => {
+      let hasWaited = false
+      const fnResult = await new Promise((resolve) => {
+        result.current.getName().then((_result: any) => {
+          expect(hasWaited).toBe(true)
+          resolve(_result)
+        })
+        jest.advanceTimersByTime(500)
+        hasWaited = true
+      })
+      expect(fnResult).toBe('test.eth')
+      expect(mockSetProvider).toHaveBeenCalledWith(providerMock2)
+      expect(mockSetProvider).toHaveBeenCalledTimes(1)
+    })
+  })
+  it('should only run setProvider() once when the chain id changes and multiple functions are called', async () => {
+    jest.useFakeTimers()
+    const { result, waitForNextUpdate } = renderHookHelper(() => useEns())
+    await waitForNextUpdate()
+    expect(result.current.ready).toBe(true)
+    expect(mockSetProvider).toHaveBeenCalledWith(providerMock)
+    const providerMock2 = { network: { chainId: 2 } }
+    mockGetProvider.mockReturnValue(providerMock2)
+    mockSetProvider.mockClear()
+    mockSetProvider.mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      return undefined
+    })
+    await act(async () => {
+      let hasWaited = false
+      let resolveCount = 0
+      const fnResult = await new Promise((resolve) => {
+        result.current.getName().then((_result: any) => {
+          expect(hasWaited).toBe(true)
+          resolveCount += 1
+          if (resolveCount === 3) {
+            resolve(_result)
+          }
+        })
+        result.current.getName().then((_result: any) => {
+          expect(hasWaited).toBe(true)
+          resolveCount += 1
+          if (resolveCount === 3) {
+            resolve(_result)
+          }
+        })
+        result.current.getName().then((_result: any) => {
+          expect(hasWaited).toBe(true)
+          resolveCount += 1
+          if (resolveCount === 3) {
+            resolve(_result)
+          }
+        })
+        jest.advanceTimersByTime(500)
+        hasWaited = true
+      })
+      expect(fnResult).toBe('test.eth')
+      expect(mockSetProvider).toHaveBeenCalledWith(providerMock2)
+      expect(mockSetProvider).toHaveBeenCalledTimes(1)
+    })
+  })
+  it('should return non-async functions as normal', async () => {
+    jest.useFakeTimers()
+    const { result, waitForNextUpdate } = renderHookHelper(() => useEns())
+    await waitForNextUpdate()
+    expect(result.current.ready).toBe(true)
+    expect(mockSetProvider).toHaveBeenCalledWith(providerMock)
+    const providerMock2 = { network: { chainId: 2 } }
+    mockGetProvider.mockReturnValue(providerMock2)
+    mockSetProvider.mockClear()
+    mockSetProvider.mockResolvedValue(undefined)
+    const fnResult = result.current.somethingSync()
+    expect(fnResult).toBe('sync')
+    expect(mockSetProvider).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/EnsProvider.tsx
+++ b/src/utils/EnsProvider.tsx
@@ -1,5 +1,5 @@
-import React, { createContext, useContext, useEffect, useMemo, useState } from 'react'
-import { useProvider } from 'wagmi'
+import { getProvider } from '@wagmi/core'
+import React, { createContext, useContext, useMemo, useRef, useState } from 'react'
 
 import { ENS } from '@ensdomains/ensjs'
 import type { ContractName } from '@ensdomains/ensjs/contracts/types'
@@ -19,27 +19,74 @@ if (process.env.NEXT_PUBLIC_GRAPH_URI) {
 }
 
 const defaultValue: ENS = new ENS(opts)
+defaultValue.staticNetwork = true
 
 const EnsContext = createContext({ ...defaultValue, ready: false })
 
 const EnsProvider = ({ children }: { children: React.ReactNode }) => {
-  const provider = useProvider()
-  const ensWithCurrentProvider = useMemo(() => defaultValue, [])
   const [ready, setReady] = useState(false)
+  const chainIdRef = useRef<number | null>(null)
+  const chainSetPromise = useRef<Promise<any> | null>(null)
 
-  useEffect(() => {
-    setReady(false)
-    ensWithCurrentProvider.setProvider(provider as any).then(() => setReady(true))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [provider])
+  const setChainPromise = () => {
+    const currentProvider = getProvider()
+    const currentChainId = currentProvider.network.chainId
+    return defaultValue.setProvider(currentProvider as any).then(() => {
+      chainIdRef.current = currentChainId
+      chainSetPromise.current = null
+      setReady(true)
+    })
+  }
 
-  return (
-    <EnsContext.Provider
-      value={useMemo(() => ({ ...ensWithCurrentProvider, ready }), [ensWithCurrentProvider, ready])}
-    >
-      {children}
-    </EnsContext.Provider>
+  useMemo(() => {
+    if (typeof window !== 'undefined' && !chainSetPromise.current) {
+      chainSetPromise.current = setChainPromise()
+    }
+  }, [])
+
+  const value = useMemo(
+    () =>
+      new Proxy(
+        { ...defaultValue, ready },
+        {
+          // chain id safety check
+          get(target, prop, reciever) {
+            const targetFn = target[prop as keyof typeof target]
+            // if on client + target is async function
+            if (
+              typeof window !== 'undefined' &&
+              typeof targetFn === 'function' &&
+              targetFn.constructor?.name === 'AsyncFunction'
+            ) {
+              const currentProvider = getProvider()
+              const currentChainId = currentProvider.network.chainId
+              // if reference chainId isn't up to date
+              if (chainIdRef.current !== currentChainId) {
+                // if there is no ongoing chain set promise
+                if (!chainSetPromise.current) {
+                  // set ready to false before making changes
+                  setReady(false)
+                  // set chain set promise to new promise
+                  chainSetPromise.current = setChainPromise()
+                }
+                // eslint-disable-next-line func-names
+                return async function (this: any, ...args: any[]) {
+                  // wait for existing chain set promise
+                  await chainSetPromise.current
+                  // return result of target function
+                  return (targetFn as Function)(...args)
+                }
+              }
+            }
+            // pass through all other getters
+            return Reflect.get(target, prop, reciever)
+          },
+        },
+      ),
+    [ready],
   )
+
+  return <EnsContext.Provider value={value}>{children}</EnsContext.Provider>
 }
 
 function useEns() {


### PR DESCRIPTION
changes:
- removed `isConnecting` and `isReconnecting` as variables to consider for page loading on profile/registration
- on registration page, set `reverseRecord` checked based on `started` variable in registration data so that it can change on connection
- hide `<PaymentChoice />` on registration page until connected

Fixes FET-1097