### PR TITLE
fix/advanced editor: abi, rebuilding state, delete addresses

### DIFF
--- a/e2e/specs/stateless/advancedEditor.spec.ts
+++ b/e2e/specs/stateless/advancedEditor.spec.ts
@@ -1,0 +1,79 @@
+import { expect } from '@playwright/test'
+import { test } from '@root/playwright'
+
+test('should be able to maintain state when returning from transaction modal to advanced editor', async ({
+  login,
+  makeName,
+  makePageObject,
+}) => {
+  const name = await makeName({
+    label: 'profile',
+    type: 'legacy',
+    records: {
+      texts: [{ key: 'text', value: 'text' }],
+      coinTypes: [{ key: 'SOL', value: 'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH' }],
+      contentHash: 'ipfs://bafybeico3uuyj3vphxpvbowchdwjlrlrh62awxscrnii7w7flu5z6fk77y',
+      abi: {
+        contentType: 1,
+        data: '{"test":"test"}',
+      },
+    },
+  })
+
+  const recordsPage = makePageObject('RecordsPage')
+  const advancedEditor = makePageObject('AdvancedEditorModal')
+  const transactionModal = makePageObject('TransactionModal')
+
+  await recordsPage.goto(name)
+  await login.connect()
+
+  // Validate records
+  await expect(recordsPage.getRecordValue('text', 'text')).toHaveText('text')
+  await expect(recordsPage.getRecordValue('address', 'sol')).toHaveText(
+    'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH',
+  )
+  await expect(recordsPage.getRecordValue('contentHash')).toHaveText(
+    'ipfs://bafybeico3uuyj3vphxpvbowchdwjlrlrh62awxscrnii7w7flu5z6fk77y',
+  )
+  await expect(recordsPage.getRecordValue('abi')).toHaveText('"{\\"test\\":\\"test\\"}"')
+
+  await recordsPage.editRecordsButton.click()
+
+  // Validate advanced editor
+  await expect(await advancedEditor.recordInput('text', 'text')).toHaveValue('text')
+  await expect(await advancedEditor.recordInput('address', 'SOL')).toHaveValue(
+    'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH',
+  )
+  await expect(await advancedEditor.recordInput('contentHash')).toHaveValue(
+    'ipfs://bafybeico3uuyj3vphxpvbowchdwjlrlrh62awxscrnii7w7flu5z6fk77y',
+  )
+  await expect(await advancedEditor.recordInput('abi')).toHaveValue('"{\\"test\\":\\"test\\"}"')
+
+  await advancedEditor.recordClearButton('text', 'text').then((button) => button.click())
+  await advancedEditor.recordClearButton('address', 'SOL').then((button) => button.click())
+  await advancedEditor.recordInput('contentHash').then((input) => input.fill(''))
+  await advancedEditor.recordInput('abi').then((input) => input.fill(''))
+
+  await advancedEditor.saveButton.click()
+
+  // Validate transaction display item
+  await expect(transactionModal.displayItem('update')).toHaveText('4 records')
+
+  await transactionModal.backButton.click()
+
+  // Validate inputs have been rebuilt correctly
+  await expect(await advancedEditor.recordComponent('text', 'text')).toHaveCount(0)
+  await expect(await advancedEditor.recordComponent('address', 'SOL')).toHaveCount(0)
+  await expect(await advancedEditor.recordInput('contentHash')).toHaveValue('')
+  await expect(await advancedEditor.recordInput('abi')).toHaveValue('')
+
+  await advancedEditor.saveButton.click()
+
+  await transactionModal.autoComplete()
+
+  // Validate change in records
+  await expect(recordsPage.getRecordButton('text', 'text')).toHaveCount(0)
+  await expect(recordsPage.getRecordButton('address', 'sol')).toHaveCount(0)
+  await expect(recordsPage.getRecordButton('contentHash')).toHaveCount(0)
+  await expect(recordsPage.getRecordButton('abi')).toHaveCount(0)
+})

