### PR TITLE
fix: broken url to support page

### DIFF
--- a/src/components/@molecules/TransactionDialogManager/stage/TransactionStageModal.tsx
+++ b/src/components/@molecules/TransactionDialogManager/stage/TransactionStageModal.tsx
@@ -220,7 +220,7 @@ export const LoadBar = ({ status, sendTime }: { status: Status; sendTime: number
         <Outlink
           iconPosition="before"
           icon={QuestionCircleSVG}
-          href="https://support.ens.domains/en/articles/7982906-long-running-transactions"
+          href="https://support.ens.domains/en/articles/13608541-transaction-troubleshooting"
         >
           {t('transaction.dialog.sent.learn')}
         </Outlink>


### PR DESCRIPTION
Fix broken URL shown when updating records at `https://app.ens.domains/<name>.eth?tab=records`

https://app.ens.domains/elimu.eth?tab=records

> <img width="868" height="333" alt="Screenshot 2026-02-07 154142" src="https://github.com/user-attachments/assets/1dccbde3-609a-4164-88c5-4772a4fea20a" />

Points to non-existing page: https://support.ens.domains/en/articles/7982906-long-running-transactions

> <img width="1495" height="668" alt="Screenshot 2026-02-07 154241" src="https://github.com/user-attachments/assets/2b895591-170d-42c6-97fd-741169417f1a" />
