### PR TITLE
fix: disconnected gas estimates

### DIFF
--- a/src/hooks/chain/useEstimateGasWithStateOverride.ts
+++ b/src/hooks/chain/useEstimateGasWithStateOverride.ts
@@ -30,7 +30,7 @@ import {
   Prettify,
   QueryConfig,
 } from '@app/types'
-import { emptyAddress } from '@app/utils/constants'
+import { DISCONNECTED_PLACEHOLDER_ADDRESS, emptyAddress } from '@app/utils/constants'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
 import { prepareQueryOptions } from '@app/utils/prepareQueryOptions'
 import { createAccessList } from '@app/utils/query/createAccessList'
@@ -251,7 +251,7 @@ export const estimateGasWithStateOverrideQueryFn =
         ? {}
         : {
             account: {
-              address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+              address: DISCONNECTED_PLACEHOLDER_ADDRESS,
               type: 'json-rpc',
             },
           }),

--- a/src/hooks/gasEstimation/calculateTransactions.ts
+++ b/src/hooks/gasEstimation/calculateTransactions.ts
@@ -72,7 +72,7 @@ export const calculateTransactions = ({
         registrationStateOverride,
         {
           address: registrationParams.owner,
-          balance: price ? (price.base + price.premium) * 2n + parseEther('10000') : undefined,
+          balance: price ? (price.base + price.premium) * 2n + parseEther('1000000') : undefined,
         },
       ],
     },

--- a/src/hooks/gasEstimation/useEstimateRegistration.ts
+++ b/src/hooks/gasEstimation/useEstimateRegistration.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 
 import { RegistrationReducerDataItem } from '@app/components/pages/profile/[name]/registration/types'
+import { DISCONNECTED_PLACEHOLDER_ADDRESS } from '@app/utils/constants'
 import { deriveYearlyFee } from '@app/utils/utils'
 
 import { useAccountSafely } from '../account/useAccountSafely'
@@ -26,7 +27,7 @@ export const useEstimateFullRegistration = ({
 
   const registrationParams = useRegistrationParams({
     name,
-    owner: address || '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    owner: address || DISCONNECTED_PLACEHOLDER_ADDRESS,
     registrationData,
   })
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -33,3 +33,6 @@ export const ENS_LINKS = {
   HOMEPAGE: 'https://ens.domains/',
   YOUTUBE: 'https://www.youtube.com/ensdomains',
 }
+
+export const DISCONNECTED_PLACEHOLDER_ADDRESS =
+  '0x0000000000000000000000000000000000001234' as const


### PR DESCRIPTION
previously when a user was disconnected, in place of their address for estimating gas for transactions, we'd use `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266` - a standard test address derived from `test test test test test test test test test test test junk`.
EIP-7702 was recently launched on mainnet, which allows a user to delegate the functionality of their address to a contract. someone delegated the test address to a sweeper contract, but that sweeper contract doesn't implement `onERC1155Received`, so the registration transaction reverts.

changes:
- set disconnected placeholder account to `0x0000000000000000000000000000000000001234`, an address no one has the private key for
- also massively increased the override balance to 1,000,000 ETH to ensure gas can still be estimated for names in temporary premium (separate issue)