### PR TITLE
fix: ipad layout

### DIFF
--- a/src/layouts/Basic.tsx
+++ b/src/layouts/Basic.tsx
@@ -14,21 +14,21 @@ import { Navigation } from './Navigation'
 
 const Container = styled.div(
   ({ theme }) => css`
-    padding: ${theme.space['4']};
+    --padding-size: ${theme.space['4']};
+    padding: var(--padding-size);
     display: flex;
     flex-gap: ${theme.space['4']};
     gap: ${theme.space['4']};
     flex-direction: column;
     align-items: stretch;
     @supports (-webkit-touch-callout: none) {
-      width: calc(100% - ${theme.space['8']});
+      // hack for iOS/iPadOS Safari
+      // width should always be 100% - total padding
+      width: calc(100% - calc(var(--padding-size) * 2));
       box-sizing: content-box;
-      ${mq.sm.min(css`
-        width: calc(100% - ${theme.space['16']});
-      `)}
     }
     ${mq.sm.min(css`
-      padding: ${theme.space['8']};
+      --padding-size: ${theme.space['8']};
       gap: ${theme.space['6']};
       flex-gap: ${theme.space['6']};
     `)}

--- a/src/layouts/Basic.tsx
+++ b/src/layouts/Basic.tsx
@@ -23,9 +23,6 @@ const Container = styled.div(
     @supports (-webkit-touch-callout: none) {
       width: calc(100% - ${theme.space['8']});
       box-sizing: content-box;
-      ${mq.sm.min(css`
-        width: calc(100% - ${theme.space['32']});
-      `)}
     }
     ${mq.sm.min(css`
       padding: ${theme.space['8']};

--- a/src/layouts/Basic.tsx
+++ b/src/layouts/Basic.tsx
@@ -23,6 +23,9 @@ const Container = styled.div(
     @supports (-webkit-touch-callout: none) {
       width: calc(100% - ${theme.space['8']});
       box-sizing: content-box;
+      ${mq.sm.min(css`
+        width: calc(100% - ${theme.space['16']});
+      `)}
     }
     ${mq.sm.min(css`
       padding: ${theme.space['8']};


### PR DESCRIPTION
previously, the iPadOS safari fix was outdated for the current layout padding

changes:
- removed padding reference for iPadOS, now using single variable and css `calc()` instead
- clarified fix for iOS/iPadOS safari

Fixes FET-1026