### PR TITLE
fix: remove primary name flow if manager transfer is required

### DIFF
--- a/e2e/specs/stateless/setPrimary.spec.ts
+++ b/e2e/specs/stateless/setPrimary.spec.ts
@@ -425,4 +425,49 @@ test.describe('profile', () => {
       timeout: 15000,
     })
   })
+
+  test('should not allow owner but not manager to set primary name for unwrapped name', async ({
+    page,
+    login,
+    accounts,
+    makeName,
+    makePageObject,
+  }) => {
+    test.slow()
+
+    const tx = await setPrimaryName(walletClient, {
+      name: '',
+      account: createAccounts().getAddress('user') as `0x${string}`,
+    })
+    await waitForTransaction(tx)
+
+    const name = await makeName({
+      label: 'legacy',
+      type: 'legacy',
+      owner: 'user',
+      manager: 'user2',
+      records: {
+        coins: [
+          {
+            coin: 'eth',
+            value: accounts.getAddress('user2'),
+          },
+        ],
+      },
+    })
+
+    const profilePage = makePageObject('ProfilePage')
+
+    await profilePage.goto(name)
+    await login.connect()
+
+    await page.pause()
+
+    await expect(page.getByTestId('profile-action-Set as primary name')).toHaveCount(0)
+
+    // Assert state
+    await expect(page.getByTestId('owner-profile-button-name.manager')).toContainText(
+      accounts.getAddress('user2', 5),
+    )
+  })
 })

--- a/src/utils/checkAvailablePrimaryName.test.ts
+++ b/src/utils/checkAvailablePrimaryName.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-
-import { checkAvailablePrimaryName } from './checkAvailablePrimaryName'
 import { GetOwnerReturnType, GetWrapperDataReturnType } from '@ensdomains/ensjs/public'
 
-describe('checkAvailablePrimaryName', () => {
+import { checkAvailablePrimaryName } from './checkAvailablePrimaryName'
 
+describe('checkAvailablePrimaryName', () => {
   it('should return true for offchain names with resolved address of user', () => {
     const address = '0x189fa72c8959aa18bea737d46c10826de4ef81a2'
     const ownerData = undefined as GetOwnerReturnType | undefined
@@ -13,7 +12,7 @@ describe('checkAvailablePrimaryName', () => {
     const wrappedData = undefined as GetWrapperDataReturnType | undefined
 
     const result = checkAvailablePrimaryName('primary.eth', {
-      isAuthorized: true
+      isAuthorized: true,
     } as any)({
       name: 'name.eth',
       relation: {
@@ -24,8 +23,26 @@ describe('checkAvailablePrimaryName', () => {
       },
       isMigrated: profile?.isMigrated !== false,
       expiryDate: undefined,
-      fuses: null
+      fuses: null,
     })
     expect(result).toBe(true)
+  })
+  it('should return false for name where registrant is user, but nothing else', () => {
+    const result = checkAvailablePrimaryName(null, {
+      // this value would be false but is irrelevant
+      isAuthorized: true,
+    } as any)({
+      name: 'name.eth',
+      relation: {
+        owner: false,
+        registrant: true,
+        resolvedAddress: false,
+        wrappedOwner: false,
+      },
+      isMigrated: true,
+      expiryDate: undefined,
+      fuses: null,
+    })
+    expect(result).toBe(false)
   })
 })

--- a/src/utils/checkAvailablePrimaryName.ts
+++ b/src/utils/checkAvailablePrimaryName.ts
@@ -15,9 +15,8 @@ const isNotTLD = (n: Pick<CheckPrimaryNameInputName, 'name'>) =>
   n.name ? n.name.split('.').length > 1 : false
 
 const isResolvedOrManagedName = ({
-  relation: { owner, registrant, resolvedAddress, wrappedOwner },
-}: Pick<CheckPrimaryNameInputName, 'relation'>) =>
-  owner || registrant || wrappedOwner || resolvedAddress
+  relation: { owner, resolvedAddress, wrappedOwner },
+}: Pick<CheckPrimaryNameInputName, 'relation'>) => owner || wrappedOwner || resolvedAddress
 
 const isNotPrimaryName =
   (primaryName?: string | null) => (n: Pick<CheckPrimaryNameInputName, 'name'>) =>


### PR DESCRIPTION
changes:
- removed `registrant` check in `isResolvedOrManagedName`, because matching registrant relation does not imply that the name is resolved or managed by the connected account.
- added unit test for case

Fixes FET-1446