### PR TITLE
fix: show all dns names with eth record as imported at a minimum

### DIFF
--- a/src/components/@molecules/SearchInput/SearchInput.tsx
+++ b/src/components/@molecules/SearchInput/SearchInput.tsx
@@ -13,6 +13,7 @@ import { useQueryClient } from 'wagmi'
 
 import { BackdropSurface, Portal, Typography, mq } from '@ensdomains/thorin'
 
+import { BatchReturn } from '@app/hooks/useBasicName'
 import { useLocalStorage } from '@app/hooks/useLocalStorage'
 import { useRouterWithHistory } from '@app/hooks/useRouterWithHistory'
 import { ValidationResult, useValidate, validate } from '@app/hooks/useValidate'
@@ -333,14 +334,16 @@ export const SearchInput = ({
       const queryKey = queryKeys.basicName(selectedItem.value, false)
       const currentQuery = queryClient.getQueryData<any[]>(queryKey)
       if (currentQuery) {
-        const [ownerData, wrapperData, expiryOrResolverData, priceOrAddrData] = currentQuery
+        const { ownerData, wrapperData, expiryData, priceData, addrData } =
+          currentQuery as NonNullable<BatchReturn>
         const registrationStatus = getRegistrationStatus({
           timestamp: Date.now(),
           validation: currentValidation,
           ownerData,
           wrapperData,
-          expiryOrResolverData,
-          priceOrAddrData,
+          expiryData,
+          priceData,
+          addrData,
         })
         if (registrationStatus === 'available') {
           path = `/register/${selectedItem.value}`

--- a/src/components/pages/profile/[name]/Profile.tsx
+++ b/src/components/pages/profile/[name]/Profile.tsx
@@ -125,6 +125,7 @@ const ProfileContent = ({ isSelf, isLoading: _isLoading, name }: Props) => {
     isLoading: detailsLoading,
     wrapperData,
     registrationStatus,
+    refetch,
   } = nameDetails
 
   const isLoading = _isLoading || detailsLoading
@@ -165,7 +166,11 @@ const ProfileContent = ({ isSelf, isLoading: _isLoading, name }: Props) => {
     ]
   }, [isSelf, beautifiedName, isValid, name, t])
 
-  const [tab, setTab] = useQueryParameterState<Tab>('tab', 'profile')
+  const [tab, setTab_] = useQueryParameterState<Tab>('tab', 'profile')
+  const setTab: typeof setTab_ = (value) => {
+    refetch()
+    setTab_(value)
+  }
   const visibileTabs = isWrapped ? tabs : tabs.filter((_tab) => _tab !== 'permissions')
 
   const abilities = useAbilities(normalisedName)

--- a/src/hooks/useBasicName.ts
+++ b/src/hooks/useBasicName.ts
@@ -131,6 +131,8 @@ export const useBasicName = (name?: string | null, options: UseBasicNameOptions 
     isFetching,
     isFetchedAfterMount,
     status,
+    refetch,
+    isRefetching,
   } = useQuery(
     queryKey,
     async () =>
@@ -226,6 +228,7 @@ export const useBasicName = (name?: string | null, options: UseBasicNameOptions 
     pccExpired,
     canBeWrapped,
     addrData: addrData as string | undefined,
-    isCachedData: status === 'success' && isFetched && !isFetchedAfterMount,
+    refetch,
+    isCachedData: isRefetching || (status === 'success' && isFetched && !isFetchedAfterMount),
   }
 }

--- a/src/hooks/useBasicName.ts
+++ b/src/hooks/useBasicName.ts
@@ -3,7 +3,7 @@ import { useQuery } from 'wagmi'
 
 import { truncateFormat } from '@ensdomains/ensjs/utils/format'
 
-import { ReturnedENS } from '@app/types'
+import { Prettify, ReturnedENS } from '@app/types'
 import { useEns } from '@app/utils/EnsProvider'
 import { useQueryKeys } from '@app/utils/cacheKeyFactory'
 import { emptyAddress } from '@app/utils/constants'
@@ -12,25 +12,39 @@ import { isLabelTooLong, yearsToSeconds } from '@app/utils/utils'
 
 import { useGlobalErrorFunc } from './errors/useGlobalErrorFunc'
 import { usePccExpired } from './fuses/usePccExpired'
-import { useChainId } from './useChainId'
 import { useContractAddress } from './useContractAddress'
 import useCurrentBlockTimestamp from './useCurrentBlockTimestamp'
 import { useSupportsTLD } from './useSupportsTLD'
 import { useValidate } from './useValidate'
 
+type PickToNotNever<T, U> = {
+  [K in keyof T]: K extends U ? T[K] : never
+}
+
 type ENS = ReturnType<typeof useEns>
-type BaseBatchReturn = [ReturnedENS['getOwner']]
-type NormalBatchReturn = [...BaseBatchReturn, ReturnedENS['getWrapperData']]
-type DnsBatchReturn = [...NormalBatchReturn, ReturnedENS['getResolver'], ReturnedENS['getAddr']]
-type ETH2LDBatchReturn = [...NormalBatchReturn, ReturnedENS['getExpiry'], ReturnedENS['getPrice']]
-type BatchReturn =
-  | []
-  | BaseBatchReturn
+type BaseBatchReturn = {
+  ownerData?: ReturnedENS['getOwner']
+  wrapperData?: ReturnedENS['getWrapperData']
+  expiryData?: ReturnedENS['getExpiry']
+  priceData?: ReturnedENS['getPrice']
+  addrData?: ReturnedENS['getAddr']
+}
+type RootBatchReturn = PickToNotNever<BaseBatchReturn, 'ownerData'>
+type ShortBatchReturn = PickToNotNever<BaseBatchReturn, undefined>
+type NormalBatchReturn = PickToNotNever<BaseBatchReturn, 'ownerData' | 'wrapperData'>
+type DnsBatchReturn = PickToNotNever<BaseBatchReturn, 'ownerData' | 'wrapperData' | 'addrData'>
+type ETH2LDBatchReturn = PickToNotNever<
+  BaseBatchReturn,
+  'ownerData' | 'wrapperData' | 'expiryData' | 'priceData'
+>
+type BatchReturn = Prettify<
+  | RootBatchReturn
+  | ShortBatchReturn
   | NormalBatchReturn
   | DnsBatchReturn
   | ETH2LDBatchReturn
   | undefined
-
+>
 const EXPIRY_LIVE_WATCH_TIME = 1_000 * 60 * 5 // 5 minutes
 
 const getBatchData = (
@@ -41,41 +55,48 @@ const getBatchData = (
 ): Promise<BatchReturn> => {
   // exception for "[root]", get owner of blank name
   if (name === '[root]') {
-    return Promise.all([ens.getOwner('', { contract: 'registry' })])
+    return ens.getOwner('', { contract: 'registry' }).then((ownerData) => ({ ownerData }))
   }
 
   const labels = name.split('.')
   if (validation.isETH && validation.is2LD) {
     if (validation.isShort) {
-      return Promise.resolve([])
+      return Promise.resolve({})
     }
-    return ens.batch(
-      ens.getOwner.batch(name, { skipGraph }),
-      ens.getWrapperData.batch(name),
-      ens.getExpiry.batch(name),
-      ens.getPrice.batch(labels[0], yearsToSeconds(1), false),
-    )
+    return ens
+      .batch(
+        ens.getOwner.batch(name, { skipGraph }),
+        ens.getWrapperData.batch(name),
+        ens.getExpiry.batch(name),
+        ens.getPrice.batch(labels[0], yearsToSeconds(1), false),
+      )
+      .then((res) => ({
+        ownerData: res?.[0],
+        wrapperData: res?.[1],
+        expiryData: res?.[2],
+        priceData: res?.[3],
+      }))
   }
 
-  if (!validation.isETH && validation.is2LD) {
+  if (!validation.isETH) {
     const getAddrBatch = ens.getAddr.batch(name)
 
-    return ens.batch(
-      ens.getOwner.batch(name),
-      ens.getWrapperData.batch(name),
-      ens.getResolver.batch(name),
-      {
+    return ens
+      .batch(ens.getOwner.batch(name), ens.getWrapperData.batch(name), {
         args: getAddrBatch.args,
         raw: getAddrBatch.raw,
         decode: async (...args) =>
           getAddrBatch
             .decode(...(args as Parameters<typeof getAddrBatch['decode']>))
             .catch(() => undefined),
-      },
-    )
+      })
+      .then((res) => ({ ownerData: res?.[0], wrapperData: res?.[1], addrData: res?.[2] }))
   }
 
-  return ens.batch(ens.getOwner.batch(name), ens.getWrapperData.batch(name))
+  return ens.batch(ens.getOwner.batch(name), ens.getWrapperData.batch(name)).then((res) => ({
+    ownerData: res?.[0],
+    wrapperData: res?.[1],
+  }))
 }
 
 type UseBasicNameOptions = {
@@ -87,8 +108,6 @@ type UseBasicNameOptions = {
 export const useBasicName = (name?: string | null, options: UseBasicNameOptions = {}) => {
   const { normalised = false, skipGraph = true, enabled = true } = options
   const ens = useEns()
-
-  const chainId = useChainId()
 
   const { name: _normalisedName, isValid, ...validation } = useValidate(name!, !name)
 
@@ -120,15 +139,13 @@ export const useBasicName = (name?: string | null, options: UseBasicNameOptions 
       enabled: !!(enabled && ens.ready && name && isValid),
     },
   )
-  const [ownerData, _wrapperData, expiryOrResolverData, priceOrAddrData] = batchData || []
-  const expiryData =
-    validation.isETH && validation.is2LD
-      ? (expiryOrResolverData as ReturnedENS['getExpiry'])
-      : undefined
-  const priceData =
-    validation.isETH && validation.is2LD ? (priceOrAddrData as ReturnedENS['getPrice']) : undefined
-  const addrData =
-    !validation.isETH && validation.is2LD ? (priceOrAddrData as ReturnedENS['getAddr']) : undefined
+  const {
+    ownerData,
+    wrapperData: _wrapperData,
+    expiryData,
+    priceData,
+    addrData,
+  } = batchData || ({} as NonNullable<BatchReturn>)
 
   const wrapperData = useMemo(() => {
     if (!_wrapperData) return undefined
@@ -166,10 +183,10 @@ export const useBasicName = (name?: string | null, options: UseBasicNameOptions 
         validation,
         ownerData,
         wrapperData,
-        expiryOrResolverData,
-        priceOrAddrData,
+        expiryData,
+        priceData,
+        addrData,
         supportedTLD,
-        chainId,
       })
     : undefined
 

--- a/src/hooks/useBasicName.ts
+++ b/src/hooks/useBasicName.ts
@@ -37,7 +37,7 @@ type ETH2LDBatchReturn = PickToNotNever<
   BaseBatchReturn,
   'ownerData' | 'wrapperData' | 'expiryData' | 'priceData'
 >
-type BatchReturn = Prettify<
+export type BatchReturn = Prettify<
   | RootBatchReturn
   | ShortBatchReturn
   | NormalBatchReturn

--- a/src/hooks/useNameDetails.tsx
+++ b/src/hooks/useNameDetails.tsx
@@ -40,6 +40,7 @@ export const useNameDetails = (name: string, skipGraph = false) => {
     expiryDate,
     gracePeriodEndDate,
     addrData,
+    refetch: refetchBasicName,
     ...basicName
   } = useBasicName(name, { normalised: false, skipGraph })
 
@@ -48,6 +49,7 @@ export const useNameDetails = (name: string, skipGraph = false) => {
     loading: profileLoading,
     status,
     isCachedData: profileIsCachedData,
+    refetch: refetchProfile,
   } = useProfile(normalisedName, {
     skip: !normalisedName || normalisedName === '[root]',
     skipGraph,
@@ -181,6 +183,10 @@ export const useNameDetails = (name: string, skipGraph = false) => {
     gracePeriodEndDate,
     expiryDate,
     addrData,
+    refetch: () => {
+      refetchBasicName()
+      refetchProfile()
+    },
     ...basicName,
   }
 }

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -38,6 +38,8 @@ export const useProfile = (
     // don't remove this line, it updates the isCachedData state (for some reason) but isn't needed to verify it
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     isFetching,
+    refetch,
+    isRefetching,
   } = useQuery(
     queryKey,
     () =>
@@ -67,6 +69,7 @@ export const useProfile = (
     loading: !ready || loading,
     status,
     isFetching,
-    isCachedData: status === 'success' && isFetched && !isFetchedAfterMount,
+    refetch,
+    isCachedData: isRefetching || (status === 'success' && isFetched && !isFetchedAfterMount),
   }
 }

--- a/src/utils/registrationStatus.test.ts
+++ b/src/utils/registrationStatus.test.ts
@@ -52,7 +52,7 @@ describe('getRegistrationStatus', () => {
         validation: { is2LD: true, isETH: true },
         ownerData,
         wrapperData,
-        expiryOrResolverData: expiryData,
+        expiryData,
       })
       expect(result).toBe('registered')
     })
@@ -67,7 +67,7 @@ describe('getRegistrationStatus', () => {
         validation: { is2LD: true, isETH: true },
         ownerData,
         wrapperData,
-        expiryOrResolverData: expiryData,
+        expiryData,
       })
       expect(result).toBe('gracePeriod')
     })
@@ -88,8 +88,8 @@ describe('getRegistrationStatus', () => {
         validation: { is2LD: true, isETH: true },
         ownerData,
         wrapperData,
-        expiryOrResolverData: expiryData,
-        priceOrAddrData: priceData,
+        expiryData,
+        priceData,
       })
       expect(result).toBe('premium')
     })
@@ -109,8 +109,8 @@ describe('getRegistrationStatus', () => {
         validation: { is2LD: true, isETH: true },
         ownerData,
         wrapperData,
-        expiryOrResolverData: expiryData,
-        priceOrAddrData: priceData,
+        expiryData,
+        priceData,
       })
 
       expect(result).toBe('available')
@@ -122,7 +122,7 @@ describe('getRegistrationStatus', () => {
         validation: { is2LD: true, isETH: true },
         ownerData,
         wrapperData,
-        expiryOrResolverData: {
+        expiryData: {
           expiry: new Date(Date.now() - 1_000 * 10),
           gracePeriod: 0,
         },
@@ -166,9 +166,7 @@ describe('getRegistrationStatus', () => {
       validation: { is2LD: true },
       ownerData,
       wrapperData,
-      chainId: 1,
-      expiryOrResolverData: "0xF142B308cF687d4358410a4cB885513b30A42025",
-      priceOrAddrData: "0xF142B308cF687d4358410a4cB885513b30A42025",
+      addrData: "0xF142B308cF687d4358410a4cB885513b30A42025",
       supportedTLD: true,
     })
     expect(result).toBe('imported')

--- a/src/utils/registrationStatus.ts
+++ b/src/utils/registrationStatus.ts
@@ -19,31 +19,24 @@ export type RegistrationStatus =
   | 'notOwned'
   | 'unsupportedTLD'
 
-const offchainDnsAddress = {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  '1': '0xF142B308cF687d4358410a4cB885513b30A42025',
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  '11155111': '0x179Be112b24Ad4cFC392eF8924DfA08C20Ad8583',
-}
-
 export const getRegistrationStatus = ({
   timestamp,
   validation: { isETH, is2LD, isShort, type },
   ownerData,
   wrapperData,
-  expiryOrResolverData,
-  priceOrAddrData,
+  expiryData,
+  priceData,
+  addrData,
   supportedTLD,
-  chainId,
 }: {
   timestamp: number
   validation: Partial<Omit<ParsedInputResult, 'normalised' | 'isValid'>>
   ownerData?: ReturnedENS['getOwner']
   wrapperData?: ReturnedENS['getWrapperData']
-  expiryOrResolverData?: ReturnedENS['getExpiry'] | ReturnedENS['getResolver']
-  priceOrAddrData?: ReturnedENS['getPrice'] | ReturnedENS['getAddr']
+  expiryData?: ReturnedENS['getExpiry']
+  priceData?: ReturnedENS['getPrice']
+  addrData?: ReturnedENS['getAddr']
   supportedTLD?: boolean | null
-  chainId?: number
 }): RegistrationStatus => {
   if (isETH && is2LD && isShort) {
     return 'short'
@@ -56,8 +49,6 @@ export const getRegistrationStatus = ({
   }
 
   if (isETH && is2LD) {
-    const expiryData = expiryOrResolverData as ReturnedENS['getExpiry']
-    const priceData = priceOrAddrData as ReturnedENS['getPrice']
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     if (expiryData && expiryData.expiry) {
       const { expiry: _expiry, gracePeriod } = expiryData as {
@@ -92,14 +83,10 @@ export const getRegistrationStatus = ({
     return 'notOwned'
   }
 
-  const addrData = priceOrAddrData as ReturnedENS['getAddr']
-  const resolverData = expiryOrResolverData as ReturnedENS['getResolver']
-
   if (
     addrData &&
     addrData !== '0x0000000000000000000000000000000000000020' &&
-    addrData !== emptyAddress &&
-    resolverData === offchainDnsAddress[String(chainId) as keyof typeof offchainDnsAddress]
+    addrData !== emptyAddress
   ) {
     return 'imported'
   }


### PR DESCRIPTION
changes:
- no longer fetching resolver data for registration status calc
  - any ccip-read dns name with an eth address will show as imported, instead of just gasless dnssec
- no longer requiring is2LD to be true to fetch addr for dns name
  - gasless subname imports will show as imported
- made batch return into obj