### PR TITLE
add etherscan icon to profile and address pages

### DIFF
--- a/src/components/Outlink.tsx
+++ b/src/components/Outlink.tsx
@@ -5,6 +5,7 @@ import { ComponentProps } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Typography } from '@ensdomains/thorin'
+import { FontVariant } from '@ensdomains/thorin/dist/types/types'
 
 import OutlinkSVG from '@app/assets/Outlink.svg'
 
@@ -39,14 +40,16 @@ export const OutlinkTypography = styled(Typography)(
 export const Outlink = ({
   href,
   children,
+  fontVariant = 'smallBold',
   ...props
 }: Omit<ComponentProps<'a'>, 'href' | 'target' | 'rel'> &
   ComponentProps<typeof StyledAnchor> & {
     href: string | UrlObject
+    fontVariant?: FontVariant
   }) => {
   const InnerContent = (
     <StyledAnchor {...props} rel="noreferrer noopener" target="_blank" role="link">
-      <OutlinkTypography fontVariant="smallBold" color="blue">
+      <OutlinkTypography fontVariant={fontVariant} color="blue">
         {children}
       </OutlinkTypography>
       <OutlinkIcon as={OutlinkSVG} />

--- a/src/components/pages/profile/[name]/Profile.tsx
+++ b/src/components/pages/profile/[name]/Profile.tsx
@@ -7,14 +7,16 @@ import { useAccount } from 'wagmi'
 import { Banner, CheckCircleSVG, Typography } from '@ensdomains/thorin'
 
 import BaseLink from '@app/components/@atoms/BaseLink'
+import { Outlink } from '@app/components/Outlink'
 import { useAbilities } from '@app/hooks/abilities/useAbilities'
+import { useChainName } from '@app/hooks/chain/useChainName'
 import { useNameDetails } from '@app/hooks/useNameDetails'
 import { useProtectedRoute } from '@app/hooks/useProtectedRoute'
 import { useQueryParameterState } from '@app/hooks/useQueryParameterState'
 import { useRouterWithHistory } from '@app/hooks/useRouterWithHistory'
 import { Content, ContentWarning } from '@app/layouts/Content'
 import { OG_IMAGE_URL } from '@app/utils/constants'
-import { formatFullExpiry, getEncodedLabelAmount } from '@app/utils/utils'
+import { formatFullExpiry, getEncodedLabelAmount, makeEtherscanLink } from '@app/utils/utils'
 
 import MoreTab from './tabs/MoreTab/MoreTab'
 import { OwnershipTab } from './tabs/OwnershipTab/OwnershipTab'
@@ -228,6 +230,8 @@ const ProfileContent = ({ isSelf, isLoading: _isLoading, name }: Props) => {
 
   const ogImageUrl = `${OG_IMAGE_URL}/name/${normalisedName || name}`
 
+  const chainName = useChainName()
+
   return (
     <>
       <Head>
@@ -260,6 +264,14 @@ const ProfileContent = ({ isSelf, isLoading: _isLoading, name }: Props) => {
               ))}
             </TabButtonContainer>
           ),
+          titleExtra: profile?.address ? (
+            <Outlink
+              fontVariant="bodyBold"
+              href={makeEtherscanLink(profile.address!, chainName, 'address')}
+            >
+              {t('etherscan', { ns: 'common' })}
+            </Outlink>
+          ) : null,
           trailing: {
             profile: <ProfileTab name={normalisedName} nameDetails={nameDetails} />,
             records: (

--- a/src/layouts/Content.tsx
+++ b/src/layouts/Content.tsx
@@ -252,6 +252,7 @@ export const Content = ({
     header?: React.ReactNode
     leading?: React.ReactNode
     trailing: React.ReactNode
+    titleExtra?: React.ReactNode
   }
 }) => {
   const router = useRouterWithHistory()
@@ -306,6 +307,7 @@ export const Content = ({
                 subtitle={subtitle && (!isDesktopMode || alwaysShowSubtitle) ? subtitle : undefined}
                 titleButton={titleButton}
               />
+              {isDesktopMode && children.titleExtra}
               {inlineHeading && children.header && isDesktopMode && (
                 <ContentContainer>
                   <Skeleton loading={loading}>{children.header}</Skeleton>
@@ -313,13 +315,13 @@ export const Content = ({
               )}
               {!isDesktopMode && <Hamburger />}
             </CustomLeadingHeading>
+            {!isDesktopMode && children.titleExtra}
           </Skeleton>
         </HeadingItems>
       )}
 
       {!isDesktopMode && WarningComponent}
       {!isDesktopMode && InfoComponent}
-
       {LeadingComponent}
 
       {!inlineHeading && children.header && (

--- a/src/pages/address.tsx
+++ b/src/pages/address.tsx
@@ -7,12 +7,14 @@ import { Address } from 'viem'
 
 import { NameListView } from '@app/components/@molecules/NameListView/NameListView'
 import NoProfileSnippet from '@app/components/address/NoProfileSnippet'
+import { Outlink } from '@app/components/Outlink'
 import { ProfileSnippet } from '@app/components/ProfileSnippet'
+import { useChainName } from '@app/hooks/chain/useChainName'
 import { usePrimaryProfile } from '@app/hooks/usePrimaryProfile'
 import { Content } from '@app/layouts/Content'
 import { ContentGrid } from '@app/layouts/ContentGrid'
 import { OG_IMAGE_URL } from '@app/utils/constants'
-import { shortenAddress } from '@app/utils/utils'
+import { makeEtherscanLink, shortenAddress } from '@app/utils/utils'
 
 import { useAccountSafely } from '../hooks/account/useAccountSafely'
 
@@ -50,6 +52,8 @@ const Page = () => {
   const descriptionContent = t('meta.description', { address })
   const ogImageUrl = `${OG_IMAGE_URL}/address/${address}`
 
+  const chainName = useChainName()
+
   return (
     <>
       <Head>
@@ -82,6 +86,11 @@ const Page = () => {
                 <NoProfileSnippet />
               )}
             </DetailsContainer>
+          ),
+          titleExtra: (
+            <Outlink fontVariant="bodyBold" href={makeEtherscanLink(address, chainName, 'address')}>
+              {t('etherscan', { ns: 'common' })}
+            </Outlink>
           ),
           trailing: <NameListView address={address} isSelf={isSelf} setError={setIsError} />,
         }}


### PR DESCRIPTION
Profile page:

![image](https://github.com/ensdomains/ens-app-v3/assets/35937217/17c4395d-9eac-472c-b60d-a95f274b290e)
![image](https://github.com/ensdomains/ens-app-v3/assets/35937217/b9cce7a5-3df0-42a5-aa26-241975fa0d6b)

it also hides an icon if no address was set

Address page:

![image](https://github.com/ensdomains/ens-app-v3/assets/35937217/390a666f-6299-4e20-8150-91d7141178dd)
![image](https://github.com/ensdomains/ens-app-v3/assets/35937217/a12b0b7e-325c-4264-8385-33984c002d9e)
