### PR TITLE
Add forced completion in registration flow if app detects name is registered

### DIFF
--- a/src/components/pages/profile/[name]/registration/steps/Transactions.tsx
+++ b/src/components/pages/profile/[name]/registration/steps/Transactions.tsx
@@ -24,6 +24,7 @@ import { makeLegacyRegistrationParams } from '@app/utils/registration/makeLegacy
 import { ONE_DAY } from '@app/utils/time'
 
 import { RegistrationReducerDataItem } from '../types'
+import { useCheckRegistered } from '@app/hooks/registration/useCheckRegistered'
 
 const PATTERNS = {
   RegistrationComplete: {
@@ -241,6 +242,8 @@ const Transactions = ({ registrationData, name, callback, onStart }: Props) => {
   })
   const canRegisterOverride = isSimulateRegistrationSuccess && commitTx?.stage !== 'complete'
 
+  const checkRegistered = useCheckRegistered({ name, ownerAddress: address, enabled: registerTx?.stage === 'sent'})
+
   useEffect(() => {
     if (canRegisterOverride) {
       trackEvent({ eventName: 'register_override_triggered' })
@@ -331,10 +334,11 @@ const Transactions = ({ registrationData, name, callback, onStart }: Props) => {
   }, [commitTx, makeCommitNameFlow])
 
   useEffect(() => {
-    if (registerTx?.stage === 'complete') {
+    if (registerTx?.stage === 'complete' || checkRegistered) {
+      stopCurrentFlow()
       callback({ back: false })
     }
-  }, [callback, registerTx?.stage])
+  }, [callback, registerTx?.stage, checkRegistered])
 
   const NormalBackButton = useMemo(
     () => (

--- a/src/components/pages/profile/[name]/registration/steps/Transactions.tsx
+++ b/src/components/pages/profile/[name]/registration/steps/Transactions.tsx
@@ -11,6 +11,7 @@ import MobileFullWidth from '@app/components/@atoms/MobileFullWidth'
 import { StatusDots } from '@app/components/@atoms/StatusDots/StatusDots'
 import { TextWithTooltip } from '@app/components/@atoms/TextWithTooltip/TextWithTooltip'
 import { Card } from '@app/components/Card'
+import { useCheckRegistered } from '@app/hooks/registration/useCheckRegistered'
 import { useExistingCommitment } from '@app/hooks/registration/useExistingCommitment'
 import { useSimulateRegistration } from '@app/hooks/registration/useSimulateRegistration'
 import { useDurationCountdown } from '@app/hooks/time/useDurationCountdown'
@@ -24,7 +25,6 @@ import { makeLegacyRegistrationParams } from '@app/utils/registration/makeLegacy
 import { ONE_DAY } from '@app/utils/time'
 
 import { RegistrationReducerDataItem } from '../types'
-import { useCheckRegistered } from '@app/hooks/registration/useCheckRegistered'
 
 const PATTERNS = {
   RegistrationComplete: {
@@ -242,7 +242,11 @@ const Transactions = ({ registrationData, name, callback, onStart }: Props) => {
   })
   const canRegisterOverride = isSimulateRegistrationSuccess && commitTx?.stage !== 'complete'
 
-  const checkRegistered = useCheckRegistered({ name, ownerAddress: address, enabled: registerTx?.stage === 'sent'})
+  const checkRegistered = useCheckRegistered({
+    name,
+    ownerAddress: address,
+    enabled: registerTx?.stage === 'sent',
+  })
 
   useEffect(() => {
     if (canRegisterOverride) {

--- a/src/hooks/registration/useCheckRegistered.ts
+++ b/src/hooks/registration/useCheckRegistered.ts
@@ -1,0 +1,42 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { useEffect } from 'react'
+import { Address } from 'viem'
+
+import { useOwner } from '../ensjs/public/useOwner'
+import { useWrapperData } from '../ensjs/public/useWrapperData'
+
+export const useCheckRegistered = ({
+  name,
+  ownerAddress,
+  enabled,
+}: {
+  name: string
+  ownerAddress?: Address
+  enabled: boolean
+}) => {
+  const active = !!ownerAddress && enabled
+  const { data: owner } = useOwner({ name, enabled: active })
+  const { data: wrapperData } = useWrapperData({
+    name,
+    enabled: active,
+  })
+  const queryClient = useQueryClient()
+
+  const checkRegistered = owner?.registrant === ownerAddress || wrapperData?.owner === ownerAddress
+
+  // We use an interval to invalidate the query instead of a retry just in case the owner or wrapper data has
+  // residual data which would stop the fetch from retryingand also to avoid the retry limit
+  useEffect(() => {
+    let interval: ReturnType<typeof setInterval>
+    if (active && !checkRegistered) {
+      interval = setInterval(() => {
+        queryClient.invalidateQueries({ queryKey: [{ name }] })
+      }, 5000)
+      // We don't need to clear the interval when checkRegistered is true because it will lead
+      // to a page redirect and the unmounting of the component
+      return () => interval && clearInterval(interval)
+    }
+  }, [active, name, queryClient, checkRegistered])
+
+  return checkRegistered
+}

--- a/src/transaction-flow/utils/shouldSkipTransactionUpdateDuringTest.ts
+++ b/src/transaction-flow/utils/shouldSkipTransactionUpdateDuringTest.ts
@@ -8,7 +8,7 @@ export const shouldSkipTransactionUpdateDuringTest = (
 ) => {
   return (
     process.env.NEXT_PUBLIC_ETH_NODE === 'anvil' &&
-    isTransaction('commitName')(transaction) &&
+    (isTransaction('commitName')(transaction) || isTransaction('registerName')(transaction)) &&
     transaction.data?.name?.startsWith('stuck-commit')
   )
 }


### PR DESCRIPTION
TLDR

Support has reported  an issue where the manager displays an error on the register name step even though the name has finished registration and the user owns the name.

The likely cause is a race condition that is somehow getting the flow stuck and displaying the error for registering an already registered name.

FIX

When register name transaction is sent, begin polling to detect if the user is the owner of the name. If the owner matches the user, force push the Registration Complete view.

HOW TO TEST

Should use dev environment on sepolia or holesky.  This is because the local development anvil chain does not support running useSimulation and the preview may not have the flag that triggers the development flag that will prevent the transactions from updating.

Use the prefix 'stuck-commit' on the name to prevent the transactions from updating.