### PR TITLE
fix: add dnsclaim redirect for claimed names

### DIFF
--- a/src/components/pages/import/[name]/DnsClaim.tsx
+++ b/src/components/pages/import/[name]/DnsClaim.tsx
@@ -28,7 +28,6 @@ const getShouldRedirect = ({
   item: DnsImportReducerDataItem
   step: DnsStep
 }) => {
-  console.log({ isLoading, registrationStatus, item, step })
   if (isLoading) return false
   if (!registrationStatus) return false
   if (registrationStatus === 'notImported') return false

--- a/src/components/pages/import/[name]/DnsClaim.tsx
+++ b/src/components/pages/import/[name]/DnsClaim.tsx
@@ -3,10 +3,11 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAccount } from 'wagmi'
 
+import { useBasicName } from '@app/hooks/useBasicName'
 import { useRouterWithHistory } from '@app/hooks/useRouterWithHistory'
-import { useValidate } from '@app/hooks/useValidate'
 import { Content } from '@app/layouts/Content'
 import { useTransactionFlow } from '@app/transaction-flow/TransactionFlowProvider'
+import { RegistrationStatus } from '@app/utils/registrationStatus'
 
 import { CompleteImport } from './steps/CompleteImport'
 import { EnableDnssec } from './steps/EnableDnssec'
@@ -14,13 +15,42 @@ import { ImportTransaction } from './steps/onchain/ImportTransaction'
 import { VerifyOnchainOwnership } from './steps/onchain/VerifyOnchainOwnership'
 import { SelectImportType } from './steps/SelectImportType'
 import { VerifyOffchainOwnership } from './steps/VerifyOffchainOwnership'
-import { useDnsImportReducer } from './useDnsImportReducer'
+import { DnsImportReducerDataItem, DnsStep, useDnsImportReducer } from './useDnsImportReducer'
+
+const getShouldRedirect = ({
+  isLoading,
+  registrationStatus,
+  item,
+  step,
+}: {
+  isLoading: boolean
+  registrationStatus?: RegistrationStatus
+  item: DnsImportReducerDataItem
+  step: DnsStep
+}) => {
+  console.log({ isLoading, registrationStatus, item, step })
+  if (isLoading) return false
+  if (!registrationStatus) return false
+  if (registrationStatus === 'notImported') return false
+  if (registrationStatus === 'notOwned') return false
+
+  if (!item.started) return true
+
+  if (step === 'completeOnchain') return false
+  if (step === 'completeOffchain') return false
+
+  return true
+}
 
 export const DnsClaim = () => {
   const router = useRouterWithHistory()
   const { address } = useAccount()
+  const {
+    registrationStatus,
+    isLoading,
+    name = '',
+  } = useBasicName({ name: router.query.name as string })
 
-  const { name = '' } = useValidate({ input: router.query.name as string })
   const { t } = useTranslation('dnssec')
 
   const { dispatch, item, selected } = useDnsImportReducer({
@@ -61,6 +91,10 @@ export const DnsClaim = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, step, selected, router.asPath])
+
+  if (router.isReady && getShouldRedirect({ isLoading, registrationStatus, item, step })) {
+    router.push(`/profile/${name}`)
+  }
 
   return (
     <>


### PR DESCRIPTION
changes:
- added logic for redirecting away from dns claim page if a name is already claimed
  - does not redirect away if the flow needs to be completed first, similar to registration
- added useBasicName call to `<DnsClaim />`
  - this kinda sucks because its only required in the redirect logic but its not already called in a parent or anything

Fixes FET-1441