### PR TITLE
chore: vscode config tweaks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,7 @@
     "**/.yarn": true,
     "**/.pnp.*": true
   },
-  "eslint.nodePath": ".yarn/sdks",
-  "typescript.tsdk": ".yarn/sdks/typescript/lib",
+  "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "eslint.format.enable": true,
   "editor.codeActionsOnSave": {
@@ -14,7 +13,7 @@
   "stylelint.configFile": ".stylelintrc.json",
   "stylelint.validate": ["css", "typescriptreact"],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "prettier.prettierPath": ".yarn/sdks/prettier/index.js",
+  "prettier.prettierPath": "node_modules/prettier/index.js",
   "[svg]": {
     "editor.defaultFormatter": "jock.svg"
   },


### PR DESCRIPTION
changes:
- typescript tsdk changed to use node_modules
- eslint node path removed (not required)
- prettier path changed to use node_modules