### PR TITLE
Fix [root] search in input

### DIFF
--- a/src/components/@molecules/SearchInput/SearchInput.tsx
+++ b/src/components/@molecules/SearchInput/SearchInput.tsx
@@ -426,6 +426,7 @@ const formatEthText = ({ name, isETH }: { name: string; isETH: boolean | undefin
   if (!name) return ''
   if (isETH) return name
   if (name.includes('.')) return ''
+  if (name === '[root]') return ''
   return `${name}.eth`
 }
 const addEthDropdownItem =
@@ -462,6 +463,7 @@ const formatBoxText = (name: string) => {
   if (!name) return ''
   if (name?.endsWith('.box')) return name
   if (name.includes('.')) return ''
+  if (name === '[root]') return ''
   return `${name}.box`
 }
 const addBoxDropdownItem =
@@ -547,6 +549,7 @@ const formatDnsText = ({ name, isETH }: { name: string; isETH: boolean | undefin
   if (!name.includes('.')) return ''
   if (name.endsWith('.box')) return ''
   if (isETH) return ''
+  if (name === '[root]') return ''
   return name
 }
 const addDnsDropdownItem =

--- a/src/hooks/useBasicName.ts
+++ b/src/hooks/useBasicName.ts
@@ -137,6 +137,7 @@ export const useBasicName = ({
         priceData,
         addrData,
         supportedTLD,
+        name: normalisedName,
       })
     : undefined
 

--- a/src/utils/registrationStatus.ts
+++ b/src/utils/registrationStatus.ts
@@ -31,6 +31,7 @@ export const getRegistrationStatus = ({
   priceData,
   addrData,
   supportedTLD,
+  name,
 }: {
   timestamp: number
   validation: Partial<Omit<ParsedInputResult, 'normalised' | 'isValid'>>
@@ -40,7 +41,10 @@ export const getRegistrationStatus = ({
   priceData?: GetPriceReturnType
   addrData?: GetAddressRecordReturnType
   supportedTLD?: boolean | null
+  name?: string
 }): RegistrationStatus => {
+  if (name === '[root]') return 'owned'
+
   if (isETH && is2LD && isShort) {
     return 'short'
   }


### PR DESCRIPTION
Bug: Entering [root] in search input causes app to crash

Cause: [root] breaks namehash because of invalid characters but [root] is an accepted input.

Fix: Remove [root] for other search item lists so that it does not attempt to namehash name

Other fix:  getRegistrationStatus, return 'owned' in name is [root]

Small fix: Adding key attribute through spread operator throws a warning in React 18