### PR TITLE
remove suggested query appending .eth in "send name" and "edit roles"…

### DIFF
--- a/src/transaction-flow/input/EditRoles/hooks/useSimpleSearch.ts
+++ b/src/transaction-flow/input/EditRoles/hooks/useSimpleSearch.ts
@@ -62,7 +62,6 @@ export const useSimpleSearch = (options: Options = {}) => {
       }
       const results = await Promise.allSettled([
         queryByName(query),
-        queryByName(`${query}.eth`),
         ...(isAddress(query) ? [queryByAddress(query)] : []),
       ])
       const filteredData = results


### PR DESCRIPTION
* Removes the getByName search that adds a ".eth" the the end of a query. 