--- a/e2e/specs/stateless/advancedEditor.spec.ts
+++ b/e2e/specs/stateless/advancedEditor.spec.ts
@@ -10,8 +10,16 @@ test('should be able to maintain state when returning from transaction modal to 
     label: 'profile',
     type: 'legacy',
     records: {
-      texts: [{ key: 'text', value: 'text' }],
-      coinTypes: [{ key: 'SOL', value: 'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH' }],
+      texts: [
+        { key: 'name', value: 'Bob' },
+        { key: 'text', value: 'text' },
+        { key: 'com.twitter', value: '@test' },
+      ],
+      coinTypes: [
+        { key: 'SOL', value: 'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH' },
+        { key: 'ETH', value: '0xbec1C7C11F2Fa9AB24b9E49122D26e721766DAF6' },
+        { key: 'BTC', value: '1PzAJcFtEiXo9UGtRU6iqXQKj8NXtcC7DE' },
+      ],
       contentHash: 'ipfs://bafybeico3uuyj3vphxpvbowchdwjlrlrh62awxscrnii7w7flu5z6fk77y',
       abi: {
         contentType: 1,
@@ -28,9 +36,17 @@ test('should be able to maintain state when returning from transaction modal to 
   await login.connect()
 
   // Validate records
+  await expect(recordsPage.getRecordValue('text', 'name')).toHaveText('Bob')
   await expect(recordsPage.getRecordValue('text', 'text')).toHaveText('text')
+  await expect(recordsPage.getRecordValue('text', 'com.twitter')).toHaveText('@test')
   await expect(recordsPage.getRecordValue('address', 'sol')).toHaveText(
     'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH',
+  )
+  await expect(recordsPage.getRecordValue('address', 'eth')).toHaveText(
+    '0xbec1C7C11F2Fa9AB24b9E49122D26e721766DAF6',
+  )
+  await expect(recordsPage.getRecordValue('address', 'btc')).toHaveText(
+    '1PzAJcFtEiXo9UGtRU6iqXQKj8NXtcC7DE',
   )
   await expect(recordsPage.getRecordValue('contentHash')).toHaveText(
     'ipfs://bafybeico3uuyj3vphxpvbowchdwjlrlrh62awxscrnii7w7flu5z6fk77y',
@@ -41,8 +57,16 @@ test('should be able to maintain state when returning from transaction modal to 
 
   // Validate advanced editor
   await expect(await advancedEditor.recordInput('text', 'text')).toHaveValue('text')
+  await expect(await advancedEditor.recordInput('text', 'name')).toHaveValue('Bob')
+  await expect(await advancedEditor.recordInput('text', 'com.twitter')).toHaveValue('@test')
   await expect(await advancedEditor.recordInput('address', 'SOL')).toHaveValue(
     'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH',
+  )
+  await expect(await advancedEditor.recordInput('address', 'ETH')).toHaveValue(
+    '0xbec1C7C11F2Fa9AB24b9E49122D26e721766DAF6',
+  )
+  await expect(await advancedEditor.recordInput('address', 'BTC')).toHaveValue(
+    '1PzAJcFtEiXo9UGtRU6iqXQKj8NXtcC7DE',
   )
   await expect(await advancedEditor.recordInput('contentHash')).toHaveValue(
     'ipfs://bafybeico3uuyj3vphxpvbowchdwjlrlrh62awxscrnii7w7flu5z6fk77y',
@@ -51,29 +75,35 @@ test('should be able to maintain state when returning from transaction modal to 
 
   await advancedEditor.recordClearButton('text', 'text').then((button) => button.click())
   await advancedEditor.recordClearButton('address', 'SOL').then((button) => button.click())
+  await advancedEditor.recordClearButton('address', 'ETH').then((button) => button.click())
   await advancedEditor.recordInput('contentHash').then((input) => input.fill(''))
   await advancedEditor.recordInput('abi').then((input) => input.fill(''))
 
   await advancedEditor.saveButton.click()
 
   // Validate transaction display item
-  await expect(transactionModal.displayItem('update')).toHaveText('4 records')
+  await expect(transactionModal.displayItem('update')).toHaveText('5 records')
 
   await transactionModal.backButton.click()
 
   // Validate inputs have been rebuilt correctly
   await expect(await advancedEditor.recordComponent('text', 'text')).toHaveCount(0)
   await expect(await advancedEditor.recordComponent('address', 'SOL')).toHaveCount(0)
+  await expect(await advancedEditor.recordComponent('address', 'ETH')).toHaveCount(0)
   await expect(await advancedEditor.recordInput('contentHash')).toHaveValue('')
   await expect(await advancedEditor.recordInput('abi')).toHaveValue('')
 
   await advancedEditor.saveButton.click()
+
+  // Validate transaction display item
+  await expect(transactionModal.displayItem('update')).toHaveText('5 records')
 
   await transactionModal.autoComplete()
 
   // Validate change in records
   await expect(recordsPage.getRecordButton('text', 'text')).toHaveCount(0)
   await expect(recordsPage.getRecordButton('address', 'sol')).toHaveCount(0)
+  await expect(recordsPage.getRecordButton('address', 'eth')).toHaveCount(0)
   await expect(recordsPage.getRecordButton('contentHash')).toHaveCount(0)
   await expect(recordsPage.getRecordButton('abi')).toHaveCount(0)
 })

--- a/e2e/specs/stateless/profileEditor.spec.ts
+++ b/e2e/specs/stateless/profileEditor.spec.ts
@@ -318,7 +318,7 @@ test.describe('wrapped', () => {
       await expect(profilePage.record('text', 'nickname')).toHaveText('Test Name')
       await page.getByTestId('records-tab').click()
 
-      await expect(page.getByTestId('name-details-text')).toHaveText('[{"test":"test"}]')
+      await expect(page.getByTestId('name-details-abi')).toHaveText('[{"test":"test"}]')
     })
   })
 })

--- a/playwright/pageObjects/advancedEditorModal.ts
+++ b/playwright/pageObjects/advancedEditorModal.ts
@@ -1,0 +1,37 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { Locator, Page } from '@playwright/test'
+
+export class AdvancedEditorModal {
+  readonly page: Page
+
+  readonly saveButton: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.saveButton = this.page.getByTestId('advanced-editor').getByRole('button', { name: 'Save' })
+  }
+
+  tab(tab: 'text' | 'address' | 'other') {
+    return this.page.getByTestId(`${tab}-tab`)
+  }
+
+  async recordComponent(type: 'text' | 'address' | 'contentHash' | 'abi', key?: string) {
+    if (['text', 'address'].includes(type)) {
+      await this.tab(type as 'text' | 'other').click()
+      return this.page.getByTestId(`record-input-${key}`)
+    }
+    await this.tab('other').click()
+    const _key = type === 'contentHash' ? 'Content Hash' : 'ABI'
+    return this.page.getByTestId(`record-input-${_key}`)
+  }
+
+  async recordInput(type: 'text' | 'address' | 'contentHash' | 'abi', key?: string) {
+    const component = await this.recordComponent(type, key)
+    return component.locator('input')
+  }
+
+  async recordClearButton(type: 'text' | 'address', key: string) {
+    const component = await this.recordComponent(type, key)
+    return component.locator('button')
+  }
+}

--- a/playwright/pageObjects/index.ts
+++ b/playwright/pageObjects/index.ts
@@ -3,6 +3,7 @@ import { Page } from '@playwright/test'
 import { Web3ProviderBackend } from 'headless-web3-provider'
 
 import { AddressPage } from './addressPage'
+import { AdvancedEditorModal } from './advancedEditorModal'
 import { EditRolesModal } from './editRolesModal'
 import { ExtendNamesModal } from './extendNamesModal'
 import { HomePage } from './homePage'
@@ -10,6 +11,7 @@ import { MorePage } from './morePage'
 import { OwnershipPage } from './ownershipPage'
 import { PermissionsPage } from './permissionsPage'
 import { ProfilePage } from './profilePage'
+import { RecordsPage } from './recordsPage'
 import { RegistrationPage } from './registrationPage'
 import { SendNameModal } from './sendNameModal'
 import { SubnamesPage } from './subnamePage'
@@ -30,6 +32,8 @@ const pageObjects = {
   SendNameModal,
   SubnamesPage,
   TransactionModal,
+  RecordsPage,
+  AdvancedEditorModal,
 }
 
 type PageObjects = typeof pageObjects

--- a/playwright/pageObjects/recordsPage.ts
+++ b/playwright/pageObjects/recordsPage.ts
@@ -1,0 +1,26 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { Locator, Page } from '@playwright/test'
+
+export class RecordsPage {
+  readonly page: Page
+
+  readonly editRecordsButton: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.editRecordsButton = this.page.getByRole('button', { name: 'Edit records' })
+  }
+
+  async goto(name: string) {
+    await this.page.goto(`/${name}?tab=records`)
+  }
+
+  getRecordButton(type: 'text' | 'address' | 'contentHash' | 'abi', key?: string) {
+    const testId = key ? `name-details-${type}-${key.toLowerCase()}` : `name-details-${type}`
+    return this.page.getByTestId(testId)
+  }
+
+  getRecordValue(type: 'text' | 'address' | 'contentHash' | 'abi', key?: string) {
+    return this.getRecordButton(type, key).locator('> div').last()
+  }
+}

