### PR TITLE
Update Playwright to v1.56.1

### DIFF
--- a/.github/workflows/test-wallet.yaml
+++ b/.github/workflows/test-wallet.yaml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.55.0-jammy
+      image: mcr.microsoft.com/playwright:v1.56.1-jammy
     steps:
       - uses: actions/checkout@v4
 

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "next-dev-https": "^0.1.2",
     "next-router-mock": "^0.9.10",
     "pako": "^2.1.0",
-    "playwright-core": "^1.55.0",
+    "playwright-core": "^1.56.1",
     "postcss-styled-syntax": "^0.7.1",
     "prettier": "3.0.3",
     "sitemap": "^7.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,7 +322,7 @@ importers:
         version: 1.50.1
       '@tenkeylabs/dappwright':
         specifier: ^2.11.2
-        version: 2.11.2(playwright-core@1.55.0)
+        version: 2.11.2(playwright-core@1.56.1)
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0
@@ -459,8 +459,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       playwright-core:
-        specifier: ^1.55.0
-        version: 1.55.0
+        specifier: ^1.56.1
+        version: 1.56.1
       postcss-styled-syntax:
         specifier: ^0.7.1
         version: 0.7.1(postcss@8.5.3)
@@ -6966,8 +6966,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright-core@1.55.0:
-    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
+  playwright-core@1.56.1:
+    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -12593,10 +12593,10 @@ snapshots:
       '@tanstack/query-core': 5.81.5
       react: 18.3.1
 
-  '@tenkeylabs/dappwright@2.11.2(playwright-core@1.55.0)':
+  '@tenkeylabs/dappwright@2.11.2(playwright-core@1.56.1)':
     dependencies:
       node-stream-zip: 1.15.0
-      playwright-core: 1.55.0
+      playwright-core: 1.56.1
 
   '@testing-library/dom@10.4.0':
     dependencies:
@@ -16817,7 +16817,7 @@ snapshots:
 
   playwright-core@1.50.1: {}
 
-  playwright-core@1.55.0: {}
+  playwright-core@1.56.1: {}
 
   playwright@1.50.1:
     dependencies:


### PR DESCRIPTION
## Summary

Updates Playwright to v1.56.1 across the codebase.

## Changes

- Update `playwright-core` dependency to v1.56.1
- Update CI workflow to use `mcr.microsoft.com/playwright:v1.56.1-jammy` container

## Testing

- CI will run with updated Playwright version

🤖 Generated with [Claude Code](https://claude.com/claude-code)