### PR TITLE
Add dnsprovejs@0.5.1 patch for RFC-compliant DoH queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -294,7 +294,8 @@
       "node-forge@1.3.1": "patches/node-forge@1.3.1.patch",
       "react-confetti@6.1.0": "patches/react-confetti@6.1.0.patch",
       "hardhat-deploy@0.12.4": "patches/hardhat-deploy@0.12.4.patch",
-      "@nomicfoundation/hardhat-viem@2.0.3": "patches/@nomicfoundation%2Fhardhat-viem@2.0.3.patch"
+      "@nomicfoundation/hardhat-viem@2.0.3": "patches/@nomicfoundation%2Fhardhat-viem@2.0.3.patch",
+      "@ensdomains/dnsprovejs@0.5.1": "patches/@ensdomains__dnsprovejs@0.5.1.patch"
     }
   },
   "packageManager": "pnpm@9.3.0"

--- a/patches/@ensdomains__dnsprovejs@0.5.1.patch
+++ b/patches/@ensdomains__dnsprovejs@0.5.1.patch
@@ -1,0 +1,37 @@
+diff --git a/dist/prove.js b/dist/prove.js
+index 66315faaac8dc0640bf0cc7760e315da7f67d570..4b32e7d883d4129039173430cb7d924e8d50f41a 100644
+--- a/dist/prove.js
++++ b/dist/prove.js
+@@ -43,6 +43,13 @@ function encodeURLParams(p) {
+         .map((kv) => kv.map(encodeURIComponent).join('='))
+         .join('&');
+ }
++// Convert standard base64 to base64url (RFC 4648 §5)
++function base64ToBase64Url(base64) {
++    return base64
++        .replace(/\+/g, '-')
++        .replace(/\//g, '_')
++        .replace(/=/g, '');
++}
+ function getKeyTag(key) {
+     const data = packet.dnskey.encode(key.data).slice(2);
+     let keytag = 0;
+@@ -87,11 +94,13 @@ function dohQuery(url) {
+     return function getDNS(q) {
+         return __awaiter(this, void 0, void 0, function* () {
+             const buf = packet.encode(q);
+-            const response = yield fetch(`${url}?${encodeURLParams({
+-                ct: 'application/dns-udpwireformat',
+-                dns: buf.toString('base64'),
+-                ts: Date.now().toString(),
+-            })}`);
++            // RFC 8484: Use base64url encoding and Accept header
++            const dnsParam = base64ToBase64Url(buf.toString('base64'));
++            const response = yield fetch(`${url}?dns=${encodeURIComponent(dnsParam)}`, {
++                headers: {
++                    'accept': 'application/dns-message'
++                }
++            });
+             return packet.decode(Buffer.from(yield response.arrayBuffer()));
+         });
+     };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ overrides:
   wrtc: https://registry.npmjs.org/@koush/wrtc/-/wrtc-0.5.2.tgz
 
 patchedDependencies:
+  '@ensdomains/dnsprovejs@0.5.1':
+    hash: dgob3meb73tkxsoa44yxrlgffu
+    path: patches/@ensdomains__dnsprovejs@0.5.1.patch
   '@nomicfoundation/hardhat-viem@2.0.3':
     hash: znglrikwqnjywwr7ebopjjz3mm
     path: patches/@nomicfoundation%2Fhardhat-viem@2.0.3.patch
@@ -9947,7 +9950,7 @@ snapshots:
       '@noble/curves': 1.8.1
       '@scure/base': 1.2.4
 
-  '@ensdomains/dnsprovejs@0.5.1':
+  '@ensdomains/dnsprovejs@0.5.1(patch_hash=dgob3meb73tkxsoa44yxrlgffu)':
     dependencies:
       '@noble/hashes': 1.7.1
       dns-packet: 5.6.1
@@ -9981,7 +9984,7 @@ snapshots:
       '@adraffy/ens-normalize': 1.10.1
       '@ensdomains/address-encoder': 1.1.3
       '@ensdomains/content-hash': 3.1.0-rc.1
-      '@ensdomains/dnsprovejs': 0.5.1
+      '@ensdomains/dnsprovejs': 0.5.1(patch_hash=dgob3meb73tkxsoa44yxrlgffu)
       abitype: 1.0.5(typescript@5.7.3)(zod@3.25.75)
       dns-packet: 5.6.1
       graphql: 16.11.0


### PR DESCRIPTION
This patch fixes DNS-over-HTTPS queries to properly comply with RFC 8484 and RFC 4648 §5:
- Adds base64ToBase64Url function to convert standard base64 to base64url encoding
- Updates dohQuery to use base64url encoding for DNS parameters
- Sets correct Accept: application/dns-message header

Ported from ensjs-v3 repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)