--- a/playwright/pageObjects/transactionModal.ts
+++ b/playwright/pageObjects/transactionModal.ts
@@ -17,6 +17,8 @@ export class TransactionModal {
 
   readonly transactionModal: Locator
 
+  readonly backButton: Locator
+
   constructor(page: Page, wallet: Web3ProviderBackend) {
     this.page = page
     this.wallet = wallet
@@ -25,6 +27,7 @@ export class TransactionModal {
     this.completeButton = this.page.getByTestId('transaction-modal-complete-button')
     this.closeButton = this.page.getByTestId('close-icon')
     this.transactionModal = this.page.getByTestId('transaction-modal-inner')
+    this.backButton = this.page.locator('body .modal').getByRole('button', { name: 'Back' })
   }
 
   async authorize() {
@@ -52,5 +55,9 @@ export class TransactionModal {
       isModalVisible = await this.transactionModal.isVisible()
     } while (isModalVisible)
     /* eslint-enable no-await-in-loop */
+  }
+
+  displayItem(key: string, option = 'normal') {
+    return this.page.getByTestId(`display-item-${key}-${option}`).locator('> div').last()
   }
 }

--- a/src/components/@molecules/AdvancedEditor/AdvancedEditorTabContent.tsx
+++ b/src/components/@molecules/AdvancedEditor/AdvancedEditorTabContent.tsx
@@ -25,6 +25,7 @@ const TabContentContainer = styled.div(
     display: flex;
     flex-direction: column;
     gap: ${theme.space['3']};
+    padding-right: ${theme.space['1']};
     overflow: hidden;
     flex: 1;
   `,

--- a/src/components/RecordItem.tsx
+++ b/src/components/RecordItem.tsx
@@ -11,7 +11,7 @@ const RecordItem = ({
   itemKey?: string
   value: string
   showLegacy?: boolean
-  type: 'text' | 'address' | 'contentHash'
+  type: 'text' | 'address' | 'contentHash' | 'abi'
 }) => {
   const breakpoint = useBreakpoint()
   const keyLabel = showLegacy && itemKey ? itemKey?.replace('_LEGACY', '') : itemKey

--- a/src/components/pages/profile/[name]/tabs/RecordsTab.tsx
+++ b/src/components/pages/profile/[name]/tabs/RecordsTab.tsx
@@ -261,7 +261,7 @@ export const RecordsTab = ({
               )}
             </SectionTitleContainer>
           </SectionHeader>
-          {abi && <RecordItem type="text" value={abi.data} />}
+          {abi && <RecordItem type="abi" value={abi.data} />}
         </RecordSection>
       </AllRecords>
       {canEdit && resolverAddress !== emptyAddress && (

--- a/src/hooks/useAdvancedEditor.test.ts
+++ b/src/hooks/useAdvancedEditor.test.ts
@@ -1,0 +1,54 @@
+import { normalizeAbi } from './useAdvancedEditor'
+
+describe('normalizeAbi', () => {
+  it('should normalize abi that is a string', () => {
+    expect(normalizeAbi("test")).toEqual({ contentType: 1, data: 'test' })
+  })
+
+  it('should normalize abi that is an empty string', () => {
+    expect(normalizeAbi("")).toEqual({ contentType: 1, data: '' })
+  })
+
+  it('should normalize abi with a string for data', () => {
+    expect(normalizeAbi({ data: 'test' })).toEqual({ contentType: 1, data: 'test' })
+  })
+
+  it('should normalize abi with an empty string for data', () => {
+    expect(normalizeAbi({ data: '' })).toEqual({ contentType: 1, data: '' })
+  })
+
+  it('should normalize abi with an object for data', () => {
+    expect(normalizeAbi({ data: {test: 'test'} })).toEqual({ contentType: 1, data: '{"test":"test"}' })
+  })
+  it('should normalize abi with an array for data', () => {
+    expect(normalizeAbi({ data: ['test'] })).toEqual({ contentType: 1, data: '["test"]' })
+  })
+
+  it('should normalize abi with an object for data', () => {
+    expect(normalizeAbi({ data: {test: 'test'} })).toEqual({ contentType: 1, data: '{"test":"test"}' })
+  })
+
+  it('should NOT normalize abi that is a number', () => {
+    expect(normalizeAbi(5 as any)).toBeUndefined()
+  })
+
+  it('should NOT normalize abi that is null', () => {
+    expect(normalizeAbi(null as any)).toBeUndefined()
+  })
+
+  it('should NOT normalize abi that is undefined', () => {
+    expect(normalizeAbi(undefined as any)).toBeUndefined()
+  })
+
+  it('should NOT normalize abi with null for data', () => {
+    expect(normalizeAbi({ data: null as any})).toBeUndefined()
+  })
+
+  it('should NOT normalize abi with undefined for data', () => {
+    expect(normalizeAbi({ data: undefined as any})).toBeUndefined()
+  })
+
+  it('should NOT normalize abi with a number for data', () => {
+    expect(normalizeAbi({ data: 5 as any})).toBeUndefined()
+  })
+})

--- a/src/hooks/useAdvancedEditor.ts
+++ b/src/hooks/useAdvancedEditor.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { Pattern, match } from 'ts-pattern'
+import { P, Pattern, match } from 'ts-pattern'
 
 import { RecordOptions } from '@ensdomains/ensjs/utils/recordHelpers'
 
@@ -11,7 +11,6 @@ import useExpandableRecordsGroup from '@app/hooks/useExpandableRecordsGroup'
 import { DetailedProfile } from '@app/hooks/useNameDetails'
 import { useProfile } from '@app/hooks/useProfile'
 import { useResolverHasInterfaces } from '@app/hooks/useResolverHasInterfaces'
-import { emptyAddress } from '@app/utils/constants'
 import {
   convertFormSafeKey,
   convertProfileToProfileFormObject,
@@ -33,6 +32,15 @@ const getFieldsByType = (type: 'text' | 'addr' | 'contentHash', data: AdvancedEd
     entries.push(['website', data.other.contentHash])
   }
   return Object.fromEntries(entries)
+}
+
+type NormalizedAbi = { contentType: number | undefined; data: string }
+export const normalizeAbi = (abi: RecordOptions['abi'] | string): NormalizedAbi | undefined => {
+  return match(abi)
+    .with(P.string, (data) => ({ contentType: 1, data }))
+    .with({ data: P.string }, ({ data }) => ({ contentType: 1, data }))
+    .with({ data: {} }, ({ data }) => ({ contentType: 1, data: JSON.stringify(data) }))
+    .otherwise(() => undefined)
 }
 
 export type AdvancedEditorType = {
@@ -166,6 +174,7 @@ const useAdvancedEditor = ({ profile, loading, overwrites, callback }: Props) =>
     }
   })()
 
+  const [shouldRunOverwritesScript, setShouldRunOverwritesScript] = useState(false)
   useEffect(() => {
     if (profile) {
       const formObject = convertProfileToProfileFormObject(profile)
@@ -189,33 +198,60 @@ const useAdvancedEditor = ({ profile, loading, overwrites, callback }: Props) =>
         address: Object.keys(newDefaultValues.address) || [],
         text: Object.keys(newDefaultValues.text) || [],
       }
+      setExistingRecords(newExistingRecords)
+      setShouldRunOverwritesScript(true)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [profile])
 
+  useEffect(() => {
+    if (shouldRunOverwritesScript) {
       overwrites?.texts?.forEach((text) => {
         const { key, value } = text
         const formKey = formSafeKey(key)
-        setValue(`text.${formKey}`, value, { shouldDirty: true })
-        if (!newExistingRecords.text.includes(formKey)) {
-          newExistingRecords.text.push(formKey)
+        const isExisting = existingRecords.text.includes(formKey)
+        if (value && isExisting) {
+          setValue(`text.${formKey}`, value, { shouldDirty: true })
+        } else if (value && !isExisting) {
+          addTextKey(formKey)
+          setValue(`text.${formKey}`, value, { shouldDirty: true })
+        } else if (!value && isExisting) {
+          removeTextKey(formKey, false)
+        } else if (!value && !isExisting) {
+          removeTextKey(formKey, true)
         }
       })
 
       overwrites?.coinTypes?.forEach((coinType) => {
         const { key, value } = coinType
         const formKey = formSafeKey(key)
-        setValue(`address.${formKey}`, value, { shouldDirty: true })
-        if (!newExistingRecords.address.includes(formKey)) {
-          newExistingRecords.address.push(formKey)
+        const isExisting = existingRecords.address.includes(formKey)
+        if (value && isExisting) {
+          setValue(`address.${formKey}`, value, { shouldDirty: true })
+        } else if (value && !isExisting) {
+          addAddressKey(formKey)
+          setValue(`address.${formKey}`, value, { shouldDirty: true })
+        } else if (!value && isExisting) {
+          removeAddressKey(formKey, false)
+        } else if (!value && !isExisting) {
+          removeAddressKey(formKey, true)
         }
       })
 
-      if (overwrites?.contentHash) {
+      if (typeof overwrites?.contentHash === 'string') {
         setValue('other.contentHash', overwrites.contentHash, { shouldDirty: true })
       }
 
-      setExistingRecords(newExistingRecords)
+      const abi = normalizeAbi(overwrites?.abi)
+      if (abi) {
+        setValue('other.abi', abi, { shouldDirty: true })
+      }
+
+      setShouldRunOverwritesScript(false)
     }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [profile])
+  }, [existingRecords, shouldRunOverwritesScript])
 
   const { hasInterface: hasABIInterface, isLoading: isLoadingABIInterface } =
     useResolverHasInterfaces(['IABIResolver'], profile?.resolverAddress, loading)
@@ -236,11 +272,6 @@ const useAdvancedEditor = ({ profile, loading, overwrites, callback }: Props) =>
       value,
     })) as { key: string; value: string }[]
 
-    const coinTypesWithZeroAddressses = coinTypes.map((coinType) => {
-      if (coinType.value) return coinType
-      return { key: coinType.key, value: emptyAddress }
-    })
-
     const contentHash = dirtyFields.other?.contentHash
 
     const abi = match(dirtyFields.other?.abi?.data)
@@ -250,7 +281,7 @@ const useAdvancedEditor = ({ profile, loading, overwrites, callback }: Props) =>
 
     const records = {
       texts,
-      coinTypes: coinTypesWithZeroAddressses,
+      coinTypes,
       contentHash,
       abi,
     }
@@ -276,7 +307,6 @@ const useAdvancedEditor = ({ profile, loading, overwrites, callback }: Props) =>
     handleTabClick,
     hasErrors,
     existingRecords,
-    setExistingRecords,
     existingTextKeys,
     newTextKeys,
     addTextKey,

--- a/src/hooks/useExpandableRecordsGroup.ts
+++ b/src/hooks/useExpandableRecordsGroup.ts
@@ -53,8 +53,7 @@ const useExpandableRecordsGroup = <T extends FieldValues>({
         shouldDirty: returnAllFields ? Object.keys(otherValues).length > 0 : true,
       })
     } else {
-      const newValues = { ...otherValues, [key]: '' }
-      setValue(group, newValues as PathValue<T, Path<T>>, { shouldDirty: true })
+      setValue(`${group}.${key}` as Path<T>, '' as PathValue<T, Path<T>>, { shouldDirty: true })
     }
   }
 

--- a/src/transaction-flow/input/AdvancedEditor/AdvancedEditor.test.tsx
+++ b/src/transaction-flow/input/AdvancedEditor/AdvancedEditor.test.tsx
@@ -278,7 +278,7 @@ describe('AdvancedEditor', () => {
     })
     expect(mockDispatch.mock.calls[0][0].payload[0].data.records.coinTypes[0]).toEqual({
       key: 'ETH',
-      value: '0x0000000000000000000000000000000000000000',
+      value: '',
     })
     expect(mockDispatch.mock.calls[0][0].payload[0].data.records.coinTypes.length).toBe(1)
   })


### PR DESCRIPTION
**Changes**
1. Fix deletion of non-evm records for advanced records editor: Fixed api for deleting address record from empty address (0x0) to  empty string ('')
2. Fix the rebuild state process when the "back" button is pressed in the transaction modal.
3. Fixed the display items to show changes to the Abi.