### PR TITLE
fix: title array error

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -40,7 +40,8 @@ export default function Page() {
   return (
     <>
       <Head>
-        <title>ENS - {t('notFound')}</title>
+        {/* this is wrapped in a string because of the way nextjs renders content, don't remove! */}
+        <title>{`ENS - ${t('notFound')}`}</title>
       </Head>
       <StyledLeadingHeading>
         <LogoAndLanguage>


### PR DESCRIPTION
nextjs adds spacing comments when rendering, which can lead to issues with the title element having multiple children where it should just have 1. (see https://github.com/vercel/next.js/discussions/38256)

changes:
- wrapped 404 page title in string literal to ensure the content output is flat

Fixes FET-1413