### PR TITLE
fix: disable unused sentry replay

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -10,11 +10,6 @@ Sentry.init({
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1.0,
   enabled: !(process.env.NODE_ENV === 'development' || process.env.NEXT_PUBLIC_PROVIDER),
-  replaysSessionSampleRate: process.env.NODE_ENV === 'development' ? 1 : 0.1,
-  // If the entire session is not sampled, use the below sample rate to sample
-  // sessions when an error occurs.
-  replaysOnErrorSampleRate: 1.0,
-  integrations: [new Sentry.Replay()],
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so


### PR DESCRIPTION
sentry replay is currently unused and adds 60kb to bundle size