### PR TITLE
fix dns import to use common hooks and fix step flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ tsconfig.tsbuildinfo
 !.yarn/sdks
 !.yarn/versions
 
+# wrangler
+.wrangler/
+
 # jest coverage
 /coverage
 

--- a/src/components/pages/import/[name]/DNSClaim.tsx
+++ b/src/components/pages/import/[name]/DNSClaim.tsx
@@ -180,19 +180,9 @@ export default () => {
   useEffect(() => {
     const init = async () => {
       try {
-        if (!isDnsSecEnabled) {
-          return
-        }
-
-        if (hasPendingTransaction(transactions)) {
-          setCurrentStep(2)
-          return
-        }
-
-        if (dnsOwner !== address) {
-          setCurrentStep(1)
-        }
-
+        if (!isDnsSecEnabled) return
+        if (hasPendingTransaction(transactions)) return setCurrentStep(2)
+        if (dnsOwner !== address) return setCurrentStep(1)
         setCurrentStep(2)
       } catch (e) {
         console.error('caught error: ', e)

--- a/src/components/pages/import/[name]/DNSClaim.tsx
+++ b/src/components/pages/import/[name]/DNSClaim.tsx
@@ -140,11 +140,10 @@ const StyledTitle = styled(Title)(
 export default () => {
   const router = useRouterWithHistory()
   const breakpoints = useBreakpoint()
-  const { address } = useAccount()
+  const { address, isConnected } = useAccount()
 
   const { name = '', isValid } = useValidate({ input: router.query.name as string })
   const transactions = useRecentTransactions()
-  const { isConnected } = useAccount()
   const { t } = useTranslation('dnssec')
 
   const {
@@ -193,7 +192,14 @@ export default () => {
 
     if (shouldShowSuccessPage(transactions)) {
       setCurrentStep(3)
-    } else if (!!name && !isDnsSecEnabledLoading && !isDnsOwnerLoading && !isInitialized) {
+    } else if (
+      !!name &&
+      isConnected &&
+      !!address &&
+      !isDnsSecEnabledLoading &&
+      !isDnsOwnerLoading &&
+      !isInitialized
+    ) {
       init()
     }
   }, [
@@ -203,12 +209,13 @@ export default () => {
     isDnsOwnerLoading,
     name,
     address,
+    isConnected,
     transactions,
     setIsInitialized,
     isInitialized,
   ])
 
-  if (!isInitialized) return null
+  if (!router.isReady) return null
   return (
     <Container>
       <Head>

--- a/src/components/pages/import/[name]/DNSClaim.tsx
+++ b/src/components/pages/import/[name]/DNSClaim.tsx
@@ -202,7 +202,6 @@ export default () => {
     }
 
     if (shouldShowSuccessPage(transactions)) {
-      alert('Switching here')
       setCurrentStep(3)
     } else if (!!name && !isDnsSecEnabledLoading && !isDnsOwnerLoading && !isInitialized) {
       init()

--- a/src/components/pages/import/[name]/EnableDNSSEC.tsx
+++ b/src/components/pages/import/[name]/EnableDNSSEC.tsx
@@ -74,7 +74,6 @@ export const EnableDNSSEC = ({
   name: string
 }) => {
   const [errorState, setErrorState] = useState(Errors.NOT_CHECKED)
-  // const [isLoading, setIsLoading] = useState(false)
   const { t } = useTranslation('dnssec')
 
   const handleCheck = async () => {

--- a/src/components/pages/import/[name]/EnableDNSSEC.tsx
+++ b/src/components/pages/import/[name]/EnableDNSSEC.tsx
@@ -1,3 +1,4 @@
+import { QueryObserverResult } from '@tanstack/react-query'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -9,7 +10,6 @@ import { Outlink } from '@app/components/Outlink'
 
 import { AlignedDropdown, ButtonContainer, CheckButton } from './shared'
 import { Steps } from './Steps'
-import { isDnsSecEnabled } from './utils'
 
 const HelperLinks = [
   {
@@ -63,25 +63,27 @@ const Container = styled.div`
 `
 
 export const EnableDNSSEC = ({
-  setCurrentStep,
+  refetch,
+  isLoading,
+  incrementStep,
   name,
 }: {
-  setCurrentStep: (arg: number) => void
+  refetch: () => Promise<QueryObserverResult<boolean, Error>>
+  isLoading: boolean
+  incrementStep: () => void
   name: string
 }) => {
   const [errorState, setErrorState] = useState(Errors.NOT_CHECKED)
-  const [isLoading, setIsLoading] = useState(false)
+  // const [isLoading, setIsLoading] = useState(false)
   const { t } = useTranslation('dnssec')
 
   const handleCheck = async () => {
-    setIsLoading(true)
-    const hasDnsSecEnabled = await isDnsSecEnabled(name as string)
-    if (hasDnsSecEnabled) {
-      setCurrentStep(1)
+    const test = await refetch()
+    if (test.data) {
+      incrementStep()
       return
     }
     setErrorState(Errors.DNSSEC_NOT_ENABLED)
-    setIsLoading(false)
   }
 
   return (

--- a/src/hooks/dns/useDnsSecEnabled.ts
+++ b/src/hooks/dns/useDnsSecEnabled.ts
@@ -7,7 +7,7 @@ import { CreateQueryKey, QueryConfig } from '@app/types'
 import { useQueryKeyFactory } from '../useQueryKeyFactory'
 
 type UseDnsSecEnabledParameters = {
-  tld?: string | undefined | null
+  name?: string | undefined | null
 }
 
 type UseDnsSecEnabledReturnType = boolean
@@ -21,11 +21,11 @@ type QueryKey<TParams extends UseDnsSecEnabledParameters> = CreateQueryKey<
 >
 
 export const getDnsSecEnabledQueryFn = async <TParams extends UseDnsSecEnabledParameters>({
-  queryKey: [{ tld }],
+  queryKey: [{ name }],
 }: QueryFunctionContext<QueryKey<TParams>>) => {
-  if (!tld) throw new Error('tld is required')
+  if (!name) throw new Error('name is required')
 
-  return isDnsSecEnabled(tld)
+  return isDnsSecEnabled(name)
 }
 
 export const useDnsSecEnabled = <TParams extends UseDnsSecEnabledParameters>({
@@ -49,7 +49,7 @@ export const useDnsSecEnabled = <TParams extends UseDnsSecEnabledParameters>({
 
   const query = useQuery(queryKey, getDnsSecEnabledQueryFn, {
     cacheTime,
-    enabled: enabled && !!params.tld && params.tld !== 'eth' && params.tld !== '[root]',
+    enabled: enabled && !!params.name && params.name !== 'eth' && params.name !== '[root]',
     staleTime,
     onError,
     onSettled,

--- a/src/hooks/ensjs/dns/useDnsOwner.ts
+++ b/src/hooks/ensjs/dns/useDnsOwner.ts
@@ -18,8 +18,7 @@ type UseDnsOwnerParameters = PartialBy<GetDnsOwnerParameters, 'name'>
 
 type UseDnsOwnerReturnType = GetDnsOwnerReturnType
 
-type UseDnsOwnerConfig = QueryConfig<
-  UseDnsOwnerReturnType,
+export type UseDnsOwnerError =
   | UnsupportedNameTypeError
   | DnsResponseStatusError
   | DnsDnssecVerificationFailedError
@@ -27,7 +26,8 @@ type UseDnsOwnerConfig = QueryConfig<
   | DnsInvalidTxtRecordError
   | DnsInvalidAddressChecksumError
   | Error
->
+
+type UseDnsOwnerConfig = QueryConfig<UseDnsOwnerReturnType, UseDnsOwnerError>
 
 type QueryKey<TParams extends UseDnsOwnerParameters> = CreateQueryKey<
   TParams,

--- a/src/hooks/useSupportsTLD.ts
+++ b/src/hooks/useSupportsTLD.ts
@@ -4,7 +4,7 @@ export const useSupportsTLD = (name = '') => {
   const labels = name?.split('.') || []
   const tld = labels[labels.length - 1]
 
-  const { data: isDnsSecEnabled, ...query } = useDnsSecEnabled({ tld })
+  const { data: isDnsSecEnabled, ...query } = useDnsSecEnabled({ name: tld })
   return {
     data: tld === 'eth' || tld === '[root]' || isDnsSecEnabled,
     ...query,


### PR DESCRIPTION
The work flow of dns import had some flashing issues and difficulty navigating back and forth. Fixed the navigation and well as improved by reusing common hooks that were used in multiple "views"