### PR TITLE
fix: disable non .eth 2lds from being extended (for now)

### DIFF
--- a/src/components/pages/my/names/MyNames.tsx
+++ b/src/components/pages/my/names/MyNames.tsx
@@ -119,7 +119,7 @@ const MyNames = () => {
   const isNameDisabled = useCallback(
     (name: ReturnedName) => {
       if (mode !== 'select') return false
-      return !name.expiryDate
+      return name.parent?.name !== 'eth'
     },
     [mode],
   )


### PR DESCRIPTION
changes:
- disable all non .eth 2lds when extending names in list (previously could extend any with expiryDate set)

Fixes FET-1275