### PR TITLE
feat: tenderly registration gas estimates

### DIFF
--- a/e2e/specs/stateless/08_registerName.spec.js
+++ b/e2e/specs/stateless/08_registerName.spec.js
@@ -25,6 +25,8 @@ describe('Register Name', () => {
         cy.findByTestId('primary-name-toggle')
           .click()
           .then(function () {
+            cy.wait(5000)
+            expect(parseFloat($item.text())).to.be.greaterThan(0)
             expect(parseFloat($item.text())).to.be.lessThan(this.estimate)
           })
           .then(() => {
@@ -33,8 +35,8 @@ describe('Register Name', () => {
       })
 
     // should show cost comparison accurately
-    cy.findByTestId('year-marker-0').should('include.text', '18% gas')
-    cy.findByTestId('year-marker-1').should('include.text', '10% gas')
+    cy.findByTestId('year-marker-0').should('include.text', '16% gas')
+    cy.findByTestId('year-marker-1').should('include.text', '8% gas')
     cy.findByTestId('year-marker-2').should('include.text', '4% gas')
 
     // should show correct price for yearly registration

--- a/e2e/specs/stateless/08_registerName.spec.js
+++ b/e2e/specs/stateless/08_registerName.spec.js
@@ -25,7 +25,7 @@ describe('Register Name', () => {
         cy.findByTestId('primary-name-toggle')
           .click()
           .then(function () {
-            cy.wait(5000)
+            cy.wait(10000)
             expect(parseFloat($item.text())).to.be.greaterThan(0)
             expect(parseFloat($item.text())).to.be.lessThan(this.estimate)
           })

--- a/src/components/@atoms/Invoice/Invoice.tsx
+++ b/src/components/@atoms/Invoice/Invoice.tsx
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber/lib/bignumber'
 import styled, { css } from 'styled-components'
 
-import { Colors } from '@ensdomains/thorin'
+import { Colors, Skeleton } from '@ensdomains/thorin'
 
 import { CurrencyDisplay } from '@app/types'
 
@@ -47,26 +47,29 @@ type Props = {
 }
 
 export const Invoice = ({ totalLabel = 'Estimated total', unit = 'eth', items }: Props) => {
-  const total = items
-    .map(({ value }) => value)
-    .filter((x) => !!x)
-    .reduce((a, b) => a!.add(b!), BigNumber.from(0))
+  const filteredItems = items.map(({ value }) => value).filter((x) => !!x)
+  const total = filteredItems.reduce((a, b) => a!.add(b!), BigNumber.from(0))
+  const hasEmptyItems = filteredItems.length !== items.length
 
   return (
     <Container>
       {items.map(({ label, value, color }, inx) => (
         <LineItem data-testid={`invoice-item-${inx}`} $color={color} key={label}>
           <div>{label}</div>
-          <div data-testid={`invoice-item-${inx}-amount`}>
-            <CurrencyText eth={value} currency={unit} />
-          </div>
+          <Skeleton loading={!value}>
+            <div data-testid={`invoice-item-${inx}-amount`}>
+              <CurrencyText eth={value || BigNumber.from(0)} currency={unit} />
+            </div>
+          </Skeleton>
         </LineItem>
       ))}
       <Total>
         <div>{totalLabel}</div>
-        <div data-testid="invoice-total">
-          <CurrencyText eth={total} currency={unit} />
-        </div>
+        <Skeleton loading={hasEmptyItems}>
+          <div data-testid="invoice-total">
+            <CurrencyText eth={hasEmptyItems ? BigNumber.from(0) : total} currency={unit} />
+          </div>
+        </Skeleton>
       </Total>
     </Container>
   )

--- a/src/components/pages/profile/[name]/registration/FullInvoice.tsx
+++ b/src/components/pages/profile/[name]/registration/FullInvoice.tsx
@@ -37,7 +37,6 @@ const FullInvoice = ({
   estimatedGasFee,
   hasPremium,
   premiumFee,
-  estimatedGasLoading,
   gasPrice,
 }: Props) => {
   const { t } = useTranslation('register')
@@ -67,8 +66,6 @@ const FullInvoice = ({
     ],
     [t, years, totalYearlyFee, estimatedGasFee, hasPremium, premiumFee],
   )
-
-  if (estimatedGasLoading) return <InvoiceContainer />
 
   return (
     <InvoiceContainer>

--- a/src/components/pages/profile/[name]/registration/steps/Info.tsx
+++ b/src/components/pages/profile/[name]/registration/steps/Info.tsx
@@ -106,13 +106,17 @@ type Props = {
 
 const Info = ({
   registrationData,
-  nameDetails: { priceData },
+  nameDetails: { normalisedName, priceData },
   callback,
   onProfileClick,
 }: Props) => {
   const { t } = useTranslation('register')
 
-  const estimate = useEstimateFullRegistration({ registration: registrationData, price: priceData })
+  const estimate = useEstimateFullRegistration({
+    name: normalisedName,
+    registrationData,
+    price: priceData,
+  })
 
   return (
     <StyledCard>

--- a/src/components/pages/profile/[name]/registration/steps/Pricing/Pricing.tsx
+++ b/src/components/pages/profile/[name]/registration/steps/Pricing/Pricing.tsx
@@ -509,12 +509,14 @@ const Pricing = ({
   ])
 
   const fullEstimate = useEstimateFullRegistration({
-    registration: {
+    name: normalisedName,
+    registrationData: {
+      ...registrationData,
+      reverseRecord,
+      years,
       records: [{ key: 'ETH', value: resolverAddress, type: 'addr', group: 'address' }],
       clearRecords: resolverExists,
       resolver: resolverAddress,
-      reverseRecord,
-      years,
     },
     price: nameDetails.priceData,
   })

--- a/src/components/pages/profile/[name]/registration/steps/Transactions.tsx
+++ b/src/components/pages/profile/[name]/registration/steps/Transactions.tsx
@@ -3,8 +3,6 @@ import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 import { useAccount } from 'wagmi'
 
-import { ChildFuses } from '@ensdomains/ensjs'
-import { BaseRegistrationParams } from '@ensdomains/ensjs/utils/registerHelpers'
 import {
   AlertSVG,
   Button,
@@ -20,12 +18,11 @@ import { InnerDialog } from '@app/components/@atoms/InnerDialog'
 import MobileFullWidth from '@app/components/@atoms/MobileFullWidth'
 import { Card } from '@app/components/Card'
 import { useNameDetails } from '@app/hooks/useNameDetails'
+import useRegistrationParams from '@app/hooks/useRegistrationParams'
 import { useTransactionFlow } from '@app/transaction-flow/TransactionFlowProvider'
 import { makeTransactionItem } from '@app/transaction-flow/transaction'
-import { yearsToSeconds } from '@app/utils/utils'
 
 import { RegistrationReducerDataItem } from '../types'
-import { profileRecordsToRecordOptions } from './Profile/profileRecordUtils'
 
 const StyledCard = styled(Card)(
   ({ theme }) => css`
@@ -155,29 +152,11 @@ const Transactions = ({ registrationData, nameDetails, callback, onStart }: Prop
     commitTimestamp && commitTimestamp + 60000 < Date.now(),
   )
 
-  const registrationParams: BaseRegistrationParams & { name: string } = useMemo(
-    () => ({
-      name: nameDetails.normalisedName,
-      owner: address!,
-      duration: yearsToSeconds(registrationData.years),
-      resolverAddress: registrationData.resolver,
-      secret: registrationData.secret,
-      records: profileRecordsToRecordOptions(
-        registrationData.records,
-        registrationData.clearRecords,
-      ),
-      fuses: {
-        named: registrationData.permissions
-          ? (Object.keys(registrationData.permissions).filter(
-              (key) => !!registrationData.permissions?.[key as ChildFuses['fuse']],
-            ) as ChildFuses['fuse'][])
-          : [],
-        unnamed: [],
-      },
-      reverseRecord: registrationData.reverseRecord,
-    }),
-    [address, nameDetails, registrationData],
-  )
+  const registrationParams = useRegistrationParams({
+    name: nameDetails.normalisedName,
+    owner: address!,
+    registrationData,
+  })
 
   const makeCommitNameFlow = useCallback(() => {
     onStart()

--- a/src/components/pages/profile/[name]/registration/types.ts
+++ b/src/components/pages/profile/[name]/registration/types.ts
@@ -8,6 +8,10 @@ type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
   ? I
   : never
 
+type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & {}
+
 export enum PaymentMethod {
   ethereum = 'ethereum',
   moonpay = 'moonpay',
@@ -35,16 +39,18 @@ export type RegistrationStepData = {
 
 export type BackObj = { back: boolean }
 
-export type RegistrationData = UnionToIntersection<RegistrationStepData[RegistrationStep]>
+export type RegistrationData = Prettify<UnionToIntersection<RegistrationStepData[RegistrationStep]>>
 
 export type SelectedItemProperties = { address: string; name: string }
 
-export type RegistrationReducerDataItem = Omit<RegistrationData, 'paymentMethodChoice'> & {
-  stepIndex: number
-  queue: RegistrationStep[]
-  isMoonpayFlow: boolean
-  externalTransactionId: string
-} & SelectedItemProperties
+export type RegistrationReducerDataItem = Prettify<
+  Omit<RegistrationData, 'paymentMethodChoice'> & {
+    stepIndex: number
+    queue: RegistrationStep[]
+    isMoonpayFlow: boolean
+    externalTransactionId: string
+  } & SelectedItemProperties
+>
 
 export type RegistrationReducerData = {
   items: RegistrationReducerDataItem[]

--- a/src/hooks/useEstimateTransactionCost.ts
+++ b/src/hooks/useEstimateTransactionCost.ts
@@ -7,7 +7,9 @@ const gasLimitDictionary = {
 }
 
 const useEstimateTransactionCost = (...transactions: (keyof typeof gasLimitDictionary)[]) => {
-  const { data: feeData, isLoading } = useFeeData()
+  const { data: feeData, isLoading } = useFeeData({
+    watch: true,
+  })
 
   const data = useMemo(() => {
     if (!feeData || isLoading) return undefined
@@ -18,7 +20,7 @@ const useEstimateTransactionCost = (...transactions: (keyof typeof gasLimitDicti
       .map((transaction) => gasLimitDictionary[transaction])
       .reduce((a, b) => a + b)
     const gasPrice = lastBaseFeePerGas.add(maxPriorityFeePerGas)
-    const transactionFee = gasPrice.mul(totalGasLimit).mul(110).div(100)
+    const transactionFee = gasPrice.mul(totalGasLimit)
     return {
       transactionFee,
       gasPrice,

--- a/src/hooks/useRegistrationParams.test.ts
+++ b/src/hooks/useRegistrationParams.test.ts
@@ -1,0 +1,198 @@
+import { renderHook } from '@app/test-utils'
+
+import useRegistrationParams from './useRegistrationParams'
+
+describe('useRegistrationParams()', () => {
+  it('should return correct default registration params', () => {
+    const { result } = renderHook(() =>
+      useRegistrationParams({
+        name: 'test',
+        owner: '0xowner',
+        registrationData: {
+          years: 1,
+          resolver: '0xresolver',
+          secret: '0xsecret',
+          records: [
+            {
+              key: 'ETH',
+              value: '0x4b2d639aC1B0497e932F8cE234eFd3B3Df9a9B74',
+              group: 'address',
+              type: 'addr',
+            },
+          ],
+          clearRecords: false,
+          reverseRecord: true,
+        },
+      }),
+    )
+    expect(result.current).toMatchInlineSnapshot(`
+      Object {
+        "duration": 31536000,
+        "fuses": Object {
+          "named": Array [],
+          "unnamed": Array [],
+        },
+        "name": "test",
+        "owner": "0xowner",
+        "records": Object {
+          "clearRecords": false,
+          "coinTypes": Array [
+            Object {
+              "key": "ETH",
+              "value": "0x4b2d639aC1B0497e932F8cE234eFd3B3Df9a9B74",
+            },
+          ],
+        },
+        "resolverAddress": "0xresolver",
+        "reverseRecord": true,
+        "secret": "0xsecret",
+      }
+    `)
+  })
+  it('should return correct registration params when records are set', () => {
+    const { result } = renderHook(() =>
+      useRegistrationParams({
+        name: 'test',
+        owner: '0xowner',
+        registrationData: {
+          years: 1,
+          resolver: '0xresolver',
+          secret: '0xsecret',
+          records: [
+            {
+              key: 'ETH',
+              value: '0x4b2d639aC1B0497e932F8cE234eFd3B3Df9a9B74',
+              group: 'address',
+              type: 'addr',
+            },
+            {
+              key: 'BTC',
+              value: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+              group: 'address',
+              type: 'addr',
+            },
+            {
+              key: 'description',
+              value: 'This is a description',
+              group: 'general',
+              type: 'text',
+            },
+          ],
+          clearRecords: false,
+          reverseRecord: true,
+        },
+      }),
+    )
+    expect(result.current).toMatchInlineSnapshot(`
+      Object {
+        "duration": 31536000,
+        "fuses": Object {
+          "named": Array [],
+          "unnamed": Array [],
+        },
+        "name": "test",
+        "owner": "0xowner",
+        "records": Object {
+          "clearRecords": false,
+          "coinTypes": Array [
+            Object {
+              "key": "ETH",
+              "value": "0x4b2d639aC1B0497e932F8cE234eFd3B3Df9a9B74",
+            },
+            Object {
+              "key": "BTC",
+              "value": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+            },
+          ],
+          "texts": Array [
+            Object {
+              "key": "description",
+              "value": "This is a description",
+            },
+          ],
+        },
+        "resolverAddress": "0xresolver",
+        "reverseRecord": true,
+        "secret": "0xsecret",
+      }
+    `)
+  })
+  it('should return correct registration params when clearRecords is true', () => {
+    const { result } = renderHook(() =>
+      useRegistrationParams({
+        name: 'test',
+        owner: '0xowner',
+        registrationData: {
+          years: 1,
+          resolver: '0xresolver',
+          secret: '0xsecret',
+          records: [],
+          clearRecords: true,
+          reverseRecord: true,
+        },
+      }),
+    )
+    expect(result.current).toMatchInlineSnapshot(`
+      Object {
+        "duration": 31536000,
+        "fuses": Object {
+          "named": Array [],
+          "unnamed": Array [],
+        },
+        "name": "test",
+        "owner": "0xowner",
+        "records": Object {
+          "clearRecords": true,
+        },
+        "resolverAddress": "0xresolver",
+        "reverseRecord": true,
+        "secret": "0xsecret",
+      }
+    `)
+  })
+  it('should return correct registration params when permissions are set', () => {
+    const { result } = renderHook(() =>
+      useRegistrationParams({
+        name: 'test',
+        owner: '0xowner',
+        registrationData: {
+          years: 1,
+          resolver: '0xresolver',
+          secret: '0xsecret',
+          records: [],
+          permissions: {
+            CAN_DO_EVERYTHING: false,
+            CANNOT_APPROVE: false,
+            CANNOT_BURN_FUSES: false,
+            CANNOT_CREATE_SUBDOMAIN: false,
+            CANNOT_SET_RESOLVER: false,
+            CANNOT_SET_TTL: false,
+            CANNOT_TRANSFER: false,
+            CANNOT_UNWRAP: true,
+          },
+          clearRecords: false,
+          reverseRecord: true,
+        },
+      }),
+    )
+    expect(result.current).toMatchInlineSnapshot(`
+      Object {
+        "duration": 31536000,
+        "fuses": Object {
+          "named": Array [
+            "CANNOT_UNWRAP",
+          ],
+          "unnamed": Array [],
+        },
+        "name": "test",
+        "owner": "0xowner",
+        "records": Object {
+          "clearRecords": false,
+        },
+        "resolverAddress": "0xresolver",
+        "reverseRecord": true,
+        "secret": "0xsecret",
+      }
+    `)
+  })
+})

--- a/src/hooks/useRegistrationParams.ts
+++ b/src/hooks/useRegistrationParams.ts
@@ -1,0 +1,44 @@
+import { useMemo } from 'react'
+
+import { ChildFuses } from '@ensdomains/ensjs'
+import { BaseRegistrationParams } from '@ensdomains/ensjs/utils/registerHelpers'
+
+import { profileRecordsToRecordOptions } from '@app/components/pages/profile/[name]/registration/steps/Profile/profileRecordUtils'
+import { RegistrationReducerDataItem } from '@app/components/pages/profile/[name]/registration/types'
+import { yearsToSeconds } from '@app/utils/utils'
+
+type Props = {
+  name: string
+  owner: string
+  registrationData: RegistrationReducerDataItem
+}
+
+const useRegistrationParams = ({ name, owner, registrationData }: Props) => {
+  const registrationParams: BaseRegistrationParams & { name: string } = useMemo(
+    () => ({
+      name,
+      owner,
+      duration: yearsToSeconds(registrationData.years),
+      resolverAddress: registrationData.resolver,
+      secret: registrationData.secret,
+      records: profileRecordsToRecordOptions(
+        registrationData.records,
+        registrationData.clearRecords,
+      ),
+      fuses: {
+        named: registrationData.permissions
+          ? (Object.keys(registrationData.permissions).filter(
+              (key) => !!registrationData.permissions?.[key as ChildFuses['fuse']],
+            ) as ChildFuses['fuse'][])
+          : [],
+        unnamed: [],
+      },
+      reverseRecord: registrationData.reverseRecord,
+    }),
+    [owner, name, registrationData],
+  )
+
+  return registrationParams
+}
+
+export default useRegistrationParams

--- a/src/hooks/useRegistrationParams.ts
+++ b/src/hooks/useRegistrationParams.ts
@@ -10,7 +10,10 @@ import { yearsToSeconds } from '@app/utils/utils'
 type Props = {
   name: string
   owner: string
-  registrationData: RegistrationReducerDataItem
+  registrationData: Pick<
+    RegistrationReducerDataItem,
+    'years' | 'resolver' | 'secret' | 'records' | 'clearRecords' | 'permissions' | 'reverseRecord'
+  >
 }
 
 const useRegistrationParams = ({ name, owner, registrationData }: Props) => {


### PR DESCRIPTION
changes:
- added to `useEstimateRegistration()` hook so that it gets the gas estimate from tenderly via a cloudflare worker
- changed hardcoded gas estimate for registration to be fallback for tenderly estimate (if there is an error)
- set base gas cost for estimate to include a resolver value (since we dont allow unsetting the resolver)
- moved registration param creator into its own hook `useRegistrationParams()`
- added skeleton to gas estimate/total value in invoice for loading instead of displaying an empty div

Fixes FET-1101