### PR TITLE
Fix sync provider update bug

### DIFF
--- a/src/utils/SyncProvider.tsx
+++ b/src/utils/SyncProvider.tsx
@@ -10,6 +10,7 @@ import { useChainId } from '@app/hooks/useChainId'
 import { useEns } from '@app/utils/EnsProvider'
 
 import { debugSubgraphIndexingErrors } from './GlobalErrorProvider/useSubgraphMetaSync'
+import { useQueryKeys } from './cacheKeyFactory'
 
 export type UpdateCallback = (transaction: Transaction) => void
 type AddCallback = (key: string, callback: UpdateCallback) => void
@@ -63,6 +64,7 @@ export const SyncProvider = ({ children }: { children: React.ReactNode }) => {
     [transactions],
   )
 
+  const graphBaseKeys = useQueryKeys().graphBase
   const { resetMeta, setMetaError } = useGlobalError()
   const hasGlobalError = useHasGlobalError()
   const { data: currentGraphBlock } = useQuery<number>(
@@ -91,13 +93,15 @@ export const SyncProvider = ({ children }: { children: React.ReactNode }) => {
         if (!data) return
         const waitingForBlock = findTransactionHigherThanBlock(data)
         if (waitingForBlock) return
-        queryClient.resetQueries({ exact: false, queryKey: ['getSubnames', 'infinite'] }).then(() =>
-          queryClient.invalidateQueries({
-            exact: false,
-            queryKey: ['graph'],
-            refetchType: 'all',
-          }),
-        )
+        queryClient
+          .resetQueries({ exact: false, queryKey: [...graphBaseKeys, 'getSubnames'] })
+          .then(() =>
+            queryClient.invalidateQueries({
+              exact: false,
+              queryKey: graphBaseKeys,
+              refetchType: 'all',
+            }),
+          )
       },
       onError: () => {
         setMetaError()

--- a/src/utils/cacheKeyFactory.ts
+++ b/src/utils/cacheKeyFactory.ts
@@ -12,6 +12,7 @@ export const useQueryKeys = () => {
   const globalKeys = [chainId, address]
 
   return {
+    graphBase: [...globalKeys, 'graph'],
     dogfood: (inputString?: string) => [...globalKeys, 'getAddr', inputString, 'dogfood'],
     transactionStageModal: {
       prepareTransaction: (
@@ -78,11 +79,11 @@ export const useQueryKeys = () => {
     subnames: (name: string, orderBy = '', orderDirection = '', search = '') => [
       ...globalKeys,
       'graph',
+      'getSubnames',
       name,
       orderBy,
       orderDirection,
       search,
-      'getSubnames',
     ],
     namesFromAddress: (localAddress?: string) => [
       ...globalKeys,


### PR DESCRIPTION
SyncProvider query invalidation was not working because key prefixes did not contain globalKeys. Currently, in <Notifications/> we have a general invalidateQuery call that is causing the updates right now, but can sometimes not work since it's not based on subgraph updated call.