### PR TITLE
hotfix: mainnet for unsupported network change button

### DIFF
--- a/src/pages/unsupportedNetwork.tsx
+++ b/src/pages/unsupportedNetwork.tsx
@@ -41,14 +41,19 @@ export default function Page() {
   const router = useRouter()
 
   useEffect(() => {
-    if (currentChain?.id === 5 || currentChain?.id === 1337) {
+    if (
+      currentChain?.id === 1 ||
+      currentChain?.id === 5 ||
+      currentChain?.id === 11155111 ||
+      currentChain?.id === 1337
+    ) {
       router.push('/')
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentChain?.id])
 
   const handleChangeNetwork = () => {
-    switchNetwork?.(5)
+    switchNetwork?.(1)
   }
 
   return (


### PR DESCRIPTION
changes:
- update supported chain ids for unsupportedNetwork page rerouting
- update "Change network" button on unsupportedNetwork page to prompt a switch to mainnet (was goerli)

repro steps:
1. be on a supported network in metamask (e.g. mainnet)
2. connect to the ens app
3. switch to unsupported network (e.g. base, linea)
4. if you weren't automatically directed to `/unsupportedNetwork`, go to `/unsupportedNetwork`
5. click the "Change network" button
6. you will be prompted to switch to goerli