### PR TITLE
Add Dawn Wallet

### DIFF
--- a/src/utils/getDefaultWallets.ts
+++ b/src/utils/getDefaultWallets.ts
@@ -3,6 +3,7 @@ import {
   argentWallet,
   braveWallet,
   coinbaseWallet,
+  dawnWallet,
   injectedWallet,
   ledgerWallet,
   metaMaskWallet,
@@ -28,6 +29,7 @@ export const getDefaultWallets = ({
         injectedWallet({ chains }),
         safeWallet({ chains }),
         braveWallet({ chains }),
+        dawnWallet({ chains }),
         // always shown
         walletConnectWallet({ chains, projectId }),
         rainbowWallet({ chains, projectId }),


### PR DESCRIPTION
Dawn is an Ethereum iOS mobile wallet which features a Safari Extension. It works as an injected wallet and is supported in RainbowKit. 

Our users can not currently use ENS with Dawn - this PR updates the RainbowKit config in the ENS app to make Dawn available as a connection option when it is detected as being available. 

I've tested this locally to check it works and have attached screenshots of what it looks like:

![Connecting](https://github.com/ensdomains/ens-app-v3/assets/20632187/83340262-8efd-4f55-8725-9305ce60dc97)
![Connecting pt 2](https://github.com/ensdomains/ens-app-v3/assets/20632187/857ba5bd-3fcf-4e70-854d-0bed7ac5a8c3)


