### PR TITLE
Fix loading issues on address page when reverse resolution fails

### DIFF
--- a/src/hooks/ensjs/public/usePrimaryName.ts
+++ b/src/hooks/ensjs/public/usePrimaryName.ts
@@ -1,4 +1,5 @@
 import { QueryFunctionContext, useQuery } from '@tanstack/react-query'
+import { ContractFunctionExecutionError } from 'viem'
 import { readContract } from 'viem/actions'
 
 import { universalResolverReverseSnippet } from '@ensdomains/ensjs/contracts'
@@ -37,8 +38,14 @@ export const getPrimaryNameQueryFn =
 
     const client = config.getClient({ chainId })
 
-    // Get the standard getName response
-    const res = await getName(client, { address, ...params })
+    let res: Awaited<ReturnType<typeof getName>>
+    try {
+      // Get the standard getName response
+      res = await getName(client, { address, ...params })
+    } catch (e) {
+      if (e instanceof ContractFunctionExecutionError) return null
+      throw e
+    }
 
     if (!res || !res.name || (!res.match && !params.allowMismatch)) return null
 


### PR DESCRIPTION
## Summary
- Handle `ContractFunctionExecutionError` in `getPrimaryNameQueryFn` to gracefully return `null` when reverse name resolution fails
- Prevents query failures that block the address page from loading
- Allows the address page to display even when `getName()` throws contract execution errors

## Test plan
- [ ] Verify address page loads successfully when reverse resolution fails
- [ ] Verify normal reverse resolution still works correctly
- [ ] Test with addresses that have no reverse records
- [ ] Test with addresses that have valid reverse records

🤖 Generated with [Claude Code](https://claude.com/claude-code)