### PR TITLE
Issues when interacting with primary name on Sepolia/Holesky

### DIFF
--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -26,13 +26,35 @@ export const mainnetWithEns = addEnsContractsWithSubgraph({
   apiKey: ENS_SUBGRAPH_API_KEY,
 })
 
-export const sepoliaWithEns = addEnsContractsWithSubgraph({
+export const sepoliaWithEnsBase = addEnsContractsWithSubgraph({
   chain: sepolia,
   subgraphId: 'G1SxZs317YUb9nQX3CC98hDyvxfMJNZH5pPRGpNrtvwN',
   apiKey: ENS_SUBGRAPH_API_KEY,
 })
 
-export const holeskyWithEns = addEnsContracts(holesky)
+export const sepoliaWithEns = {
+  ...sepoliaWithEnsBase,
+  contracts: {
+    ...sepoliaWithEnsBase.contracts,
+    ensEthRegistrarController: { address: '0xFED6a969AaA60E4961FCD3EBF1A2e8913ac65B72' as const },
+    ensPublicResolver: { address: '0x8FADE66B79cC9f707aB26799354482EB93a5B7dD' as const },
+    ensReverseRegistrar: { address: '0xA0a1AbcDAe1a2a4A2EF8e9113Ff0e02DD81DC0C6' as const },
+  },
+} as unknown as typeof sepoliaWithEnsBase
+
+console.log('sepoliaWithEns', sepoliaWithEns)
+
+export const holeskyWithEnsBase = addEnsContracts(holesky)
+
+export const holeskyWithEns = {
+  ...holeskyWithEnsBase,
+  contracts: {
+    ...holeskyWithEnsBase.contracts,
+    ensEthRegistrarController: { address: '0x179Be112b24Ad4cFC392eF8924DfA08C20Ad8583' as const },
+    ensPublicResolver: { address: '0x9010A27463717360cAD99CEA8bD39b8705CCA238' as const },
+    ensReverseRegistrar: { address: '0x132AC0B116a73add4225029D1951A9A707Ef673f ' as const },
+  },
+} as unknown as typeof holeskyWithEnsBase
 
 export const chainsWithEns = [
   mainnetWithEns,

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -42,8 +42,6 @@ export const sepoliaWithEns = {
   },
 } as unknown as typeof sepoliaWithEnsBase
 
-console.log('sepoliaWithEns', sepoliaWithEns)
-
 export const holeskyWithEnsBase = addEnsContracts(holesky)
 
 export const holeskyWithEns = {

--- a/src/constants/resolverAddressData.test.ts
+++ b/src/constants/resolverAddressData.test.ts
@@ -12,7 +12,9 @@ it('should have the most recent resolver as the first address', async () => {
   expect(KNOWN_RESOLVER_DATA['1']![0].address).toEqual(
     getChainContractAddress({ chain: mainnetWithEns, contract: 'ensPublicResolver' }),
   )
-  expect(KNOWN_RESOLVER_DATA['11155111']![0].address).toEqual(
+
+  // TODO: Switch back to the first address after the next release of ens-contracts (1.6.0)
+  expect(KNOWN_RESOLVER_DATA['11155111']![1].address).toEqual(
     getChainContractAddress({ chain: sepoliaWithEns, contract: 'ensPublicResolver' }),
   )
   // localhost is not included by default in the resolver data


### PR DESCRIPTION
For Holesky and Sepolia, the latest registrar controller has some configuration issues so we rolled them back to a previous version by overriding the contracts on the chain