### PR TITLE
Add scripts for https test nets

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "dev:holesky": "NEXT_PUBLIC_CHAIN_NAME=holesky pnpm dev",
     "dev:sepolia": "NEXT_PUBLIC_CHAIN_NAME=sepolia pnpm dev",
     "dev:https": "next dev --experimental-https --port 443",
+    "dev:https:holesky": "NEXT_PUBLIC_CHAIN_NAME=holesky pnpm dev:https",
+    "dev:https:sepolia": "NEXT_PUBLIC_CHAIN_NAME=sepolia pnpm dev:https",
     "dev:nlocal": "NEXT_PUBLIC_PROVIDER=http://localhost:8545 NEXT_PUBLIC_AVUP_ENDPOINT=http://localhost:8787 pnpm dev",
     "dev:localname": "NEXT_PUBLIC_PROVIDER=\"http://$(\"hostname\"):8545\" && NEXT_PUBLIC_AVUP_ENDPOINT=\"http://$(\"hostname\"):8787\" && NEXT_PUBLIC_GRAPH_URI=\"http://$(\"hostname\"):8000/subgraphs/name/graphprotocol/ens\" && pnpm dev",
     "dev:glocal": "SWC_CACHE=false rm -rf .next && NEXT_PUBLIC_GRAPH_URI=http://localhost:8000/subgraphs/name/graphprotocol/ens NEXT_PUBLIC_ETH_NODE=anvil pnpm dev:nlocal",


### PR DESCRIPTION
When testing safe transactions QA needs to alter chains.ts in order to set the chain to a testate. This adds a vulnerability for them to commit the change. Adding script so that they don't need to do this.