### PR TITLE
Fix: Names in grace period should not show wrap button

### DIFF
--- a/e2e/specs/stateless/wrapName.spec.ts
+++ b/e2e/specs/stateless/wrapName.spec.ts
@@ -471,3 +471,147 @@ test('Wrapped, emancipated(NPC), 3LD Manager', async ({ login, makeName, makePag
   await transactionModal.autoComplete()
   await expect(morePage.wrapButton).toBeVisible()
 })
+
+test('Should not show wrap button on unwrapped name in Grace period', async ({
+  login,
+  makeName,
+  makePageObject,
+}) => {
+  const name = await makeName({
+    label: 'to-be-wrapped',
+    type: 'legacy',
+    duration: -24 * 60 * 60,
+  })
+
+  const morePage = makePageObject('MorePage')
+  await morePage.goto(name)
+
+  await login.connect()
+
+  await expect(morePage.wrapButton).not.toBeVisible()
+  await expect(morePage.wrapButton).toHaveCount(0)
+})
+
+test('should show wrap button on unwrapped subname in Grace period', async ({
+  login,
+  makeName,
+  makePageObject,
+}) => {
+  const name = await makeName({
+    label: 'to-be-wrapped',
+    type: 'legacy',
+    subnames: [
+      {
+        label: 'sub',
+      },
+    ],
+    duration: -24 * 60 * 60,
+  })
+
+  const morePage = makePageObject('MorePage')
+  const transactionModal = makePageObject('TransactionModal')
+  await morePage.goto(`sub.${name}`)
+
+  await login.connect()
+
+  await expect(morePage.wrapButton).toBeVisible()
+  await expect(morePage.wrapButton).toBeEnabled()
+
+  await morePage.wrapButton.click()
+  await transactionModal.autoComplete()
+
+  await morePage.goto(`sub.${name}`)
+  await expect(morePage.wrapButton).toHaveCount(0)
+})
+
+test('should not show unwrap button on wrapped name in Grace period', async ({
+  login,
+  makeName,
+  makePageObject,
+}) => {
+  const name = await makeName({
+    label: 'wrapped',
+    type: 'wrapped',
+    duration: -24 * 60 * 60,
+  })
+
+  const morePage = makePageObject('MorePage')
+  await morePage.goto(name)
+
+  await login.connect()
+
+  await expect(morePage.unwrapButton).toHaveCount(0)
+})
+
+test('should show unwrap button on wrapped subname in Grace period', async ({
+  login,
+  makeName,
+  makePageObject,
+}) => {
+  const name = await makeName({
+    label: 'to-be-wrapped',
+    type: 'wrapped',
+    owner: 'user',
+    subnames: [
+      {
+        label: 'sub',
+        owner: 'user',
+      },
+    ],
+    duration: -24 * 60 * 60,
+  })
+
+  const morePage = makePageObject('MorePage')
+  const transactionModal = makePageObject('TransactionModal')
+  await morePage.goto(`sub.${name}`)
+
+  await login.connect()
+
+  await expect(morePage.unwrapButton).toBeVisible()
+  await expect(morePage.unwrapButton).toBeEnabled()
+
+  await morePage.unwrapButton.click()
+  await transactionModal.autoComplete()
+
+  await morePage.goto(`sub.${name}`)
+  await expect(morePage.unwrapButton).toHaveCount(0)
+})
+
+test('Wrapped, emancipated(NPC), 3LD Manager should be able to unwrap when parent is in Grace period', async ({
+  login,
+  makeName,
+  makePageObject,
+}) => {
+  const name = await makeName({
+    label: 'wrapped',
+    type: 'wrapped',
+    owner: 'user2',
+    fuses: {
+      named: ['CANNOT_UNWRAP'],
+    },
+    subnames: [
+      {
+        label: 'test',
+        owner: 'user',
+        fuses: {
+          parent: {
+            named: ['PARENT_CANNOT_CONTROL'],
+          },
+        },
+      },
+    ],
+    duration: -24 * 60 * 60,
+  })
+
+  const morePage = makePageObject('MorePage')
+  const transactionModal = makePageObject('TransactionModal')
+  await morePage.goto(`test.${name}`)
+
+  await login.connect()
+
+  await expect(morePage.unwrapButton).toBeVisible()
+  await expect(morePage.unwrapButton).toBeEnabled()
+  await morePage.unwrapButton.click()
+  await transactionModal.autoComplete()
+  await expect(morePage.wrapButton).toBeVisible()
+})

--- a/src/hooks/useBasicName.ts
+++ b/src/hooks/useBasicName.ts
@@ -110,16 +110,6 @@ export const useBasicName = ({
 
   const nameWrapperAddress = useContractAddress({ contract: 'ensNameWrapper' })
   const isWrapped = !!wrapperData
-  const canBeWrapped = useMemo(
-    () =>
-      !!(
-        nameWrapperAddress &&
-        !isWrapped &&
-        normalisedName?.endsWith('.eth') &&
-        !isLabelTooLong(normalisedName)
-      ),
-    [nameWrapperAddress, isWrapped, normalisedName],
-  )
 
   const registrationStatusTimestamp = useMemo(() => {
     if (!isTempPremiumDesynced) return Date.now()
@@ -141,6 +131,19 @@ export const useBasicName = ({
         name: normalisedName,
       })
     : undefined
+
+  const canBeWrapped = useMemo(
+    () =>
+      !!(
+        nameWrapperAddress &&
+        !isWrapped &&
+        normalisedName?.endsWith('.eth') &&
+        !isLabelTooLong(normalisedName) &&
+        !!registrationStatus &&
+        ['registered', 'imported', 'owned'].includes(registrationStatus)
+      ),
+    [nameWrapperAddress, isWrapped, normalisedName, registrationStatus],
+  )
 
   const { data: subgraphRegistrant } = useSubgraphRegistrant({
     name: normalisedName,

--- a/test/mock/makeMockUseBasicName.ts
+++ b/test/mock/makeMockUseBasicName.ts
@@ -253,7 +253,7 @@ export const makeMockUseBasicName = (type: MockUseBasicNameType) => {
       truncatedName: 'name.eth',
       isWrapped: false,
       pccExpired: false,
-      canBeWrapped: true,
+      canBeWrapped: false,
       registrationStatus: 'available' as const,
       isLoading: false,
       isCachedData: false,
@@ -306,7 +306,7 @@ export const makeMockUseBasicName = (type: MockUseBasicNameType) => {
       registrationStatus: 'gracePeriod' as const,
       isWrapped: false,
       pccExpired: false,
-      canBeWrapped: true,
+      canBeWrapped: false,
       isLoading: false,
       isCachedData: false,
     }))
@@ -318,7 +318,7 @@ export const makeMockUseBasicName = (type: MockUseBasicNameType) => {
       registrationStatus: 'gracePeriod' as const,
       isWrapped: false,
       pccExpired: false,
-      canBeWrapped: true,
+      canBeWrapped: false,
       isLoading: false,
       isCachedData: false,
     }))


### PR DESCRIPTION
Unwrapped names should not show wrap name button in other tab.

Will also need to check:
* Shows the button for unwrapped subnames
*. Shows the button for unwrapped onchain imported names/subnames
* Does not show button for off chain names/subnames
* Does not show button for eth (old)
