### PR TITLE
Remove dev telegram from Namechain page

### DIFF
--- a/public/locales/en/ensv2.json
+++ b/public/locales/en/ensv2.json
@@ -18,11 +18,6 @@
       "text": "Layer 2 enables seamless .eth name use across blockchains with trustless connections."
     }
   },
-  "learn-more": {
-    "title": "Want to learn more?",
-    "caption": "If you’re interested in learning more and building on Namechain, join the ENS Developer Telegram.",
-    "button": "Developer Telegram"
-  },
   "announcement": {
     "title": "Announcements",
     "l2": {

--- a/src/pages/ens-v2.tsx
+++ b/src/pages/ens-v2.tsx
@@ -272,22 +272,6 @@ export default function ENSv2() {
         referrerPolicy="strict-origin-when-cross-origin"
         allowFullScreen
       />
-      <CenteredCard>
-        <Typography fontVariant="headingTwo" as="h2">
-          {t('learn-more.title')}
-        </Typography>
-        <Typography fontVariant="body">{t('learn-more.caption')}</Typography>
-        <Button
-          as="a"
-          href="https://t.me/+cx5my3EQWH8wODYx"
-          width="max"
-          colorStyle="greenPrimary"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {t('learn-more.button')}
-        </Button>
-      </CenteredCard>
       <GridOneToThree>
         <CardWithEmoji>
           <Typography fontVariant="headingTwo" as="h2">
@@ -298,7 +282,7 @@ export default function ENSv2() {
             as="a"
             href="https://roadmap.ens.domains/l2-roadmap"
             width="max"
-            colorStyle="greenSecondary"
+            colorStyle="greenPrimary"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
Caused spam, so I disabled the Telegram invite link. I thought of editing the copy, but figure its better to just remove for now so its not 404'ing.