### PR TITLE
fix: allow root domain to load on address page

### DIFF
--- a/src/hooks/useNamesFromAddress.test.ts
+++ b/src/hooks/useNamesFromAddress.test.ts
@@ -291,4 +291,33 @@ describe('useNamesFromAddress', () => {
       names[0].registration.expiryDate.getTime(),
     )
   })
+  it('should add name to root domain', async () => {
+    const names = [
+      {
+        id: '0x0000000000000000000000000000000000000000000000000000000000000000',
+        labelName: null,
+        labelhash: null,
+        truncatedName: null,
+        name: null,
+        isMigrated: true,
+        parent: null,
+        type: 'domain',
+      },
+    ]
+
+    mockGetNames.mockResolvedValue(names)
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useNamesFromAddress({
+        page: 1,
+        resultsPerPage: 5,
+        sort: {
+          orderDirection: 'desc',
+          type: 'expiryDate',
+        },
+        address: '0x123',
+      }),
+    )
+    await waitForNextUpdate()
+    expect(result.current.currentPage![0].name).toBe('[root]')
+  })
 })

--- a/src/hooks/useNamesFromAddress.ts
+++ b/src/hooks/useNamesFromAddress.ts
@@ -63,6 +63,14 @@ export const useNamesFromAddress = ({
   const mergedData = useMemo(() => {
     if (!data) return []
     const nameMap = data.reduce((map, curr) => {
+      if (curr.id === '0x0000000000000000000000000000000000000000000000000000000000000000') {
+        // eslint-disable-next-line no-param-reassign
+        curr = {
+          ...curr,
+          name: '[root]',
+          truncatedName: '[root]',
+        }
+      }
       const existingEntry = map[curr.name] || {}
       const isController = curr.type === 'domain'
       const isRegistrant = curr.type === 'registration'
@@ -96,7 +104,7 @@ export const useNamesFromAddress = ({
       // filter out names with expiry beyond grace period
       if (n.expiryDate && blockTimestamp && n?.expiryDate.getTime() < blockTimestamp - GRACE_PERIOD)
         return false
-      return n.parent.name !== 'addr.reverse'
+      return n.parent?.name !== 'addr.reverse'
     }
     let secondaryFilter: (n: ReturnedName) => boolean = () => true
     let searchFilter: (n: ReturnedName) => boolean = () => true


### PR DESCRIPTION
previously the address page of the root owner would fail to load since it doesn't have a name in the graph response.
added a manual catch for this which adds the `[root]` name to the domain entity.