### PR TITLE
Fix enter verification process from unconnected state

### DIFF
--- a/src/hooks/verification/useDentityProfile/useDentityProfile.ts
+++ b/src/hooks/verification/useDentityProfile/useDentityProfile.ts
@@ -9,27 +9,25 @@ import { VerificationProtocol } from '@app/transaction-flow/input/VerifyProfile/
 import { ConfigWithEns, CreateQueryKey, QueryConfig } from '@app/types'
 import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 
-import { getAPIEndpointForVerifier } from './utils/getAPIEndpointForVerifier'
+import { type DentityFederatedToken } from '../useDentityToken/useDentityToken'
 
 type UseVerificationOAuthParameters = {
-  verifier?: VerificationProtocol | null
-  code?: string | null
-  onSuccess?: (resp: UseVerificationOAuthReturnType) => void
+  token?: DentityFederatedToken
 }
 
-export type UseVerificationOAuthReturnType = {
+export type UseDentityProfileReturnType = {
   verifier: VerificationProtocol
-  name: string
-  owner: Hash
+  name?: string
+  owner?: Hash | null
   manager?: Hash
   primaryName?: string
-  address: Hash
-  resolverAddress: Hash
-  verifiedPresentationUri: string
+  address?: Hash
+  resolverAddress?: Hash
+  verifiedPresentationUri?: string
   verificationRecord?: string
 }
 
-type UseVerificationOAuthConfig = QueryConfig<UseVerificationOAuthReturnType, Error>
+type UseVerificationOAuthConfig = QueryConfig<UseDentityProfileReturnType, Error>
 
 type QueryKey<TParams extends UseVerificationOAuthParameters> = CreateQueryKey<
   TParams,
@@ -37,58 +35,46 @@ type QueryKey<TParams extends UseVerificationOAuthParameters> = CreateQueryKey<
   'standard'
 >
 
-export const getVerificationOAuth =
+export const getDentityProfile =
   (config: ConfigWithEns) =>
   async <TParams extends UseVerificationOAuthParameters>({
-    queryKey: [{ verifier, code }, chainId],
-  }: QueryFunctionContext<QueryKey<TParams>>): Promise<UseVerificationOAuthReturnType> => {
-    // Get federated token from oidc worker
-    const url = getAPIEndpointForVerifier(verifier)
-    const response = await fetch(url, {
-      method: 'POST',
-      body: JSON.stringify({ code }),
-    })
-    const json = await response.json()
-
-    const { name } = json as UseVerificationOAuthReturnType
-
-    if (!name)
+    queryKey: [{ token }, chainId],
+  }: QueryFunctionContext<QueryKey<TParams>>): Promise<UseDentityProfileReturnType> => {
+    if (!token || !token.name || !token.verifiedPresentationUri) {
       return {
-        verifier,
-        ...json,
+        verifier: 'dentity',
+        ...token,
       }
+    }
+
+    const { name } = token
 
     // Get resolver address since it will be needed for setting verification record
     const client = config.getClient({ chainId })
     const records = await getRecords(client, { name, texts: [VERIFICATION_RECORD_KEY] })
-
     // Get owner data to
     const ownerData = await getOwner(client, { name })
     const { owner, registrant, ownershipLevel } = ownerData || {}
-
     const _owner = ownershipLevel === 'registrar' ? registrant : owner
     const manager = ownershipLevel === 'registrar' ? owner : undefined
-
     const userWithSetRecordAbility = manager ?? _owner
     const primaryName = userWithSetRecordAbility
       ? await getName(client, { address: userWithSetRecordAbility })
       : undefined
-
     const data = {
-      ...json,
-      verifier,
+      ...token,
+      verifier: 'dentity' as const,
       owner: _owner,
       manager,
-      primaryName,
+      primaryName: primaryName?.name,
       resolverAddress: records.resolverAddress,
       verificationRecord: records.texts.find((text) => text.key === VERIFICATION_RECORD_KEY)?.value,
     }
     return data
   }
 
