### PR TITLE
Add support to Cardano ADA on user Profile for Offchain resolver

### DIFF
--- a/public/locales/en/register.json
+++ b/public/locales/en/register.json
@@ -83,7 +83,8 @@
               "op": "0xb8c2C2...",
               "arb1": "0xb8c2C2...",
               "base": "0xb8c2C2...",
-              "matic": "0xb8c2C2..."
+              "matic": "0xb8c2C2...",
+              "ada": "addr1q84..."
             }
           },
           "website": {

--- a/src/constants/supportedAddresses.ts
+++ b/src/constants/supportedAddresses.ts
@@ -1,1 +1,1 @@
-export const supportedAddresses = ['eth', 'btc', 'sol', 'op', 'arb1', 'base', 'matic'] as const
+export const supportedAddresses = ['eth', 'btc', 'sol', 'op', 'arb1', 'base', 'matic', 'ada'] as const

--- a/src/hooks/useProfile.test.ts
+++ b/src/hooks/useProfile.test.ts
@@ -242,6 +242,7 @@ it('should fetch union of supported coin records and subgraph coin records', () 
         evmChainIdToCoinType(10),
         /* subgraph coins */ 118,
         128,
+        1815,
       ]),
     }),
   )


### PR DESCRIPTION
Hi Team,

I'm from Begin Wallet currently supporting Cardano and we're launching https://beginid.io/ based on ENS offchain resolver. and we'd like to list the ADA address when users come to the ENS app.