### PR TITLE
fix: safe tx hash replacement

### DIFF
--- a/src/hooks/transactions/transactionStore.ts
+++ b/src/hooks/transactions/transactionStore.ts
@@ -399,21 +399,15 @@ export function createTransactionStore(config_: ConfigWithEns) {
           const requestPromise = waitForTransaction(config, {
             confirmations: 1,
             hash: hash as `0x${string}`,
-            onReplaced: (replacedTransaction) => {
-              if (replacedTransaction.reason === 'repriced') {
-                setTransactionStatus(
-                  account,
-                  chainId,
-                  hash,
-                  'repriced',
-                  replacedTransaction.transaction.hash,
-                )
+            onReplaced: (response) => {
+              if (response.reason === 'repriced') {
+                setTransactionStatus(account, chainId, hash, 'repriced', response.transactionHash)
                 addTransaction(account, chainId, {
                   ...transaction,
                   isSafeTx: false,
-                  hash: replacedTransaction.transaction.hash,
+                  hash: response.transactionHash,
                 })
-                transactionRequestCache.set(replacedTransaction.transaction.hash, requestPromise)
+                transactionRequestCache.set(response.transactionHash, requestPromise)
                 transactionRequestCache.delete(hash)
               }
             },


### PR DESCRIPTION
previously when using safe, the safe transaction hash was not being updated to the normal transaction hash once it was found. this lead to a race condition in the etherscan transaction finder logic since the transaction hash at the expected nonce of the transaction was mismatched, so the transaction would be updated to show as failed.

changes:
- update safe transaction hash => transaction hash through a `repriced` onReplaced callback