### PR TITLE
fix: serialisation + prefetch hook

### DIFF
--- a/src/components/@atoms/CacheableComponent.tsx
+++ b/src/components/@atoms/CacheableComponent.tsx
@@ -22,7 +22,7 @@ export const cacheableComponentStyles = ({ $isCached }: { $isCached?: boolean })
   css`
     opacity: 0.5;
     pointer-events: none;
-    animation: ${anim} 0.25s ease-in-out 0.5s backwards;
+    animation: ${anim} 0.25s ease-in-out 1s backwards;
   `}
 `
 

--- a/src/components/@atoms/CacheableComponent.tsx
+++ b/src/components/@atoms/CacheableComponent.tsx
@@ -5,13 +5,8 @@ const anim = keyframes`
     opacity: 1;
   }
 
-  0%, 99% {
-    pointer-events: auto;
-  }
-
   100% {
     opacity: 0.5;
-    pointer-events: none;
   }
 `
 

--- a/src/components/@atoms/ExpiryComponents/ExpiryComponents.tsx
+++ b/src/components/@atoms/ExpiryComponents/ExpiryComponents.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
-import { Typography } from '@ensdomains/thorin'
+import { Skeleton, Typography } from '@ensdomains/thorin'
 
 import ClockSVG from '@app/assets/Clock.svg'
 import { secondsToDays, secondsToHours } from '@app/utils/utils'
@@ -70,7 +70,7 @@ export const ShortExpiry = ({
 }) => {
   const { t } = useTranslation()
   const blockTimestamp = useBlockTimestamp()
-  const currentDate = new Date(Number(blockTimestamp.data))
+  const currentDate = blockTimestamp.data ? new Date(Number(blockTimestamp.data)) : new Date()
   let secondsDiff = (expiry.getTime() - currentDate.getTime()) / 1000
   const inverse = secondsDiff < 0
   if (inverse) {
@@ -111,17 +111,22 @@ export const ShortExpiry = ({
     color = 'red'
   }
 
-  if (textOnly) return <>{text}</>
   return (
-    <ExpiryText
-      data-testid="short-expiry"
-      data-color={color}
-      data-timestamp={expiry.getTime()}
-      $color={color}
-      fontVariant="small"
-    >
-      {text}
-    </ExpiryText>
+    <Skeleton loading={blockTimestamp.isLoading}>
+      {textOnly ? (
+        text
+      ) : (
+        <ExpiryText
+          data-testid="short-expiry"
+          data-color={color}
+          data-timestamp={expiry.getTime()}
+          $color={color}
+          fontVariant="small"
+        >
+          {text}
+        </ExpiryText>
+      )}
+    </Skeleton>
   )
 }
 

--- a/src/components/@molecules/NameListView/NameListView.tsx
+++ b/src/components/@molecules/NameListView/NameListView.tsx
@@ -16,6 +16,7 @@ import {
   SortType,
 } from '@app/components/@molecules/NameTableHeader/NameTableHeader'
 import { TabWrapper } from '@app/components/pages/profile/TabWrapper'
+import { usePrefetchBlockTimestamp } from '@app/hooks/chain/useBlockTimestamp'
 import { useNamesForAddress } from '@app/hooks/ensjs/subgraph/useNamesForAddress'
 import useDebouncedCallback from '@app/hooks/useDebouncedCallback'
 import { useQueryParameterState } from '@app/hooks/useQueryParameterState'
@@ -107,6 +108,12 @@ export const NameListView = ({ address, isSelf, setError, setLoading }: NameList
       searchString: searchQuery,
     },
   })
+
+  // useBlockTimestamp() is used in:
+  // <TaggedNameItem />
+  // => <NameDetailItem />
+  //   => <ShortExpiry />
+  usePrefetchBlockTimestamp()
 
   useEffect(() => {
     setError?.(isError)

--- a/src/hooks/chain/useBlockTimestamp.ts
+++ b/src/hooks/chain/useBlockTimestamp.ts
@@ -1,4 +1,7 @@
-import { useBlock } from 'wagmi'
+import { useBlock, useChainId, useConfig } from 'wagmi'
+import { getBlockQueryOptions } from 'wagmi/query'
+
+import { usePrefetchQuery } from '../usePrefetchQuery'
 
 type UseBlockTimestampParameters = {
   enabled?: boolean
@@ -15,4 +18,10 @@ export const useBlockTimestamp = ({ enabled = true }: UseBlockTimestampParameter
       select: (b) => b.timestamp * 1000n,
     },
   })
+}
+
+export const usePrefetchBlockTimestamp = () => {
+  const config = useConfig()
+  const chainId = useChainId()
+  return usePrefetchQuery(getBlockQueryOptions(config, { chainId, blockTag: 'latest' }))
 }

--- a/src/hooks/chain/useEstimateGasWithStateOverride.ts
+++ b/src/hooks/chain/useEstimateGasWithStateOverride.ts
@@ -1,4 +1,4 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import {
   Address,
@@ -32,6 +32,7 @@ import {
   QueryConfig,
 } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 import { useGasPrice } from './useGasPrice'
 
@@ -256,11 +257,10 @@ export const useEstimateGasWithStateOverride = <
   const TransactionItems extends TransactionItem[] | readonly TransactionItem[],
 >({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
-
   // params
   ...params
 }: UseEstimateGasWithStateOverrideParameters<TransactionItems> &
@@ -276,17 +276,15 @@ export const useEstimateGasWithStateOverride = <
     queryFn: estimateGasWithStateOverrideQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn(connectorClient),
     enabled: enabled && !isConnectorLoading,
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   const {
     data: gasPrice,

--- a/src/hooks/chain/useEstimateGasWithStateOverride.ts
+++ b/src/hooks/chain/useEstimateGasWithStateOverride.ts
@@ -286,10 +286,6 @@ export const useEstimateGasWithStateOverride = <
     ...preparedOptions,
     gcTime,
     staleTime,
-    select: (r) => ({
-      reduced: BigInt(r.reduced),
-      gasEstimates: r.gasEstimates.map((g) => BigInt(g)),
-    }),
   })
 
   const {

--- a/src/hooks/chain/useGasPrice.ts
+++ b/src/hooks/chain/useGasPrice.ts
@@ -7,7 +7,7 @@ import { useInvalidateOnBlock } from './useInvalidateOnBlock'
 const gasPriceBlockInterval = 2n // get gas price every two blocks
 
 export const useGasPrice = () => {
-  const query = useWagmiGasPrice({ query: { select: (d) => BigInt(d) } })
+  const query = useWagmiGasPrice()
 
   const chainId = useChainId()
   const queryKey = useMemo(() => getGasPriceQueryKey({ chainId }), [chainId])

--- a/src/hooks/dns/useDnsSecEnabled.ts
+++ b/src/hooks/dns/useDnsSecEnabled.ts
@@ -1,7 +1,8 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 
 import { CreateQueryKey, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 import { useQueryOptions } from '../useQueryOptions'
 
@@ -68,11 +69,10 @@ export const getDnsSecEnabledQueryFn = async <TParams extends UseDnsSecEnabledPa
 
 export const useDnsSecEnabled = <TParams extends UseDnsSecEnabledParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
-
   // params
   ...params
 }: TParams & UseDnsSecEnabledConfig) => {
@@ -84,18 +84,16 @@ export const useDnsSecEnabled = <TParams extends UseDnsSecEnabledParameters>({
     queryFn: getDnsSecEnabledQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled: enabled && !!params.name && params.name !== 'eth' && params.name !== '[root]',
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     retry: 2,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/dns/useDnsImportData.ts
+++ b/src/hooks/ensjs/dns/useDnsImportData.ts
@@ -1,4 +1,4 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 
 import {
   getDnsImportData,
@@ -9,6 +9,7 @@ import {
 import { useQueryOptions } from '@app/hooks/useQueryOptions'
 import { ConfigWithEns, CreateQueryKey, PartialBy, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 type UseDnsImportDataParameters = PartialBy<GetDnsImportDataParameters, 'name'>
 
@@ -36,9 +37,9 @@ export const getDnsImportDataQueryFn =
 
 export const useDnsImportData = <TParams extends UseDnsImportDataParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
   // params
   ...params
@@ -51,7 +52,7 @@ export const useDnsImportData = <TParams extends UseDnsImportDataParameters>({
     queryFn: getDnsImportDataQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled:
@@ -60,14 +61,12 @@ export const useDnsImportData = <TParams extends UseDnsImportDataParameters>({
       !params.name?.endsWith('.eth') &&
       params.name !== 'eth' &&
       params.name !== '[root]',
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     retry: 2,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/dns/useDnsOffchainData.ts
+++ b/src/hooks/ensjs/dns/useDnsOffchainData.ts
@@ -1,4 +1,4 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 
 import {
   DnsDnssecVerificationFailedError,
@@ -16,6 +16,7 @@ import {
 import { useQueryOptions } from '@app/hooks/useQueryOptions'
 import { ConfigWithEns, CreateQueryKey, PartialBy, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 type UseDnsOffchainDataParameters = PartialBy<GetDnsOffchainDataParameters, 'name'>
 
@@ -51,9 +52,9 @@ export const getDnsOffchainDataQueryFn =
 
 export const useDnsOffchainData = <TParams extends UseDnsOffchainDataParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
   // params
   ...params
@@ -66,7 +67,7 @@ export const useDnsOffchainData = <TParams extends UseDnsOffchainDataParameters>
     queryFn: getDnsOffchainDataQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled:
@@ -75,14 +76,12 @@ export const useDnsOffchainData = <TParams extends UseDnsOffchainDataParameters>
       !params.name?.endsWith('.eth') &&
       params.name !== 'eth' &&
       params.name !== '[root]',
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     retry: 2,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/dns/useDnsOwner.ts
+++ b/src/hooks/ensjs/dns/useDnsOwner.ts
@@ -1,4 +1,4 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 
 import {
   DnsDnssecVerificationFailedError,
@@ -13,6 +13,7 @@ import { getDnsOwner, GetDnsOwnerParameters, GetDnsOwnerReturnType } from '@ensd
 import { useQueryOptions } from '@app/hooks/useQueryOptions'
 import { CreateQueryKey, PartialBy, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 type UseDnsOwnerParameters = PartialBy<GetDnsOwnerParameters, 'name'>
 
@@ -45,9 +46,9 @@ export const getDnsOwnerQueryFn = async <TParams extends UseDnsOwnerParameters>(
 
 export const useDnsOwner = <TParams extends UseDnsOwnerParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
   // params
   ...params
@@ -60,7 +61,7 @@ export const useDnsOwner = <TParams extends UseDnsOwnerParameters>({
     queryFn: getDnsOwnerQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled:
@@ -69,14 +70,12 @@ export const useDnsOwner = <TParams extends UseDnsOwnerParameters>({
       !params.name?.endsWith('.eth') &&
       params.name !== 'eth' &&
       params.name !== '[root]',
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     retry: 2,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/public/useAddressRecord.ts
+++ b/src/hooks/ensjs/public/useAddressRecord.ts
@@ -1,4 +1,4 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 
 import {
   getAddressRecord,
@@ -9,6 +9,7 @@ import {
 import { useQueryOptions } from '@app/hooks/useQueryOptions'
 import { ConfigWithEns, CreateQueryKey, PartialBy, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 type UseAddressRecordParameters = PartialBy<GetAddressRecordParameters, 'name'>
 
@@ -36,9 +37,9 @@ export const getAddressRecordQueryFn =
 
 export const useAddressRecord = <TParams extends UseAddressRecordParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
   // params
   ...params
@@ -51,17 +52,15 @@ export const useAddressRecord = <TParams extends UseAddressRecordParameters>({
     queryFn: getAddressRecordQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled: enabled && !!params.name,
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/public/useExpiry.ts
+++ b/src/hooks/ensjs/public/useExpiry.ts
@@ -59,8 +59,6 @@ export const useExpiry = <TParams extends UseExpiryParameters>({
     staleTime,
   })
 
-  console.log(query.data)
-
   return {
     ...query,
     refetchIfEnabled: preparedOptions.enabled ? query.refetch : () => {},

--- a/src/hooks/ensjs/public/useExpiry.ts
+++ b/src/hooks/ensjs/public/useExpiry.ts
@@ -1,10 +1,11 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 
 import { getExpiry, GetExpiryParameters, GetExpiryReturnType } from '@ensdomains/ensjs/public'
 
 import { useQueryOptions } from '@app/hooks/useQueryOptions'
 import { ConfigWithEns, CreateQueryKey, PartialBy, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 type UseExpiryParameters = PartialBy<GetExpiryParameters, 'name'>
 
@@ -32,9 +33,9 @@ export const getExpiryQueryFn =
 
 export const useExpiry = <TParams extends UseExpiryParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
   // params
   ...params
@@ -47,17 +48,15 @@ export const useExpiry = <TParams extends UseExpiryParameters>({
     queryFn: getExpiryQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled: enabled && !!params.name,
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/public/useExpiry.ts
+++ b/src/hooks/ensjs/public/useExpiry.ts
@@ -57,17 +57,9 @@ export const useExpiry = <TParams extends UseExpiryParameters>({
     ...preparedOptions,
     gcTime,
     staleTime,
-    select: (data) => {
-      if (!data) return null
-      return {
-        ...data,
-        expiry: {
-          ...data.expiry,
-          date: new Date(data.expiry.date),
-        },
-      }
-    },
   })
+
+  console.log(query.data)
 
   return {
     ...query,

--- a/src/hooks/ensjs/public/useOwner.ts
+++ b/src/hooks/ensjs/public/useOwner.ts
@@ -1,10 +1,11 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 
 import { getOwner, GetOwnerParameters, GetOwnerReturnType } from '@ensdomains/ensjs/public'
 
 import { useQueryOptions } from '@app/hooks/useQueryOptions'
 import { ConfigWithEns, CreateQueryKey, PartialBy, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 type OwnerContract = 'nameWrapper' | 'registry' | 'registrar'
 
@@ -36,9 +37,9 @@ export const useOwner = <
   TContract extends OwnerContract | undefined = undefined,
   const TParams extends UseOwnerParameters<TContract> = UseOwnerParameters<TContract>,
 >({
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
   ...params
 }: TParams & UseOwnerConfig<TContract>) => {
@@ -50,17 +51,15 @@ export const useOwner = <
     queryFn: getOwnerQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled: enabled && !!params.name,
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/public/usePrice.ts
+++ b/src/hooks/ensjs/public/usePrice.ts
@@ -53,13 +53,6 @@ export const usePrice = <TParams extends UsePriceParameters>({
     ...preparedOptions,
     gcTime,
     staleTime,
-    select: (data) => {
-      if (!data) return data
-      return {
-        base: BigInt(data.base),
-        premium: BigInt(data.premium),
-      }
-    },
   })
 
   return {

--- a/src/hooks/ensjs/public/usePrice.ts
+++ b/src/hooks/ensjs/public/usePrice.ts
@@ -1,10 +1,11 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 
 import { getPrice, GetPriceParameters, GetPriceReturnType } from '@ensdomains/ensjs/public'
 
 import { useQueryOptions } from '@app/hooks/useQueryOptions'
 import { ConfigWithEns, CreateQueryKey, PartialBy, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 type UsePriceParameters = PartialBy<GetPriceParameters, 'nameOrNames'>
 
@@ -28,9 +29,9 @@ export const getPriceQueryFn =
 
 export const usePrice = <TParams extends UsePriceParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
   // params
   ...params
@@ -43,17 +44,15 @@ export const usePrice = <TParams extends UsePriceParameters>({
     queryFn: getPriceQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled: enabled && !!params.nameOrNames,
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/public/usePrimaryName.ts
+++ b/src/hooks/ensjs/public/usePrimaryName.ts
@@ -1,4 +1,4 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 
 import { getName, GetNameParameters, GetNameReturnType } from '@ensdomains/ensjs/public'
 
@@ -7,6 +7,7 @@ import { ConfigWithEns, CreateQueryKey, PartialBy, QueryConfig } from '@app/type
 import { tryBeautify } from '@app/utils/beautify'
 import { emptyAddress } from '@app/utils/constants'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 type UsePrimaryNameParameters = PartialBy<GetNameParameters, 'address'> & {
   allowMismatch?: boolean
@@ -43,11 +44,10 @@ export const getPrimaryNameQueryFn =
 
 export const usePrimaryName = <TParams extends UsePrimaryNameParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
-
   // params
   allowMismatch = false,
   ...params
@@ -60,17 +60,15 @@ export const usePrimaryName = <TParams extends UsePrimaryNameParameters>({
     queryFn: getPrimaryNameQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled: enabled && !!params.address && params.address !== emptyAddress,
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/public/useRecords.ts
+++ b/src/hooks/ensjs/public/useRecords.ts
@@ -1,10 +1,11 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 
 import { getRecords, GetRecordsParameters, GetRecordsReturnType } from '@ensdomains/ensjs/public'
 
 import { useQueryOptions } from '@app/hooks/useQueryOptions'
 import { ConfigWithEns, CreateQueryKey, PartialBy, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 type UseRecordsParameters<
   TTexts extends readonly string[] | undefined = undefined,
@@ -59,9 +60,9 @@ export const useRecords = <
   const TAbi extends boolean = false,
 >({
   // config
-  gcTime,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
   // params
   ...params
@@ -75,17 +76,15 @@ export const useRecords = <
     queryFn: getRecordsQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled: enabled && !!params.name,
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/public/useResolver.ts
+++ b/src/hooks/ensjs/public/useResolver.ts
@@ -1,10 +1,11 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 
 import { getResolver, GetResolverParameters, GetResolverReturnType } from '@ensdomains/ensjs/public'
 
 import { useQueryOptions } from '@app/hooks/useQueryOptions'
 import { ConfigWithEns, CreateQueryKey, PartialBy, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 type UseResolverParameters = PartialBy<GetResolverParameters, 'name'>
 
@@ -32,11 +33,10 @@ export const getResolverQueryFn =
 
 export const useResolver = <TParams extends UseResolverParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
-
   // params
   ...params
 }: TParams & UseResolverConfig) => {
@@ -48,17 +48,15 @@ export const useResolver = <TParams extends UseResolverParameters>({
     queryFn: getResolverQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled: enabled && !!params.name,
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/public/useSupportedInterfaces.ts
+++ b/src/hooks/ensjs/public/useSupportedInterfaces.ts
@@ -1,4 +1,4 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 import { Hex } from 'viem'
 
 import {
@@ -10,6 +10,7 @@ import {
 import { useQueryOptions } from '@app/hooks/useQueryOptions'
 import { ConfigWithEns, CreateQueryKey, PartialBy, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 type UseSupportedInterfacesParameters<TInterfaces extends readonly Hex[] = readonly Hex[]> =
   PartialBy<GetSupportedInterfacesParameters<TInterfaces>, 'address'>
@@ -46,9 +47,9 @@ export const useSupportedInterfaces = <
     UseSupportedInterfacesParameters<TInterfaces> = UseSupportedInterfacesParameters<TInterfaces>,
 >({
   // config
-  gcTime,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
   // params
   ...params
@@ -61,17 +62,15 @@ export const useSupportedInterfaces = <
     queryFn: getSupportedInterfacesQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled: enabled && !!params.address && params.interfaces.length > 0,
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/public/useWrapperData.ts
+++ b/src/hooks/ensjs/public/useWrapperData.ts
@@ -61,18 +61,6 @@ export const useWrapperData = <TParams extends UseWrapperDataParameters>({
     ...preparedOptions,
     gcTime,
     staleTime,
-    select: (data) => {
-      if (!data) return null
-      return {
-        ...data,
-        expiry: data.expiry
-          ? {
-              ...data.expiry,
-              date: new Date(data.expiry.date),
-            }
-          : null,
-      }
-    },
   })
 
   return {

--- a/src/hooks/ensjs/public/useWrapperData.ts
+++ b/src/hooks/ensjs/public/useWrapperData.ts
@@ -1,4 +1,4 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 
 import {
   getWrapperData,
@@ -9,6 +9,7 @@ import {
 import { useQueryOptions } from '@app/hooks/useQueryOptions'
 import { ConfigWithEns, CreateQueryKey, PartialBy, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 type UseWrapperDataParameters = PartialBy<GetWrapperDataParameters, 'name'>
 
@@ -36,9 +37,9 @@ export const getWrapperDataQueryFn =
 
 export const useWrapperData = <TParams extends UseWrapperDataParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
   // params
   ...params
@@ -51,17 +52,15 @@ export const useWrapperData = <TParams extends UseWrapperDataParameters>({
     queryFn: getWrapperDataQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled: enabled && !!params.name,
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/subgraph/useDecodedName.ts
+++ b/src/hooks/ensjs/subgraph/useDecodedName.ts
@@ -1,4 +1,4 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 
 import {
@@ -11,6 +11,7 @@ import { checkIsDecrypted } from '@ensdomains/ensjs/utils'
 import { useQueryOptions } from '@app/hooks/useQueryOptions'
 import { ConfigWithEns, CreateQueryKey, PartialBy, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 type UseDecodedNameParameters = PartialBy<GetDecodedNameParameters, 'name'>
 
@@ -38,9 +39,9 @@ export const getDecodedNameQueryFn =
 
 export const useDecodedName = <TParams extends UseDecodedNameParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
   // params
   ...params
@@ -58,17 +59,15 @@ export const useDecodedName = <TParams extends UseDecodedNameParameters>({
     [params.name],
   )
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled: enabled && !!params.name && nameIsEncrypted,
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/subgraph/useNameHistory.ts
+++ b/src/hooks/ensjs/subgraph/useNameHistory.ts
@@ -1,4 +1,4 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 
 import {
   getNameHistory,
@@ -9,6 +9,7 @@ import {
 import { useQueryOptions } from '@app/hooks/useQueryOptions'
 import { ConfigWithEns, CreateQueryKey, PartialBy, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 type UseNameHistoryParameters = PartialBy<GetNameHistoryParameters, 'name'>
 
@@ -36,11 +37,10 @@ export const getNameHistoryQueryFn =
 
 export const useNameHistory = <TParams extends UseNameHistoryParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
-
   // params
   ...params
 }: TParams & UseNameHistoryConfig) => {
@@ -52,17 +52,15 @@ export const useNameHistory = <TParams extends UseNameHistoryParameters>({
     queryFn: getNameHistoryQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled: enabled && !!params.name,
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/subgraph/useNamesForAddress.ts
+++ b/src/hooks/ensjs/subgraph/useNamesForAddress.ts
@@ -49,9 +49,9 @@ const initialPageParam = [] as GetNamesForAddressReturnType
 
 export const useNamesForAddress = <TParams extends UseNamesForAddressParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
   // params
   ...params
@@ -69,15 +69,13 @@ export const useNamesForAddress = <TParams extends UseNamesForAddressParameters>
     queryFn: initialOptions.queryFn,
     getNextPageParam: getNextPageParam(params),
     initialPageParam,
+    enabled: enabled && !!params.address,
+    gcTime,
+    staleTime,
   })
 
   const { data, status, isFetched, isFetching, isLoading, isFetchedAfterMount, ...rest } =
-    useInfiniteQuery({
-      ...preparedOptions,
-      enabled: enabled && !!params.address,
-      gcTime,
-      staleTime,
-    })
+    useInfiniteQuery(preparedOptions)
 
   const [unfilteredPages, setUnfilteredPages] = useState<GetNamesForAddressReturnType>([])
 

--- a/src/hooks/ensjs/subgraph/useSubgraphRecords.ts
+++ b/src/hooks/ensjs/subgraph/useSubgraphRecords.ts
@@ -1,4 +1,4 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 
 import {
   getSubgraphRecords,
@@ -9,6 +9,7 @@ import {
 import { useQueryOptions } from '@app/hooks/useQueryOptions'
 import { ConfigWithEns, CreateQueryKey, PartialBy, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 type UseSubgraphRecordsParameters = PartialBy<GetSubgraphRecordsParameters, 'name'>
 
@@ -36,11 +37,10 @@ export const getSubgraphRecordsQueryFn =
 
 export const useSubgraphRecords = <TParams extends UseSubgraphRecordsParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
-
   // params
   ...params
 }: TParams & UseSubgraphRecordsConfig) => {
@@ -52,17 +52,15 @@ export const useSubgraphRecords = <TParams extends UseSubgraphRecordsParameters>
     queryFn: getSubgraphRecordsQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled: enabled && !!params.name,
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/ensjs/subgraph/useSubnames.ts
+++ b/src/hooks/ensjs/subgraph/useSubnames.ts
@@ -46,9 +46,9 @@ const initialPageParam = [] as GetSubnamesReturnType
 
 export const useSubnames = <TParams extends UseSubnamesParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
   // params
   ...params
@@ -66,14 +66,13 @@ export const useSubnames = <TParams extends UseSubnamesParameters>({
     queryFn: initialOptions.queryFn,
     getNextPageParam: getNextPageParam(params),
     initialPageParam,
-  })
-
-  const { data, status, isFetched, isFetchedAfterMount, ...rest } = useInfiniteQuery({
-    ...preparedOptions,
     enabled: enabled && !!params.name,
     gcTime,
     staleTime,
   })
+
+  const { data, status, isFetched, isFetchedAfterMount, ...rest } =
+    useInfiniteQuery(preparedOptions)
 
   const pageCount = data?.pages.length || 0
   const nameCount = data?.pages.reduce((acc, page) => acc + page.length, 0) || 0

--- a/src/hooks/useEthPrice.ts
+++ b/src/hooks/useEthPrice.ts
@@ -29,8 +29,5 @@ export const useEthPrice = () => {
     ],
     address,
     functionName: 'latestAnswer',
-    query: {
-      select: (r) => BigInt(r),
-    },
   })
 }

--- a/src/hooks/usePrefetchQuery.ts
+++ b/src/hooks/usePrefetchQuery.ts
@@ -1,0 +1,18 @@
+import { FetchQueryOptions, QueryKey, useQueryClient } from '@tanstack/react-query'
+
+export const usePrefetchQuery = <
+  TQueryFnData,
+  TError = Error,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+) => {
+  const queryClient = useQueryClient()
+
+  // This happens in render, but is safe to do because ensureQueryData
+  // only fetches if there is no data in the cache for this query. This
+  // means we know no observers are watching the data so the side effect
+  // is not observable, which is safe.
+  queryClient.ensureQueryData(options)
+}

--- a/src/hooks/useProfile.test.ts
+++ b/src/hooks/useProfile.test.ts
@@ -1,6 +1,6 @@
 import { mockFunction, renderHook, waitFor } from '@app/test-utils'
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, expect, it, vi } from 'vitest'
 
 import { GetRecordsReturnType } from '@ensdomains/ensjs/public'
 import { GetSubgraphRecordsReturnType } from '@ensdomains/ensjs/subgraph'
@@ -140,6 +140,7 @@ it('should return the correct data', () => {
       "isCachedData": false,
       "isFetching": false,
       "isLoading": false,
+      "refetchIfEnabled": [Function],
     }
   `)
 })

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -26,8 +26,6 @@ export const useProfile = ({
 }: UseProfileParameters) => {
   const {
     data: subgraphRecords,
-    isLoading: isSubgraphRecordsLoading,
-    isCachedData: isSubgraphRecordsCachedData,
     isFetching: isSubgraphRecordsFetching,
     refetchIfEnabled: refetchSubgraphRecords,
   } = useSubgraphRecords({ name, resolverAddress, enabled: enabled && subgraphEnabled })
@@ -95,8 +93,9 @@ export const useProfile = ({
 
   return {
     data: returnProfile,
-    isLoading: isSubgraphRecordsLoading || isProfileLoading,
-    isCachedData: isSubgraphRecordsCachedData || isProfileCachedData,
+    // we only need to depend on profile for loading/cached state because subgraph records are not required to load the profile
+    isLoading: isProfileLoading,
+    isCachedData: isProfileCachedData,
     isFetching: isSubgraphRecordsFetching || isProfileFetching,
     refetchIfEnabled: () => {
       refetchSubgraphRecords()

--- a/src/hooks/useRegistrationData.ts
+++ b/src/hooks/useRegistrationData.ts
@@ -1,10 +1,11 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 import { labelhash } from 'viem'
 
 import { createSubgraphClient } from '@ensdomains/ensjs/subgraph'
 
 import { ConfigWithEns, CreateQueryKey, QueryConfig } from '@app/types'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 import { checkETH2LDFromName } from '@app/utils/utils'
 
 import { useQueryOptions } from './useQueryOptions'
@@ -68,11 +69,10 @@ export const getRegistrationDataQueryFn =
 
 const useRegistrationData = <TParams extends UseRegistrationDataParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
-
   // params
   ...params
 }: TParams & UseRegistrationDataConfig) => {
@@ -83,17 +83,15 @@ const useRegistrationData = <TParams extends UseRegistrationDataParameters>({
     queryFn: getRegistrationDataQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
     enabled: enabled && !!params.name && checkETH2LDFromName(params.name),
-  })
-
-  const query = useQuery({
-    ...preparedOptions,
     gcTime,
     staleTime,
   })
+
+  const query = useQuery(preparedOptions)
 
   return {
     ...query,

--- a/src/hooks/useRegistrationData.ts
+++ b/src/hooks/useRegistrationData.ts
@@ -93,13 +93,6 @@ const useRegistrationData = <TParams extends UseRegistrationDataParameters>({
     ...preparedOptions,
     gcTime,
     staleTime,
-    select: (data) => {
-      if (!data) return data
-      return {
-        registrationDate: new Date(data.registrationDate),
-        transactionHash: data.transactionHash,
-      }
-    },
   })
 
   return {

--- a/src/hooks/useResolverExists.ts
+++ b/src/hooks/useResolverExists.ts
@@ -1,9 +1,10 @@
-import { QueryFunctionContext, queryOptions, useQuery } from '@tanstack/react-query'
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
 import { namehash, type Address } from 'viem'
 
 import { createSubgraphClient } from '@ensdomains/ensjs/subgraph'
 
 import { ConfigWithEns, CreateQueryKey, QueryConfig } from '@app/types'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
 import { useQueryOptions } from './useQueryOptions'
 
@@ -64,11 +65,10 @@ export const getResolverExistsQueryFn =
  */
 export const useResolverExists = <TParams extends UseResolverExistsParameters>({
   // config
-  gcTime = 1_000 * 60 * 60 * 24,
   enabled = true,
-  staleTime = 1_000 * 60 * 5,
+  gcTime,
+  staleTime,
   scopeKey,
-
   // params
   ...params
 }: TParams & UseResolverExistsConfig) => {
@@ -80,15 +80,13 @@ export const useResolverExists = <TParams extends UseResolverExistsParameters>({
     queryFn: getResolverExistsQueryFn,
   })
 
-  const preparedOptions = queryOptions({
+  const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
-  })
-
-  return useQuery({
-    ...preparedOptions,
     enabled: enabled && !!params.name && !!params.address,
     gcTime,
     staleTime,
   })
+
+  return useQuery(preparedOptions)
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -26,12 +26,6 @@ import i18n from '../i18n'
 
 import '../styles.css'
 
-// @ts-ignore: Unreachable code error
-// eslint-disable-next-line no-extend-native, func-names
-BigInt.prototype.toJSON = function () {
-  return this.toString()
-}
-
 const INTERCOM_ID = process.env.NEXT_PUBLIC_INTERCOM_ID || 'eotmigir'
 
 const rainbowKitTheme: Theme = {

--- a/src/utils/prepareQueryOptions.ts
+++ b/src/utils/prepareQueryOptions.ts
@@ -1,0 +1,36 @@
+import {
+  DataTag,
+  DefinedInitialDataOptions,
+  QueryKey,
+  UndefinedInitialDataOptions,
+} from '@tanstack/react-query'
+
+export function prepareQueryOptions<
+  TQueryFnData = unknown,
+  TError = Error,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+): UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  queryKey: DataTag<TQueryKey, TQueryFnData>
+}
+export function prepareQueryOptions<
+  TQueryFnData = unknown,
+  TError = Error,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+): DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey> & {
+  queryKey: DataTag<TQueryKey, TQueryFnData>
+}
+export function prepareQueryOptions(options: Record<string, any>) {
+  const newOptions = {} as Record<string, any>
+  for (const key in options) {
+    if (options[key] !== undefined) {
+      newOptions[key] = options[key]
+    }
+  }
+  return newOptions
+}

--- a/src/utils/query/persist.ts
+++ b/src/utils/query/persist.ts
@@ -1,14 +1,24 @@
 import { PersistQueryClientOptions } from '@tanstack/query-persist-client-core'
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister'
 import { QueryClient } from '@tanstack/react-query'
-import { deserialize, serialize } from 'wagmi'
+import { deserialize } from 'wagmi'
+
+import { serialize } from './serialize'
 
 const persister = () =>
   createSyncStoragePersister({
     key: 'wagmi.cache',
     storage: typeof window !== 'undefined' ? window.localStorage : undefined,
-    serialize,
-    deserialize,
+    serialize: (data) =>
+      serialize(data, function replacer(this: any, key) {
+        const directValueReference = this[key]
+        if (directValueReference instanceof Date)
+          return { __type: 'Date', value: directValueReference.toISOString() }
+      }),
+    deserialize: (data) =>
+      deserialize(data, (_key, value) => {
+        if (value?.__type === 'Date') return new Date(value.value)
+      }),
   })
 
 export const createPersistConfig = ({

--- a/src/utils/query/reactQuery.ts
+++ b/src/utils/query/reactQuery.ts
@@ -5,7 +5,7 @@ export const queryClient = new QueryClient({
     queries: {
       refetchOnWindowFocus: false,
       refetchOnMount: true,
-      staleTime: 1_000 * 60 * 5,
+      staleTime: 1_000 * 12,
       gcTime: 1_000 * 60 * 60 * 24,
     },
   },
@@ -15,7 +15,7 @@ export const refetchOptions: DefaultOptions<Error> = {
   queries: {
     refetchOnWindowFocus: true,
     refetchInterval: 1000 * 60,
-    staleTime: 1000 * 120,
+    staleTime: 0,
     meta: {
       isRefetchQuery: true,
     },

--- a/src/utils/query/serialize.ts
+++ b/src/utils/query/serialize.ts
@@ -1,0 +1,114 @@
+// from @wagmi/core
+
+/**
+ * Get the reference key for the circular value
+ *
+ * @param keys the keys to build the reference key from
+ * @param cutoff the maximum number of keys to include
+ * @returns the reference key
+ */
+function getReferenceKey(keys: string[], cutoff: number) {
+  return keys.slice(0, cutoff).join('.') || '.'
+}
+
+/**
+ * Faster `Array.prototype.indexOf` implementation build for slicing / splicing
+ *
+ * @param array the array to match the value in
+ * @param value the value to match
+ * @returns the matching index, or -1
+ */
+function getCutoff(array: any[], value: any) {
+  const { length } = array
+
+  // eslint-disable-next-line no-plusplus
+  for (let index = 0; index < length; ++index) {
+    if (array[index] === value) {
+      return index + 1
+    }
+  }
+
+  return 0
+}
+
+type StandardReplacer = (key: string, value: any) => any
+type CircularReplacer = (key: string, value: any, referenceKey: string) => any
+
+/**
+ * Create a replacer method that handles circular values
+ *
+ * @param [replacer] a custom replacer to use for non-circular values
+ * @param [circularReplacer] a custom replacer to use for circular methods
+ * @returns the value to stringify
+ */
+function createReplacer(
+  replacer?: StandardReplacer | null | undefined,
+  circularReplacer?: CircularReplacer | null | undefined,
+): StandardReplacer {
+  const hasReplacer = typeof replacer === 'function'
+  const hasCircularReplacer = typeof circularReplacer === 'function'
+
+  const cache: any[] = []
+  const keys: string[] = []
+
+  return function replace(this: any, key: string, value: any) {
+    if (typeof value === 'object') {
+      if (cache.length) {
+        const thisCutoff = getCutoff(cache, this)
+
+        if (thisCutoff === 0) {
+          cache[cache.length] = this
+        } else {
+          cache.splice(thisCutoff)
+          keys.splice(thisCutoff)
+        }
+
+        keys[keys.length] = key
+
+        const valueCutoff = getCutoff(cache, value)
+
+        if (valueCutoff !== 0) {
+          return hasCircularReplacer
+            ? circularReplacer.call(this, key, value, getReferenceKey(keys, valueCutoff))
+            : `[ref=${getReferenceKey(keys, valueCutoff)}]`
+        }
+      } else {
+        cache[0] = value
+        keys[0] = key
+      }
+    }
+
+    return hasReplacer ? replacer.call(this, key, value) : value
+  }
+}
+
+/**
+ * Stringifier that handles circular values
+ *
+ * Forked from https://github.com/planttheidea/fast-stringify
+ *
+ * @param value to stringify
+ * @param [replacer] a custom replacer function for handling standard values
+ * @param [indent] the number of spaces to indent the output by
+ * @param [circularReplacer] a custom replacer function for handling circular values
+ * @returns the stringified output
+ */
+export function serialize(
+  value: any,
+  replacer?: StandardReplacer | null | undefined,
+  indent?: number | null | undefined,
+  circularReplacer?: CircularReplacer | null | undefined,
+) {
+  return JSON.stringify(
+    value,
+    createReplacer(function initialReplacer(this: any, key, replacerValue_) {
+      let replacerValue = replacerValue_
+      if (typeof replacerValue === 'bigint')
+        replacerValue = { __type: 'bigint', value: replacerValue_.toString() }
+      if (value instanceof Map)
+        replacerValue = { __type: 'Map', value: Array.from(replacerValue_.entries()) }
+      return replacer?.call(this, key, replacerValue) ?? replacerValue
+    }, circularReplacer),
+    indent ?? undefined,
+  )
+}


### PR DESCRIPTION
requires: #663 

changes:
- added `usePrefetchQuery()` from tanstack query docs, input is the same as normal `useQuery()`
- added `usePrefetchBlockTimestamp()` for prefetching block timestamp
- added loading/fallback state for `<ShortExpiry />`
- added prefetch for block timestamp in `<NameListView />` so that it is normally loaded before the names are shown. this should make the loading state for `<ShortExpiry />` very rare.
- fixed serialisation of bigints by removing the prototype change in `_app.tsx`
- added custom serialisation/deserialisation to allow date objects to be losslessly serialised

Fixes FET-1409