### PR TITLE
fix offchain dns nametype + [root] validation

### DIFF
--- a/src/components/@molecules/SearchInput/SearchInput.tsx
+++ b/src/components/@molecules/SearchInput/SearchInput.tsx
@@ -383,6 +383,7 @@ export const SearchInput = ({
       )
       if (ownerData) {
         const registrationStatus = getRegistrationStatus({
+          name: selectedItem.value,
           timestamp: Date.now(),
           validation: currentValidation,
           ownerData,

--- a/src/components/pages/profile/[name]/tabs/OwnershipTab/sections/ExpirySection/hooks/useExpiryDetails.ts
+++ b/src/components/pages/profile/[name]/tabs/OwnershipTab/sections/ExpirySection/hooks/useExpiryDetails.ts
@@ -141,6 +141,7 @@ export const useExpiryDetails = ({ name, details }: Input, options: Options = {}
             'dns-wrapped-2ld',
             'dns-emancipated-2ld',
             'dns-locked-2ld',
+            'dns-offchain-2ld',
             'dns-unwrapped-subname',
             'dns-wrapped-subname',
             'dns-emancipated-subname',

--- a/src/hooks/nameType/getNameType.ts
+++ b/src/hooks/nameType/getNameType.ts
@@ -22,6 +22,7 @@ export type NameType =
   | 'eth-pcc-expired-subname'
   | 'dns-unwrapped-2ld'
   | 'dns-wrapped-2ld'
+  | 'dns-offchain-2ld'
   | 'dns-emancipated-2ld' // *
   | 'dns-locked-2ld' // *
   | 'dns-unwrapped-subname'
@@ -85,6 +86,9 @@ export const getNameType = ({
       ]) => {
         return `${_tldType}-${_wrapLevel}-2ld` as const
       },
+    )
+    .with(['dns', 'unwrapped', '2ld', 'imported'], () =>
+      ownerData ? ('dns-unwrapped-2ld' as const) : ('dns-offchain-2ld' as const),
     )
     .with(['dns', P._, '2ld', P._], ([, _wrapLevel]) => `dns-${_wrapLevel}-2ld` as const)
     .with([P._, P._, 'subname', P._], ([_tldType, _wrapLevel]) =>

--- a/src/hooks/nameType/useNameType.test.ts
+++ b/src/hooks/nameType/useNameType.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { useNameType } from './useNameType'
 import { makeMockUseContractAddress } from '../../../test/mock/makeMockUseContractAddress'
 import { makeMockUseBasicName } from '../../../test/mock/makeMockUseBasicName'
+import { mockUseNameTypeConfig, mockUseNameTypes } from '../../../test/mock/makeMockUseNameType'
 
 const mockBasicData = vi.fn()
 vi.mock('@app/hooks/useBasicName', () => ({
@@ -163,6 +164,15 @@ describe('useNameType', () => {
       mockBasicData.mockReturnValue(makeMockUseBasicName('eth-locked-2ld:grace-period'))
       const { result } = renderHook(() => useNameType('name.eth'))
       expect(result.current.data).toEqual('eth-locked-2ld:grace-period')
+    })
+  })
+
+  describe('mocks', () => {
+    it.each(mockUseNameTypes)('should return the correct data for: %s', async (type) => {
+      const config = mockUseNameTypeConfig[type]
+      mockBasicData.mockReturnValue(makeMockUseBasicName(config.basicNameType))
+      const { result } = renderHook(() => useNameType(config.name))
+      expect(result.current.data).toEqual(type)
     })
   })
 })

--- a/src/hooks/ownership/useRoles/utils/getRoles.ts
+++ b/src/hooks/ownership/useRoles/utils/getRoles.ts
@@ -74,6 +74,10 @@ export const getRoles = ({
       { address: owner, role: 'manager' as const },
       { address: ethAddress, role: 'eth-record' as const },
     ])
+    .with('dns-offchain-2ld', () => [
+      { address: dnsOwner, role: 'dns-owner' as const },
+      { address: ethAddress, role: 'eth-record' as const },
+    ])
     .with(P.union(P.nullish, 'tld', 'root'), () => [])
     .exhaustive()
 }

--- a/src/hooks/useBasicName.ts
+++ b/src/hooks/useBasicName.ts
@@ -129,6 +129,7 @@ export const useBasicName = ({
 
   const registrationStatus = !publicCallsLoading
     ? getRegistrationStatus({
+        name: normalisedName,
         timestamp: registrationStatusTimestamp,
         validation,
         ownerData,

--- a/src/hooks/useValidate.ts
+++ b/src/hooks/useValidate.ts
@@ -35,7 +35,7 @@ export const validate = (input: string) => {
     ...parsedInput,
     name: outputName,
     beautifiedName: tryBeautify(outputName),
-    isNonASCII,
+    isNonASCII: input !== '[root]' && isNonASCII,
     labelCount: parsedInput.labelDataArray.length,
   }
 }

--- a/src/transaction-flow/input/SendName/utils/checkCanSend.ts
+++ b/src/transaction-flow/input/SendName/utils/checkCanSend.ts
@@ -34,6 +34,7 @@ export const senderRole = (nameType: ReturnType<typeof useNameType>['data']) => 
       P.union(
         'dns-unwrapped-2ld',
         'dns-wrapped-2ld',
+        'dns-offchain-2ld',
         'eth-emancipated-2ld:grace-period',
         'eth-locked-2ld:grace-period',
         'eth-unwrapped-2ld:grace-period',

--- a/src/transaction-flow/input/SyncManager/utils/checkCanSyncManager.ts
+++ b/src/transaction-flow/input/SyncManager/utils/checkCanSyncManager.ts
@@ -41,6 +41,7 @@ export const checkCanSyncManager = ({
         'eth-pcc-expired-subname',
         'dns-locked-2ld',
         'dns-emancipated-2ld',
+        'dns-offchain-2ld',
         'dns-unwrapped-subname',
         'dns-wrapped-subname',
         'dns-emancipated-subname',

--- a/src/utils/registrationStatus.ts
+++ b/src/utils/registrationStatus.ts
@@ -23,6 +23,7 @@ export type RegistrationStatus =
   | 'unsupportedTLD'
 
 export const getRegistrationStatus = ({
+  name,
   timestamp,
   validation: { isETH, is2LD, isShort, type },
   ownerData,
@@ -32,6 +33,7 @@ export const getRegistrationStatus = ({
   addrData,
   supportedTLD,
 }: {
+  name: string
   timestamp: number
   validation: Partial<Omit<ParsedInputResult, 'normalised' | 'isValid'>>
   ownerData?: GetOwnerReturnType
@@ -41,6 +43,8 @@ export const getRegistrationStatus = ({
   addrData?: GetAddressRecordReturnType
   supportedTLD?: boolean | null
 }): RegistrationStatus => {
+  if (name === '[root]') return 'owned'
+
   if (isETH && is2LD && isShort) {
     return 'short'
   }

--- a/test/mock/makeMockUseBasicName.ts
+++ b/test/mock/makeMockUseBasicName.ts
@@ -20,6 +20,12 @@ type MockUseBasicNameConfig = {
 }
 
 export const mockUseBasicNameConfig = {
+  root: {
+    useValidateType: 'root',
+    useOwnerType: 'root',
+    useExpiryType: 'root',
+    usePriceType: 'root',
+  } as MockUseBasicNameConfig,
   eth: {
     useValidateType: 'eth',
     useOwnerType: 'eth',
@@ -179,6 +185,10 @@ export const mockUseBasicNameConfig = {
     useOwnerType: 'namewrapper:unowned',
     useWrapperDataType: 'locked:unowned',
   } as MockUseBasicNameConfig,
+  'eth-pcc-expired-subname': {
+    useValidateType: 'valid-subname',
+    useOwnerType: 'registry:pcc-expired',
+  } as MockUseBasicNameConfig,
   // DNS
   dns: {
     useValidateType: 'dns',
@@ -209,6 +219,17 @@ export const mockUseBasicNameConfig = {
     useValidateType: 'valid-2ld:dns',
     useAddrRecordType: 'owned',
   } as MockUseBasicNameConfig,
+  'dns-unwrapped-subname': {
+    useValidateType: 'valid-subname:dns',
+    useOwnerType: 'registry',
+    useAddrRecordType: 'owned',
+  } as MockUseBasicNameConfig,
+  'dns-wrapped-subname': {
+    useValidateType: 'valid-subname:dns',
+    useOwnerType: 'namewrapper',
+    useWrapperDataType: 'wrapped',
+    useAddrRecordType: 'owned',
+  } as MockUseBasicNameConfig,
 } as const
 
 export type MockUseBasicNameType = keyof typeof mockUseBasicNameConfig
@@ -236,6 +257,17 @@ export const makeMockUseBasicName = (type: MockUseBasicNameType) => {
     gracePeriodEndDate,
   }
   return match(type)
+    .with('root', () => ({
+      ...BaseBasicName,
+      normalisedName: '[root]',
+      truncatedName: '[root]',
+      canBeWrapped: false,
+      pccExpired: false,
+      registrationStatus: 'owned' as const,
+      isCachedData: false,
+      isLoading: false,
+      isWrapped: false,
+    }))
     .with('eth', () => ({
       ...BaseBasicName,
       normalisedName: 'eth',
@@ -373,6 +405,17 @@ export const makeMockUseBasicName = (type: MockUseBasicNameType) => {
         isCachedData: false,
       }),
     )
+    .with('eth-pcc-expired-subname', () => ({
+      ...BaseBasicName,
+      normalisedName: 'subname.name.eth',
+      truncatedName: 'subname.name.eth',
+      registrationStatus: 'owned' as const,
+      isWrapped: false,
+      pccExpired: true,
+      canBeWrapped: true,
+      isLoading: false,
+      isCachedData: false,
+    }))
     .with('dns', () => ({
       ...BaseBasicName,
       normalisedName: 'com',
@@ -408,6 +451,28 @@ export const makeMockUseBasicName = (type: MockUseBasicNameType) => {
       normalisedName: 'name.com',
       truncatedName: 'name.com',
       registrationStatus: 'imported' as const,
+      isWrapped: true,
+      pccExpired: false,
+      canBeWrapped: false,
+      isLoading: false,
+      isCachedData: false,
+    }))
+    .with('dns-unwrapped-subname', () => ({
+      ...BaseBasicName,
+      normalisedName: 'subname.name.com',
+      truncatedName: 'subname.name.com',
+      registrationStatus: 'owned' as const,
+      isWrapped: false,
+      pccExpired: false,
+      canBeWrapped: false,
+      isLoading: false,
+      isCachedData: false,
+    }))
+    .with('dns-wrapped-subname', () => ({
+      ...BaseBasicName,
+      normalisedName: 'subname.name.com',
+      truncatedName: 'subname.name.com',
+      registrationStatus: 'owned' as const,
       isWrapped: true,
       pccExpired: false,
       canBeWrapped: false,

--- a/test/mock/makeMockUseExpiryData.ts
+++ b/test/mock/makeMockUseExpiryData.ts
@@ -2,11 +2,12 @@ import { match, P } from 'ts-pattern'
 
 import { GetExpiryReturnType } from '@ensdomains/ensjs/public'
 
-const mockUseExpiryTypes = ['eth', 'active', 'grace-period'] as const
+const mockUseExpiryTypes = ['root', 'eth', 'active', 'grace-period'] as const
 export type MockUseExpiryType = (typeof mockUseExpiryTypes)[number] | undefined
 
 export const makeMockUseExpiryData = (type: MockUseExpiryType): GetExpiryReturnType | undefined =>
   match(type)
+    .with('root', () => undefined)
     .with('eth', () => ({
       expiry: {
         date: new Date('+275760-09-13T00:00:00.000Z'),

--- a/test/mock/makeMockUseNameType.ts
+++ b/test/mock/makeMockUseNameType.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { NameType } from '@app/hooks/nameType/getNameType'
+
+import { MockUseBasicNameType } from './makeMockUseBasicName'
+
+export type MockUseNameTypeType = Exclude<
+  NameType,
+  | 'dns-emancipated-2ld'
+  | 'dns-locked-2ld'
+  | 'dns-emancipated-subname'
+  | 'dns-locked-subname'
+  | 'dns-pcc-expired-subname'
+>
+
+type MockUseNameTypeConfig = {
+  name: string
+  basicNameType: MockUseBasicNameType
+}
+
+export const mockUseNameTypeConfig: { [key in MockUseNameTypeType]: MockUseNameTypeConfig } = {
+  root: {
+    name: '[root]',
+    basicNameType: 'root',
+  },
+  tld: {
+    name: 'eth',
+    basicNameType: 'eth',
+  },
+  'eth-unwrapped-2ld': {
+    name: 'name.eth',
+    basicNameType: 'eth-unwrapped-2ld',
+  },
+  'eth-unwrapped-2ld:grace-period': {
+    name: 'name.eth',
+    basicNameType: 'eth-unwrapped-2ld:grace-period',
+  },
+  'eth-emancipated-2ld': {
+    name: 'name.eth',
+    basicNameType: 'eth-emancipated-2ld',
+  },
+  'eth-emancipated-2ld:grace-period': {
+    name: 'name.eth',
+    basicNameType: 'eth-emancipated-2ld:grace-period',
+  },
+  'eth-locked-2ld': {
+    name: 'name.eth',
+    basicNameType: 'eth-locked-2ld',
+  },
+  'eth-locked-2ld:grace-period': {
+    name: 'name.eth',
+    basicNameType: 'eth-locked-2ld:grace-period',
+  },
+  'eth-unwrapped-subname': {
+    name: 'subname.name.eth',
+    basicNameType: 'eth-unwrapped-subname',
+  },
+  'eth-wrapped-subname': {
+    name: 'subname.name.eth',
+    basicNameType: 'eth-wrapped-subname',
+  },
+  'eth-emancipated-subname': {
+    name: 'subname.name.eth',
+    basicNameType: 'eth-emancipated-subname',
+  },
+  'eth-locked-subname': {
+    name: 'subname.name.eth',
+    basicNameType: 'eth-locked-subname',
+  },
+  'eth-pcc-expired-subname': {
+    name: 'subname.name.eth',
+    basicNameType: 'eth-pcc-expired-subname',
+  },
+  'dns-unwrapped-2ld': {
+    name: 'name.com',
+    basicNameType: 'dns-unwrapped-2ld',
+  },
+  'dns-wrapped-2ld': {
+    name: 'name.com',
+    basicNameType: 'dns-wrapped-2ld',
+  },
+  'dns-offchain-2ld': {
+    name: 'name.com',
+    basicNameType: 'dns-offchain-2ld',
+  },
+  'dns-unwrapped-subname': {
+    name: 'subname.name.com',
+    basicNameType: 'dns-unwrapped-subname',
+  },
+  'dns-wrapped-subname': {
+    name: 'subname.name.com',
+    basicNameType: 'dns-wrapped-subname',
+  },
+}
+
+export const mockUseNameTypes = Object.keys(mockUseNameTypeConfig) as MockUseNameTypeType[]
+
+export const makeMockUseNameTypeData = (type: MockUseNameTypeType) => {
+  return type
+}

--- a/test/mock/makeMockUseOwnerData.ts
+++ b/test/mock/makeMockUseOwnerData.ts
@@ -7,6 +7,7 @@ import { createAccounts } from '../../playwright/fixtures/accounts'
 import { makeMockUseContractAddress } from './makeMockUseContractAddress'
 
 const mockUseOwnerTypes = [
+  'root',
   'eth',
   'registrar',
   'registrar:owner',
@@ -24,7 +25,9 @@ const mockUseOwnerTypes = [
   'namewrapper:grace-period',
   'registry',
   'registry:unowned',
+  'registry:pcc-expired',
   'dns',
+  'dns:offchain',
 ] as const
 
 export type MockUseOwnerType = (typeof mockUseOwnerTypes)[number] | undefined
@@ -34,6 +37,7 @@ const user2Address = createAccounts().getAddress('user2') as Address
 
 export const makeMockUseOwnerData = (type: MockUseOwnerType): GetOwnerReturnType | undefined =>
   match(type)
+    .with('root', () => undefined)
     .with('eth', () => ({
       owner: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0' as Address,
       ownershipLevel: 'registry' as const,
@@ -94,9 +98,14 @@ export const makeMockUseOwnerData = (type: MockUseOwnerType): GetOwnerReturnType
       owner: _type.endsWith('unowned') ? user2Address : userAddress,
       ownershipLevel: 'registry' as const,
     }))
+    .with('registry:pcc-expired', () => ({
+      owner: makeMockUseContractAddress({ contract: 'ensNameWrapper' }),
+      ownershipLevel: 'registry' as const,
+    }))
     .with('dns', () => ({
       owner: '0xB32cB5677a7C971689228EC835800432B339bA2B' as Address,
       ownershipLevel: 'registry' as const,
     }))
+    .with('dns:offchain', () => null)
     .with(P.nullish, () => null)
     .exhaustive()

--- a/test/mock/makeMockUsePriceData.ts
+++ b/test/mock/makeMockUsePriceData.ts
@@ -2,11 +2,12 @@ import { match, P } from 'ts-pattern'
 
 import { GetPriceReturnType } from '@ensdomains/ensjs/public'
 
-const mockUsePriceTypes = ['tld', 'base', 'premium'] as const
+const mockUsePriceTypes = ['root', 'tld', 'base', 'premium'] as const
 export type MockUsePriceType = (typeof mockUsePriceTypes)[number] | undefined
 
 export const makeMockUsePriceData = (type: MockUsePriceType): GetPriceReturnType | undefined =>
   match(type)
+    .with('root', () => undefined)
     .with('tld', () => undefined)
     .with('base', () => ({ base: 3203936997786453n, premium: 0n }))
     .with('premium', () => ({

--- a/test/mock/makeMockUseValidate.ts
+++ b/test/mock/makeMockUseValidate.ts
@@ -4,18 +4,39 @@ import { match } from 'ts-pattern'
 import { ValidationResult } from '@app/hooks/useValidate'
 
 export const mockUseValidateConfig = {
+  root: { input: '[root]' },
   eth: { input: 'eth' },
   dns: { input: 'com' },
   'valid-2ld': { input: 'name.eth' },
   'valid-2ld:dns': { input: 'name.com' },
   'invalid-2ld': { input: 'name❤️.eth' },
   'valid-subname': { input: 'subname.name.eth' },
+  'valid-subname:dns': { input: 'subname.name.com' },
 } as const
 export type MockUseValidateType = keyof typeof mockUseValidateConfig
 export const mockUseValidateTypes = Object.keys(mockUseValidateConfig) as MockUseValidateType[]
 
 export const makeMockUseValidate = (type: MockUseValidateType): ValidationResult => {
   return match(type)
+    .with('root', () => ({
+      type: 'label' as const,
+      isShort: true,
+      isValid: true,
+      is2LD: false,
+      isETH: false,
+      labelDataArray: [
+        {
+          error: new Error('disallowed character: "["‎ {5B}'),
+          input: [91, 114, 111, 111, 116, 93],
+          offset: 0,
+          output: undefined,
+        },
+      ],
+      name: '[root]',
+      beautifiedName: '[root]',
+      isNonASCII: false,
+      labelCount: 1,
+    }))
     .with('eth', () => ({
       type: 'label' as const,
       isShort: false,
@@ -172,6 +193,40 @@ export const makeMockUseValidate = (type: MockUseValidateType): ValidationResult
         },
       ],
       beautifiedName: 'subname.name.eth',
+      isNonASCII: false,
+      labelCount: 3,
+    }))
+    .with('valid-subname:dns', () => ({
+      type: 'name' as const,
+      name: 'subname.name.com',
+      isShort: false,
+      isValid: true,
+      is2LD: false,
+      isETH: false,
+      labelDataArray: [
+        {
+          input: [115, 117, 98, 110, 97, 109, 101],
+          offset: 0,
+          tokens: [[115, +117, +98, +110, +97, +109, +101]],
+          type: 'ASCII',
+          output: [115, +117, +98, +110, +97, +109, +101],
+        },
+        {
+          input: [110, 97, 109, 101],
+          offset: 8,
+          tokens: [[110, 97, 109, 101]],
+          type: 'ASCII',
+          output: [110, 97, 109, 101],
+        },
+        {
+          input: [99, 111, 109],
+          offset: 13,
+          tokens: [[99, 111, 109]],
+          type: 'ASCII',
+          output: [99, 111, 109],
+        },
+      ],
+      beautifiedName: 'subname.name.com',
       isNonASCII: false,
       labelCount: 3,
     }))


### PR DESCRIPTION
User reported a bug where "sync manager" button appeared on his off-chain dns name. The source of the bug was that he also began the process of on-chain import by setting his dns-owner record.

Additional fix in this PR fixes the profile page for [root] where the invalid name warning and isNonASCII warning were showing.

This PR:
* Updates useNameType hook to check for ownerData before assigning on-chain dns name type.
* Adds additional unit tests for useNameType
* Fixes validation for [root] where isNonASCII is now false
* Fixes registrationStatus for [root] where it is now "owned" instead of "invalid"