### PR TITLE
ux(unicode): info for valid diacritics; warning only for mixed scripts (homoglyph risk)

### DIFF
--- a/public/locales/en/profile.json
+++ b/public/locales/en/profile.json
@@ -53,7 +53,7 @@
       "warnings": {
         "wrappedDNS": "DNS names can be reclaimed by the DNS owner at any time. Do not purchase DNS names.",
         "offchain": "Offchain names do not currently appear in your 'Names' list. <a>Learn more</a>",
-        "homoglyph": "This name contains non-ASCII characters. There may be characters that look identical or very similar to other characters, which could be used to deceive readers. <a>Learn more about homoglyphs</a>"
+        "homoglyph": "This name uses non-ASCII characters (for example, accents). That’s common in many languages, such as Spanish. If this is your intended spelling, you can proceed. <a>Learn more about Unicode security guidance</a>"
       }
     },
     "records": {

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -1,5 +1,5 @@
 {
-  "title": "Tu nombre de usuario de Web3",
+  "title": "Tu nombre de usuario en Web3",
   "description": "Tu identidad en todo Web3, un nombre para todas tus direcciones de criptomonedas y tu sitio web descentralizado.",
   "loading": "Cargando",
   "unsupportedNetwork": "Red no compatible",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -418,5 +418,18 @@
     "ownerNotManager": "Debes estar conectado como Administrador de este nombre para establecer el registro de verificación. Puedes ver y actualizar el Administrador en la pestaña Propiedad.",
     "wrongAccount": "Debes estar conectado como <strong>{{nameOrAddress}}</strong> para establecer el registro de verificación.",
     "default": "No pudimos verificar tu cuenta. Por favor, regresa a Dentity e inténtalo de nuevo."
-  }
+  },
+  "homoglyph": {
+  "content": "Este nombre contiene caracteres válidos en español (á, é, í, ó, ú, ü, ñ). A diferencia de otros idiomas:",
+  "points": [
+    "Son ortografía correcta (ej: «canción.eth», «México.eth»)",
+    "NO son sustitutos de caracteres ingleses",
+    "Se conservan exactamente como los escribes:",
+    "- «sótano.eth» ≠ «sotano.eth»",
+    "- «pingüino.eth» ≠ «pinguino.eth»",
+    "Algunos sistemas antiguos podrían no soportarlos"
+  ],
+  "link": "https://unicode.org/reports/tr36/",
+  "title": "Caracteres del español"
+}
 }

--- a/public/locales/es/profile.json
+++ b/public/locales/es/profile.json
@@ -53,7 +53,7 @@
       "warnings": {
         "wrappedDNS": "Los nombres DNS pueden ser reclamados por el Propietario DNS en cualquier momento. No compres nombres DNS.",
         "offchain": "Los nombres offchain no aparecen actualmente en tu lista de 'Nombres'. <a>Más información</a>",
-        "homoglyph": "Este nombre contiene caracteres no ASCII. Podrían existir caracteres idénticos o muy similares a otros, lo cual puede usarse para engañar a los lectores. <a>Más información sobre homoglifos</a>"
+        "homoglyph": "Este nombre usa caracteres no ASCII (por ejemplo, acentos). Es común en idiomas como el español. Si es la ortografía que deseas, puedes continuar. <a>Más información sobre Unicode</a>"
       }
     },
     "records": {

--- a/src/components/pages/profile/[name]/tabs/ProfileTab.tsx
+++ b/src/components/pages/profile/[name]/tabs/ProfileTab.tsx
@@ -129,7 +129,7 @@ const ProfileTab = ({ nameDetails, name }: Props) => {
             />
           </Helper>
         )}
