### PR TITLE
fix: placeholder zorb in avatar

### DIFF
--- a/src/components/@atoms/NameDetailItem/NameDetailItem.tsx
+++ b/src/components/@atoms/NameDetailItem/NameDetailItem.tsx
@@ -174,7 +174,7 @@ export const NameDetailItem = ({
             }}
           >
             <Avatar
-              placeholder={`url(${zorb})`}
+              placeholder={zorb}
               label={truncatedName || name}
               src={avatar || zorb}
               data-testid="name-detail-item-avatar"

--- a/src/components/AvatarWithZorb.tsx
+++ b/src/components/AvatarWithZorb.tsx
@@ -81,7 +81,7 @@ export const NameAvatar = ({
 
   return (
     <Wrapper $size={size}>
-      <Avatar {...props} placeholder={`url(${zorb})`} src={avatar || zorb} />
+      <Avatar {...props} placeholder={zorb} src={avatar || zorb} />
     </Wrapper>
   )
 }
@@ -102,7 +102,7 @@ export const AvatarWithZorb = ({
   const zorb = useZorb(address || name || '', address ? 'address' : 'name')
   return (
     <Wrapper $size={size}>
-      <Avatar {...props} placeholder={`url(${zorb})`} src={avatar || zorb} />
+      <Avatar {...props} placeholder={zorb} src={avatar || zorb} />
     </Wrapper>
   )
 }

--- a/src/components/AvatarWithZorb.tsx
+++ b/src/components/AvatarWithZorb.tsx
@@ -47,7 +47,11 @@ const Wrapper = styled.div<{ $size?: QuerySpace }>(
         `}
 
     & > div {
-      background: none;
+      background: radial-gradient(
+        circle closest-side,
+        ${theme.colors.backgroundSecondary} 0 calc(100% - 2px),
+        transparent calc(100% - 2px) 100%
+      );
     }
   `,
 )

--- a/src/components/AvatarWithZorb.tsx
+++ b/src/components/AvatarWithZorb.tsx
@@ -45,9 +45,9 @@ const Wrapper = styled.div<{ $size?: QuerySpace }>(
                 : null
             })}
         `}
-    
-    img {
-      display: block;
+
+    & > div {
+      background: none;
     }
   `,
 )


### PR DESCRIPTION
in https://github.com/ensdomains/thorin/commit/7fd8153b0d8b4e11ee23de216a4a64ccc2b3a4db the `<Avatar />` component changed from using the CSS `background` property for an avatar placeholder, to using `src` (on `<img />`). 

with this change, the app is no longer using the zorb as a placeholder, instead it is firing a broken request which 404s every time. zorbs still show up in most cases, because when an avatar record is not available, the zorb value is used for the `src` parameter. however in the case that a broken but valid avatar record is used, a broken image placeholder is used which looks completely out of place. example name: https://sepolia.app.ens.domains/swagalicious.eth

changes:
- removed css URL formatting for placeholders
- removed background colour on avatar to avoid alias artifacts 