-export const useVerificationOAuth = <TParams extends UseVerificationOAuthParameters>({
+export const useDentityProfile = <TParams extends UseVerificationOAuthParameters>({
   enabled = true,
-  onSuccess,
   gcTime,
   staleTime,
   scopeKey,
@@ -99,13 +85,13 @@ export const useVerificationOAuth = <TParams extends UseVerificationOAuthParamet
     scopeKey,
     functionName: 'getVerificationOAuth',
     queryDependencyType: 'standard',
-    queryFn: getVerificationOAuth,
+    queryFn: getDentityProfile,
   })
 
   const preparedOptions = prepareQueryOptions({
     queryKey: initialOptions.queryKey,
     queryFn: initialOptions.queryFn,
-    enabled: enabled && !!params.verifier && !!params.code,
+    enabled: enabled && !!params.token,
     gcTime,
     staleTime,
     retry: 0,

--- a/src/hooks/verification/useDentityToken/useDentityToken.ts
+++ b/src/hooks/verification/useDentityToken/useDentityToken.ts
@@ -1,0 +1,67 @@
+import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
+
+import { VERIFICATION_OAUTH_BASE_URL } from '@app/constants/verification'
+import { useQueryOptions } from '@app/hooks/useQueryOptions'
+import { CreateQueryKey, QueryConfig } from '@app/types'
+import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
+
+export type DentityFederatedToken = {
+  name: string
+  verifiedPresentationUri: string
+}
+
+type UseDentityTokenParameters = {
+  code?: string | null
+}
+
+export type UseDentityTokenReturnType = DentityFederatedToken
+
+type UseVerificationOAuthConfig = QueryConfig<UseDentityTokenReturnType, Error>
+
+type QueryKey<TParams extends UseDentityTokenParameters> = CreateQueryKey<
+  TParams,
+  'getDentityToken',
+  'independent'
+>
+
+export const getDentityToken = async <TParams extends UseDentityTokenParameters>({
+  queryKey: [{ code }],
+}: QueryFunctionContext<QueryKey<TParams>>): Promise<UseDentityTokenReturnType> => {
+  // Get federated token from oidc worker
+  const url = `${VERIFICATION_OAUTH_BASE_URL}/dentity/token`
+  const response = await fetch(url, {
+    method: 'POST',
+    body: JSON.stringify({ code }),
+  })
+  const json = await response.json()
+
+  return json as UseDentityTokenReturnType
+}
+
+export const useDentityToken = <TParams extends UseDentityTokenParameters>({
+  enabled = true,
+  gcTime,
+  scopeKey,
+  ...params
+}: TParams & UseVerificationOAuthConfig) => {
+  const initialOptions = useQueryOptions({
+    params,
+    scopeKey,
+    functionName: 'getDentityToken',
+    queryDependencyType: 'independent',
+    queryFn: getDentityToken,
+  })
+
+  const preparedOptions = prepareQueryOptions({
+    queryKey: initialOptions.queryKey,
+    queryFn: initialOptions.queryFn,
+    enabled: enabled && !!params.code,
+    gcTime,
+    staleTime: Infinity,
+    retry: 0,
+  })
+
+  const query = useQuery(preparedOptions)
+
+  return query
+}

--- a/src/hooks/verification/useVerificationOAuth/utils/getAPIEndpointForVerifier.ts
+++ b/src/hooks/verification/useVerificationOAuth/utils/getAPIEndpointForVerifier.ts
@@ -1,9 +1,0 @@
-import { match } from 'ts-pattern'
-
-import { VERIFICATION_OAUTH_BASE_URL } from '@app/constants/verification'
-
-export const getAPIEndpointForVerifier = (verifier?: string | null): string => {
-  return match(verifier)
-    .with('dentity', () => `${VERIFICATION_OAUTH_BASE_URL}/dentity/token`)
-    .otherwise(() => '')
-}

--- a/src/hooks/verification/useVerificationOAuthHandler/useVerificationOAuthHandler.ts
+++ b/src/hooks/verification/useVerificationOAuthHandler/useVerificationOAuthHandler.ts
@@ -7,16 +7,11 @@ import { useAccount } from 'wagmi'
 import type { VerificationErrorDialogProps } from '@app/components/pages/VerificationErrorDialog'
 import { DENTITY_ISS } from '@app/constants/verification'
 import { useRouterWithHistory } from '@app/hooks/useRouterWithHistory'
-import { VerificationProtocol } from '@app/transaction-flow/input/VerifyProfile/VerifyProfile-flow'
 import { useTransactionFlow } from '@app/transaction-flow/TransactionFlowProvider'
 
-import { useVerificationOAuth } from '../useVerificationOAuth/useVerificationOAuth'
+import { useDentityProfile } from '../useDentityProfile/useDentityProfile'
+import { useDentityToken } from '../useDentityToken/useDentityToken'
 import { dentityVerificationHandler } from './utils/dentityHandler'
-
-const issToVerificationProtocol = (iss: string | null): VerificationProtocol | null => {
-  if (iss === DENTITY_ISS) return 'dentity'
-  return null
-}
 
 type UseVerificationOAuthHandlerReturnType = {
   dialogProps: VerificationErrorDialogProps
@@ -32,14 +27,23 @@ export const useVerificationOAuthHandler = (): UseVerificationOAuthHandlerReturn
 
   const { address: userAddress } = useAccount()
 
-  const isReady = !!createTransactionFlow && !!router && !!iss && !!code
-
-  const { data, isLoading, error } = useVerificationOAuth({
-    verifier: issToVerificationProtocol(iss),
+  const isReady = !!createTransactionFlow && !!router && !!iss && !!code && iss === DENTITY_ISS
+  const { data: dentityToken, isLoading: isDentityTokenLoading } = useDentityToken({
     code,
     enabled: isReady,
   })
 
+  const isReadyToFetchProfile = !!dentityToken && !isDentityTokenLoading
+  const {
+    data,
+    isLoading: isDentityProfileLoading,
+    error,
+  } = useDentityProfile({
+    token: dentityToken,
+    enabled: isReadyToFetchProfile,
+  })
+
+  const isLoading = isDentityTokenLoading || isDentityProfileLoading
   const [dialogProps, setDialogProps] = useState<VerificationErrorDialogProps>()
   const onClose = () => setDialogProps(undefined)
   const onDismiss = () => setDialogProps(undefined)
@@ -64,7 +68,7 @@ export const useVerificationOAuthHandler = (): UseVerificationOAuthHandlerReturn
       setDialogProps(newProps)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, isLoading, error])
+  }, [data, isDentityProfileLoading, error])
 
   return {
     dialogProps,

--- a/src/hooks/verification/useVerificationOAuthHandler/useVerificationOAuthHandler.ts
+++ b/src/hooks/verification/useVerificationOAuthHandler/useVerificationOAuthHandler.ts
@@ -68,7 +68,7 @@ export const useVerificationOAuthHandler = (): UseVerificationOAuthHandlerReturn
       setDialogProps(newProps)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, isDentityProfileLoading, error])
+  }, [data, isLoading, error])
 
   return {
     dialogProps,

--- a/src/hooks/verification/useVerificationOAuthHandler/utils/createVerificationTransactionFlow.ts
+++ b/src/hooks/verification/useVerificationOAuthHandler/utils/createVerificationTransactionFlow.ts
@@ -3,10 +3,10 @@ import { Hash } from 'viem'
 import { createTransactionItem } from '@app/transaction-flow/transaction'
 import { CreateTransactionFlow } from '@app/transaction-flow/TransactionFlowProvider'
 
-import { UseVerificationOAuthReturnType } from '../../useVerificationOAuth/useVerificationOAuth'
+import { UseDentityProfileReturnType } from '../../useDentityProfile/useDentityProfile'
 
 type Props = Pick<
-  UseVerificationOAuthReturnType,
+  UseDentityProfileReturnType,
   'name' | 'verifier' | 'resolverAddress' | 'verifiedPresentationUri'
 > & {
   userAddress?: Hash

--- a/src/hooks/verification/useVerificationOAuthHandler/utils/dentityHandler.ts
+++ b/src/hooks/verification/useVerificationOAuthHandler/utils/dentityHandler.ts
@@ -11,7 +11,7 @@ import { getDestination } from '@app/routes'
 import { CreateTransactionFlow } from '@app/transaction-flow/TransactionFlowProvider'
 
 import { shortenAddress } from '../../../../utils/utils'
-import { UseVerificationOAuthReturnType } from '../../useVerificationOAuth/useVerificationOAuth'
+import { UseDentityProfileReturnType } from '../../useDentityProfile/useDentityProfile'
 import { createVerificationTransactionFlow } from './createVerificationTransactionFlow'
 
 // Patterns
@@ -49,7 +49,7 @@ export const dentityVerificationHandler =
     createTransactionFlow: CreateTransactionFlow
     t: TFunction
   }) =>
-  (json: UseVerificationOAuthReturnType): VerificationErrorDialogProps => {
+  (json: UseDentityProfileReturnType): VerificationErrorDialogProps => {
     return match(json)
       .with(
         {


### PR DESCRIPTION
When processing the *code* received from dentity.com when returning from their site, the manager app would fail because the app would refresh, causing a refetch of the name info which is one time use only.

FIX:
Split the processing of the code into two hooks:
1. useDentityToken - Is only responsible for the name info from dentity.com. This has a **staleTime** of _Infinity_ and a **queryDependencyType** of _independent_.  This was necessary because the former **queryDependencyType** of _standard_ injects the user's address into the **queryKey**, triggering a refetch when the page is reloaded.
2. useDentityProfile - Processes the dentity token and adds additional information such as the owner, manager, resolver address and current verification uri.

To test the implementation, in the e2e tests, the mock return function has been updated to return an error message on a refetch and a page.reload was added to ensure that the cache is working properly.

I also renamed the functions to make it more clear what the functions do and removed extraneous functions that are not needed since 'dentity' is currently the only service this hook supports at the moment.