### PR TITLE
fix: safari csp

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -64,6 +64,12 @@ const firefoxRewrite: PagesFunction = async ({ request, next }) => {
       .transform(response)
   }
 
+  // safari CSP exception
+  if (userAgent?.includes('safari/') && userAgent.includes('version/')) {
+    response.headers.set('Content-Security-Policy', cspOnlyFrameAncestors)
+    return response
+  }
+
   // default headers
   response.headers.set('Content-Security-Policy', cspWithFrameAncestors)
   return response

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -52,7 +52,7 @@ const staticHandler: PagesFunction = async ({ request, next, env }) => {
   return next()
 }
 
-const firefoxRewrite: PagesFunction = async ({ request, next }) => {
+const cspRewrite: PagesFunction = async ({ request, next }) => {
   const userAgent = request.headers.get('user-agent')?.toLowerCase()
   const response = await next()
 
@@ -172,4 +172,4 @@ const pathRewriter: PagesFunction = async ({ request, next }) => {
   return next()
 }
 
-export const onRequest = [staticHandler, firefoxRewrite, pathRewriter]
+export const onRequest = [staticHandler, cspRewrite, pathRewriter]


### PR DESCRIPTION
fixes #608 

safari is similar to firefox in that we can remove all but `frame-ancestors` from the CSP header, and utilise the CSP meta tag