-        {nameDetails.isNonASCII && (
+        {nameDetails.isNonASCII && nameDetails.isLatinOnly && !nameDetails.hasMixedScripts && (
           <Helper alert="info" alignment="horizontal">
             <Trans
               i18nKey="tabs.profile.warnings.homoglyph"
@@ -138,6 +138,11 @@ const ProfileTab = ({ nameDetails, name }: Props) => {
                 a: <Outlink href="https://unicode.org/reports/tr36/" />,
               }}
             />
+          </Helper>
+        )}
+        {(nameDetails.isNonASCII && nameDetails.hasMixedScripts) && (
+          <Helper alert="warning" alignment="horizontal">
+            {t('tabs.profile.warnings.homoglyph')}
           </Helper>
         )}
         {isWrapped && !normalisedName.endsWith('.eth') && (

--- a/src/components/pages/profile/[name]/tabs/ProfileTab.tsx
+++ b/src/components/pages/profile/[name]/tabs/ProfileTab.tsx
@@ -130,12 +130,12 @@ const ProfileTab = ({ nameDetails, name }: Props) => {
           </Helper>
         )}
         {nameDetails.isNonASCII && (
-          <Helper alert="warning" alignment="horizontal">
+          <Helper alert="info" alignment="horizontal">
             <Trans
               i18nKey="tabs.profile.warnings.homoglyph"
               ns="profile"
               components={{
-                a: <Outlink href={getSupportLink('homoglyphs')} />,
+                a: <Outlink href="https://unicode.org/reports/tr36/" />,
               }}
             />
           </Helper>

--- a/src/hooks/useValidate.ts
+++ b/src/hooks/useValidate.ts
@@ -10,6 +10,9 @@ export type ValidationResult = Prettify<
     isNonASCII: boolean | undefined
     labelCount: number
     labelDataArray: ParsedInputResult['labelDataArray']
+    hasEmoji?: boolean
+    hasMixedScripts?: boolean
+    isLatinOnly?: boolean
   }
 >
 
@@ -25,6 +28,10 @@ export const validate = (input: string) => {
   const decodedInput = tryDecodeURIComponent(input)
   const { normalised: name, ...parsedInput } = parseInput(decodedInput)
   const isNonASCII = parsedInput.labelDataArray.some((dataItem) => dataItem.type !== 'ASCII')
+  const scriptTypes = new Set(parsedInput.labelDataArray.map((d) => d.type).filter((t) => t && t !== 'ASCII'))
+  const hasMixedScripts = scriptTypes.size > 1
+  const isLatinOnly = scriptTypes.size === 1 && scriptTypes.has('Latin')
+  const hasEmoji = parsedInput.labelDataArray.some((d) => Boolean((d as any).emoji))
   const outputName = name || input
 
   return {
@@ -33,6 +40,9 @@ export const validate = (input: string) => {
     beautifiedName: tryBeautify(outputName),
     isNonASCII,
     labelCount: parsedInput.labelDataArray.length,
+    hasEmoji,
+    hasMixedScripts,
+    isLatinOnly,
   }
 }
 
@@ -47,6 +57,9 @@ const defaultData = Object.freeze({
   is2LD: undefined,
   isETH: undefined,
   labelDataArray: [],
+  hasEmoji: undefined as boolean | undefined,
+  hasMixedScripts: undefined as boolean | undefined,
+  isLatinOnly: undefined as boolean | undefined,
 })
 
 type UseValidateParameters = {


### PR DESCRIPTION
This PR improves the UX for international names:\n\n- Show informational banner for valid non-ASCII names that are Latin-only (e.g., diacritics in Spanish), with a clear, inclusive message.\n- Keep a Warning banner only when scripts are mixed (potential confusables).\n- Link "Learn more" to Unicode TR36 for security guidance.\n\nImplementation details:\n- Expose hasMixedScripts / isLatinOnly / hasEmoji from useValidate (based on ensjs parseInput labelDataArray).\n- Gate the ProfileTab helper banner accordingly.\n- Update en/es copy for clarity.\n\nHappy to adjust wording, logic, or move this gating lower if preferred.\n