### PR TITLE
fix: resolved address names in names page

### DIFF
--- a/src/components/@molecules/NameListView/NameListView.tsx
+++ b/src/components/@molecules/NameListView/NameListView.tsx
@@ -105,6 +105,7 @@ export const NameListView = ({ address, selfAddress, setError, setLoading }: Nam
     pageSize: 20,
     filter: {
       searchString: searchQuery,
+      resolvedAddress: false,
     },
   })
 


### PR DESCRIPTION
set `resolvedAddress` param to be false