### PR TITLE
fix: use calendar-aware year calculation in renew modal to prevent infinite loop

### DIFF
--- a/src/components/@molecules/DateSelection/DateSelection.tsx
+++ b/src/components/@molecules/DateSelection/DateSelection.tsx
@@ -6,9 +6,9 @@ import { Typography } from '@ensdomains/thorin'
 
 import { Calendar } from '@app/components/@atoms/Calendar/Calendar'
 import { PlusMinusControl } from '@app/components/@atoms/PlusMinusControl/PlusMinusControl'
-import { roundDurationWithDay, secondsFromDateDiff } from '@app/utils/date'
+import { calculateDatesDiff, roundDurationWithDay, secondsFromDateDiff } from '@app/utils/date'
 import { isInsideSafe } from '@app/utils/safe'
-import { formatDurationOfDates, secondsToYears } from '@app/utils/utils'
+import { formatDurationOfDates } from '@app/utils/utils'
 
 const YearsViewSwitch = styled.button(
   ({ theme }) => css`
@@ -59,7 +59,10 @@ export const DateSelection = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [minSeconds, seconds])
 
-  const dateInYears = Math.floor(secondsToYears(seconds))
+  const dateInYears = calculateDatesDiff(
+    new Date(currentTime * 1000),
+    new Date((currentTime + seconds) * 1000),
+  ).diff.years
 
   // When the duration type is years, normalise the seconds to a year value
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fix infinite increment bug in the renew modal when entering large year values (e.g. 1600)
- **Root cause:** Feedback loop between a leap-day-ignorant seconds-to-years conversion (`Math.floor(seconds / ONE_YEAR)` where `ONE_YEAR = 365 * 24 * 3600`) and a leap-day-aware years-to-seconds conversion (`Date.setFullYear()`). For large values, the leap day accumulation caused the year count to keep increasing on each render.
- **Fix:** Replace the naive `secondsToYears` floor division with `calculateDatesDiff(startDate, endDate).diff.years`, which uses calendar-aware date arithmetic consistent with the years-to-seconds path, creating a stable roundtrip.

**File:** `src/components/@molecules/DateSelection/DateSelection.tsx`

Fixes #1076

## Test plan
- [ ] Enter year value of 1600 in the renew modal — should not keep incrementing
- [ ] Enter normal values (1-10 years) — should work as before
- [ ] Switch between year and date views — should remain consistent