### PR TITLE
fix: metamask connection weirdness from page prefetch

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -13,6 +13,21 @@ const ipfsPathScript = `
   })();
 `
 
+const hiddenCheckScript = `
+  let wasHidden = document.hidden
+  document.addEventListener(
+    'visibilitychange',
+    () => {
+      if (!document.hidden && wasHidden && typeof window.ethereum !== 'undefined') {
+        window.location.reload()
+      }
+    },
+    {
+      once: true,
+    },
+  )
+`
+
 const makeIPFSURL = (url: string) => {
   if (process.env.NEXT_PUBLIC_IPFS) {
     return `.${url}`
@@ -51,6 +66,8 @@ export default class MyDocument extends Document {
     return (
       <Html>
         <Head>
+          {/* eslint-disable-next-line react/no-danger */}
+          <script dangerouslySetInnerHTML={{ __html: hiddenCheckScript }} />
           {process.env.NEXT_PUBLIC_IPFS && (
             <>
               {/* eslint-disable-next-line react/no-danger */}


### PR DESCRIPTION
chrome prefetches and renders pages when searching for urls. if a site is fast enough to load and render before the user visits the page metamask can inject `window.ethereum`, but with messaging setup between the prerendered page and metamask's controller. this means that once the real tab exists, the connections between the page and metamask are killed and rpc requests will be unresponsive.

to fix:
- check for `document.hidden` (on initial load, the likelihood is that this is from prerendering)
- add one time listener for visibilityChange event
- once visibility changes, check for existence of `window.ethereum`
- if `window.ethereum` exists, reload the page

the reload isn't actually visible to the user, the behaviour just mimics that of no prerendering