### PR TITLE
(hot)fix: support for # sign in app

### DIFF
--- a/src/components/@molecules/AvatarWithIdentifier/AvatarWithIdentifier.tsx
+++ b/src/components/@molecules/AvatarWithIdentifier/AvatarWithIdentifier.tsx
@@ -54,10 +54,9 @@ export const AvatarWithIdentifier = ({
   const primary = usePrimary(address, !address || !!name || address === emptyAddress)
   const network = useChainId()
 
-  const _name = name || primary.data?.beautifiedName
+  const _name = primary.data?.beautifiedName || name
   const _title = _name || (shortenAddressAsTitle ? shortenAddress(address) : address)
-  const _subtitle =
-    subtitle || (primary.data?.beautifiedName || name ? shortenAddress(address) : undefined)
+  const _subtitle = subtitle || (_name ? shortenAddress(address) : undefined)
 
   const isTitleFullAddress = !shortenAddressAsTitle && !_name
 

--- a/src/components/@molecules/ProfileEditor/Avatar/AvatarUpload.tsx
+++ b/src/components/@molecules/ProfileEditor/Avatar/AvatarUpload.tsx
@@ -82,7 +82,7 @@ const UploadComponent = ({
     if (network !== 'mainnet') {
       baseURL = `${baseURL}/${network}`
     }
-    const endpoint = `${baseURL}/${name}`
+    const endpoint = `${baseURL}/${encodeURIComponent(name)}`
 
     const sig = await signTypedDataAsync()
     const fetched = (await fetch(endpoint, {

--- a/src/components/pages/profile/[name]/registration/useMoonpayRegistration.ts
+++ b/src/components/pages/profile/[name]/registration/useMoonpayRegistration.ts
@@ -29,7 +29,11 @@ export const useMoonpayRegistration = (
     const label = getLabelFromName(normalisedName)
     const tokenId = labelhash(label)
 
-    const requestUrl = `${MOONPAY_WORKER_URL[chainId]}/signedurl?tokenId=${tokenId}&name=${normalisedName}&duration=${duration}&walletAddress=${address}`
+    const requestUrl = `${
+      MOONPAY_WORKER_URL[chainId]
+    }/signedurl?tokenId=${tokenId}&name=${encodeURIComponent(
+      normalisedName,
+    )}&duration=${duration}&walletAddress=${address}`
     const response = await fetch(requestUrl)
     const textResponse = await response.text()
     setMoonpayUrl(textResponse)

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -245,9 +245,9 @@ export const getDestination = (url: UrlObject | string) => {
     const match = regex.exec(href)
     if (match) {
       const values = href.split('/')
-      let replacedDestination = (
-        isIPFS ? rewrite.destination : rewrite.flattenedDestination
-      ).replace(/\$(\d)/g, (_, n) => values[parseInt(n)])
+      let replacedDestination = (isIPFS ? rewrite.destination : rewrite.flattenedDestination)
+        .replace(/\$(\d)/g, (_, n) => values[parseInt(n)])
+        .replace('#', '%23')
       if (!isIPFS && rewrite.tldPrefix && !replacedDestination.includes('.')) {
         replacedDestination = `/tld${replacedDestination}`
       }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -20,13 +20,15 @@ const baseMetadataURL = process.env.NEXT_PUBLIC_PROVIDER
 export function imageUrlUnknownRecord(name: string, network: number) {
   const supported = getSupportedNetworkName(network)
 
-  return `${baseMetadataURL}/${supported}/avatar/${name}?timestamp=${Date.now()}`
+  return `${baseMetadataURL}/${supported}/avatar/${encodeURIComponent(
+    name,
+  )}?timestamp=${Date.now()}`
 }
 
 export function ensNftImageUrl(name: string, network: number, regAddr: string) {
   const supported = getSupportedNetworkName(network)
 
-  return `${baseMetadataURL}/${supported}/${regAddr}/${name}/image`
+  return `${baseMetadataURL}/${supported}/${regAddr}/${encodeURIComponent(name)}/image`
 }
 
 export const shortenAddress = (address = '', maxLength = 10, leftSlice = 5, rightSlice = 5) => {


### PR DESCRIPTION
the `#` character is supported by name normalisation when used for the #️⃣ emoji. previously, this was an issue because although nextjs router automatically URI encodes all path data, `#` is seen to signify a browser location, so is not encoded, and breaks decoding the name in the app.

changes:
- `getDestination()` now manually rewrites `#` to `%23`, which covers all cases where a name is used in nextjs router.

this is not a permanent fix. i'll rewrite the routing system to accommodate this in the viem branch.

Fixes FET-1375
