### PR TITLE
fix: av upload byte length

### DIFF
--- a/src/components/@molecules/ProfileEditor/Avatar/AvatarUpload.test.tsx
+++ b/src/components/@molecules/ProfileEditor/Avatar/AvatarUpload.test.tsx
@@ -2,11 +2,13 @@ import { fireEvent, mockFunction, render, screen, waitFor } from '@app/test-util
 
 import { useSignTypedData } from 'wagmi'
 
+import { useChainName } from '@app/hooks/useChainName'
+
 import { AvatarUpload } from './AvatarUpload'
 
-jest.mock('@app/hooks/useChainName', () => ({
-  useChainName: () => 'mainnet',
-}))
+jest.mock('@app/hooks/useChainName')
+
+const mockUseChainName = mockFunction(useChainName)
 
 const mockHandleCancel = jest.fn()
 const mockHandleSubmit = jest.fn()
@@ -27,6 +29,7 @@ describe('<AvatarUpload />', () => {
   mockUseSignTypedData.mockImplementation(() => ({
     signTypedDataAsync: mockSignTypedDataAsync,
   }))
+  mockUseChainName.mockImplementation(() => 'mainnet')
 
   beforeAll(() => {
     URL.createObjectURL = jest.fn(() => 'https://localhost/test.png')
@@ -59,29 +62,55 @@ describe('<AvatarUpload />', () => {
     fireEvent.click(screen.getByTestId('continue-button'))
     fireEvent.click(screen.getByTestId('upload-button'))
     await waitFor(() =>
-      expect(global.fetch).toBeCalledWith(
-        'https://avatar-upload.ens-cf.workers.dev/mainnet/test.eth',
-        {
-          method: 'PUT',
-          headers: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            expiry: `${1588994800000 + 1000 * 60 * 60 * 24 * 7}`,
-            dataURL: mockFileDataURL,
-            sig: 'sig',
-          }),
+      expect(global.fetch).toBeCalledWith('https://ens.xyz/test.eth', {
+        method: 'PUT',
+        headers: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          'Content-Type': 'application/json',
         },
-      ),
+        body: JSON.stringify({
+          expiry: `${1588994800000 + 1000 * 60 * 60 * 24 * 7}`,
+          dataURL: mockFileDataURL,
+          sig: 'sig',
+        }),
+      }),
     )
 
     await waitFor(() =>
       expect(mockHandleSubmit).toHaveBeenCalledWith(
         'upload',
-        'https://avatar-upload.ens-cf.workers.dev/mainnet/test.eth',
+        'https://ens.xyz/test.eth',
         mockFileDataURL,
       ),
+    )
+  })
+  it('calls handleSubmit with network path if network is not mainnet', async () => {
+    mockUseChainName.mockImplementation(() => 'goerli')
+    global.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        json: () => ({ message: 'uploaded' }),
+      }),
+    )
+    jest.spyOn(Date, 'now').mockImplementation(() => 1588994800000)
+    jest.spyOn(Uint8Array, 'from').mockImplementation(() => new Uint8Array())
+    mockSignTypedDataAsync.mockResolvedValue('sig')
+
+    render(<AvatarUpload {...props} />)
+    fireEvent.click(screen.getByTestId('continue-button'))
+    fireEvent.click(screen.getByTestId('upload-button'))
+    await waitFor(() =>
+      expect(global.fetch).toBeCalledWith('https://ens.xyz/goerli/test.eth', {
+        method: 'PUT',
+        headers: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          expiry: `${1588994800000 + 1000 * 60 * 60 * 24 * 7}`,
+          dataURL: mockFileDataURL,
+          sig: 'sig',
+        }),
+      }),
     )
   })
   it('does not call handleSubmit if upload is unsuccessful', async () => {

--- a/src/components/@molecules/ProfileEditor/Avatar/AvatarUpload.tsx
+++ b/src/components/@molecules/ProfileEditor/Avatar/AvatarUpload.tsx
@@ -76,8 +76,10 @@ const UploadComponent = ({
   })
 
   const { mutate: signAndUpload, isLoading } = useMutation(async () => {
-    const baseURL =
-      process.env.NEXT_PUBLIC_AVUP_ENDPOINT || `https://avatar-upload.ens-cf.workers.dev/${network}`
+    let baseURL = process.env.NEXT_PUBLIC_AVUP_ENDPOINT || `https://ens.xyz`
+    if (network !== 'mainnet') {
+      baseURL = `${baseURL}/${network}`
+    }
     const endpoint = `${baseURL}/${name}`
 
     const sig = await signTypedDataAsync()

--- a/src/components/pages/profile/[name]/registration/steps/Profile/Profile.tsx
+++ b/src/components/pages/profile/[name]/registration/steps/Profile/Profile.tsx
@@ -205,13 +205,8 @@ const Profile = ({ nameDetails, callback, registrationData, resolverExists }: Pr
             handleCancel={() => setModalOpen(false)}
             type={modalOption}
             handleSubmit={(type: 'nft' | 'upload', uri: string, display?: string) => {
-              if (type === 'nft') {
-                setAvatar(uri)
-                setAvatarSrc(display)
-              } else {
-                setAvatar(`${uri}?timestamp=${Date.now()}`)
-                setAvatarSrc(display)
-              }
+              setAvatar(uri)
+              setAvatarSrc(display)
               setModalOpen(false)
               trigger()
             }}

--- a/src/transaction-flow/input/ProfileEditor/ProfileEditor-flow.tsx
+++ b/src/transaction-flow/input/ProfileEditor/ProfileEditor-flow.tsx
@@ -416,13 +416,8 @@ const ProfileEditor = ({ data = {}, transactions = [], dispatch, onDismiss }: Pr
               handleCancel={() => setView('editor')}
               type="upload"
               handleSubmit={(type: 'upload' | 'nft', uri: string, display?: string) => {
-                if (type === 'nft') {
-                  setAvatar(uri)
-                  setAvatarSrc(display)
-                } else {
-                  setAvatar(`${uri}?timestamp=${Date.now()}`)
-                  setAvatarSrc(display)
-                }
+                setAvatar(uri)
+                setAvatarSrc(display)
                 setView('editor')
                 trigger()
               }}
@@ -435,13 +430,8 @@ const ProfileEditor = ({ data = {}, transactions = [], dispatch, onDismiss }: Pr
               handleCancel={() => setView('editor')}
               type="nft"
               handleSubmit={(type: 'upload' | 'nft', uri: string, display?: string) => {
-                if (type === 'nft') {
-                  setAvatar(uri)
-                  setAvatarSrc(display)
-                } else {
-                  setAvatar(`${uri}?timestamp=${Date.now()}`)
-                  setAvatarSrc(display)
-                }
+                setAvatar(uri)
+                setAvatarSrc(display)
                 setView('editor')
                 trigger()
               }}


### PR DESCRIPTION
changes:
- changed endpoint url to `https://ens.xyz`
- only add network path if network is not mainnet (e.g. `/mainnet/test.eth` => `/test.eth`)
- removed `?timestamp=` from avatar record setters