### PR TITLE
Fix subgraph errors showing on ccip names

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@ensdomains/dnssecoraclejs": "^0.2.7",
     "@ensdomains/ens-contracts": "0.0.16",
     "@ensdomains/ens-validation": "^0.1.0",
-    "@ensdomains/ensjs": "3.0.0-alpha.63",
+    "@ensdomains/ensjs": "3.0.0-alpha.64",
     "@ensdomains/eth-ens-namehash": "^2.0.15",
     "@ensdomains/thorin": "0.6.40",
     "@ethersproject/abi": "^5.6.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
       '@ensdomains/ens-contracts': 0.0.16
       '@ensdomains/ens-test-env': ^0.3.7
       '@ensdomains/ens-validation': ^0.1.0
-      '@ensdomains/ensjs': 3.0.0-alpha.63
+      '@ensdomains/ensjs': 3.0.0-alpha.64
       '@ensdomains/eth-ens-namehash': ^2.0.15
       '@ensdomains/thorin': 0.6.40
       '@ethersproject/abi': ^5.6.4
@@ -184,7 +184,7 @@ importers:
       '@ensdomains/dnssecoraclejs': 0.2.7_v6aogrdjojfeat5uhab6hyaxg4
       '@ensdomains/ens-contracts': 0.0.16_hardhat@2.11.2
       '@ensdomains/ens-validation': 0.1.0
-      '@ensdomains/ensjs': 3.0.0-alpha.63_4wk6sblqc5kfzwjkcabkhle2du
+      '@ensdomains/ensjs': 3.0.0-alpha.64_4wk6sblqc5kfzwjkcabkhle2du
       '@ensdomains/eth-ens-namehash': 2.0.15
       '@ensdomains/thorin': 0.6.40_6haozuff5ofofiwuoke6ixqiri
       '@ethersproject/abi': 5.7.0
@@ -3019,8 +3019,8 @@ packages:
       - bufferutil
       - utf-8-validate
 
-  /@ensdomains/ensjs/3.0.0-alpha.63_4wk6sblqc5kfzwjkcabkhle2du:
-    resolution: {integrity: sha512-701N5l8RRDaEx9j+hJCnvY7L901DEhjNAerddmgf5bgFOPUGIoTxHTCKQAmws9Ihq8kac5HKp4/ioS5kPXpbNg==}
+  /@ensdomains/ensjs/3.0.0-alpha.64_4wk6sblqc5kfzwjkcabkhle2du:
+    resolution: {integrity: sha512-UJhj0c1C3cas6Wfb7tB+Hoa6/9HRDM/yKBGckq+HGoynkWL6oqujRGYnSpbfLw26Lmg9xbHLKVG/VEDIfnPGiQ==}
     peerDependencies:
       '@ethersproject/abi': ^5.6.4
       '@ethersproject/abstract-provider': ^5.7.0

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -27,6 +27,7 @@ export const useProfile = (
     queryKey,
     func: getProfile,
     skip: skipGraph,
+    ms: 10000,
   })
   const {
     data: profile,


### PR DESCRIPTION
* Increased network latency time on useProfile from 5000 to 10000 to account for extra time needed to fetch ccip name records
* make getSubnames fails gracefully when the graph has no data for the domain