### PR TITLE
Update supportLinks.ts

### DIFF
--- a/src/utils/supportLinks.ts
+++ b/src/utils/supportLinks.ts
@@ -1,13 +1,13 @@
 const SUPPORT_LINKS = {
-  homoglyphs: 'https://support-kb.ens.domains/en/articles/7901658-homoglyphs',
+  homoglyphs: 'https://support.ens.domains/en/articles/7901658-homoglyphs',
   namesAndSubnames:
-    'https://support-kb.ens.domains/en/articles/7902188-managing-a-name#h_d83b3ffcb0',
+    'https://support.ens.domains/en/articles/7902188-managing-a-name#h_d83b3ffcb0',
   managersAndOwners:
-    'https://support-kb.ens.domains/en/articles/7902188-managing-a-name#h_3cf7f2fbdf',
-  resolver: 'https://support-kb.ens.domains/en/articles/7902188-managing-a-name#h_1ef2545a3f',
-  fuses: 'https://support-kb.ens.domains/en/articles/7902567-fuses',
-  primaryName: 'https://support-kb.ens.domains/en/articles/7902188-managing-a-name#h_b2baf0c02b',
-  nameWrapper: 'https://support-kb.ens.domains/en/articles/7902188-managing-a-name#h_cae4f1dea6',
+    'https://support.ens.domains/en/articles/7902188-managing-a-name#h_3cf7f2fbdf',
+  resolver: 'https://support.ens.domains/en/articles/7902188-managing-a-name#h_1ef2545a3f',
+  fuses: 'https://support.ens.domains/en/articles/7902567-fuses',
+  primaryName: 'https://support.ens.domains/en/articles/7902188-managing-a-name#h_b2baf0c02b',
+  nameWrapper: 'https://support.ens.domains/en/articles/7902188-managing-a-name#h_cae4f1dea6',
 }
 
 type SupportTopic = keyof typeof SUPPORT_LINKS


### PR DESCRIPTION
Pointing support links to the transitioned knowledge base at support.ens.domains