### PR TITLE
feat(i18n): Improve Spanish warning for non-ASCII characters

### DIFF
--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -1,5 +1,5 @@
 {
-  "title": "Tu nombre de usuario de Web3",
+  "title": "Tu nombre de usuario en Web3",
   "description": "Tu identidad en todo Web3, un nombre para todas tus direcciones de criptomonedas y tu sitio web descentralizado.",
   "loading": "Cargando",
   "unsupportedNetwork": "Red no compatible",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -418,5 +418,18 @@
     "ownerNotManager": "Debes estar conectado como Administrador de este nombre para establecer el registro de verificación. Puedes ver y actualizar el Administrador en la pestaña Propiedad.",
     "wrongAccount": "Debes estar conectado como <strong>{{nameOrAddress}}</strong> para establecer el registro de verificación.",
     "default": "No pudimos verificar tu cuenta. Por favor, regresa a Dentity e inténtalo de nuevo."
-  }
+  },
+  "homoglyph": {
+  "content": "Este nombre contiene caracteres válidos en español (á, é, í, ó, ú, ü, ñ). A diferencia de otros idiomas:",
+  "points": [
+    "Son ortografía correcta (ej: «canción.eth», «México.eth»)",
+    "NO son sustitutos de caracteres ingleses",
+    "Se conservan exactamente como los escribes:",
+    "- «sótano.eth» ≠ «sotano.eth»",
+    "- «pingüino.eth» ≠ «pinguino.eth»",
+    "Algunos sistemas antiguos podrían no soportarlos"
+  ],
+  "link": "https://unicode.org/reports/tr36/",
+  "title": "Caracteres del español"
+}
 }


### PR DESCRIPTION
## Purpose  
This PR improves the warning message for Spanish speakers using valid characters (á, é, í, ó, ú, ü, ñ) in ENS names:  
- Reduces false alarms for correct Spanish orthography  
- Educates users about character preservation  
- References Unicode TR36 for technical accuracy  

## Changes  
- Added complete list of Spanish diacritics  
- Clear examples: «canción.eth» ≠ «cancion.eth»  
- Compatibility warnings for legacy systems  

## References  
- [Unicode TR36](https://unicode.org/reports/tr36/) (Confusable Characters)  
- Related discussion: #1652 (legacy app PR)  