### PR TITLE
Hide gas savings banner when savings are minimal

### DIFF
--- a/src/components/@atoms/RegistrationTimeComparisonBanner/RegistrationTimeComparisonBanner.test.tsx
+++ b/src/components/@atoms/RegistrationTimeComparisonBanner/RegistrationTimeComparisonBanner.test.tsx
@@ -2,7 +2,10 @@ import { render, screen, waitFor } from '@app/test-utils'
 
 import { describe, expect, it } from 'vitest'
 
-import { RegistrationTimeComparisonBanner } from './RegistrationTimeComparisonBanner'
+import {
+  hasMeaningfulGasSavings,
+  RegistrationTimeComparisonBanner,
+} from './RegistrationTimeComparisonBanner'
 
 describe('RegistrationTimeComparisonBanner', () => {
   it('should render correctly', async () => {
@@ -18,5 +21,31 @@ describe('RegistrationTimeComparisonBanner', () => {
     })
     expect(screen.getByText(`unit.gas.33%`))
     expect(screen.getByText(`unit.gas.17%`))
+  })
+})
+
+describe('hasMeaningfulGasSavings', () => {
+  it('should return true when gas fee is high relative to yearly fee', () => {
+    const yearlyFee = 1000000000000000000n // 1 ETH
+    const transactionFee = 1000000000000000000n // 1 ETH (equal to yearly fee)
+    expect(hasMeaningfulGasSavings(yearlyFee, transactionFee)).toBe(true)
+  })
+
+  it('should return true when savings are at the 5% threshold', () => {
+    const yearlyFee = 1000000000000000000n // 1 ETH
+    const transactionFee = 100000000000000000n // 0.1 ETH (gives ~7% savings)
+    expect(hasMeaningfulGasSavings(yearlyFee, transactionFee)).toBe(true)
+  })
+
+  it('should return false when gas fee is very low relative to yearly fee', () => {
+    const yearlyFee = 1000000000000000000n // 1 ETH
+    const transactionFee = 10000000000000000n // 0.01 ETH (1% of yearly fee)
+    expect(hasMeaningfulGasSavings(yearlyFee, transactionFee)).toBe(false)
+  })
+
+  it('should return false when savings are below 5%', () => {
+    const yearlyFee = 100000000000000000000n // 100 ETH
+    const transactionFee = 100000000000000000n // 0.1 ETH (very small relative to yearly fee)
+    expect(hasMeaningfulGasSavings(yearlyFee, transactionFee)).toBe(false)
   })
 })

--- a/src/components/@atoms/RegistrationTimeComparisonBanner/RegistrationTimeComparisonBanner.tsx
+++ b/src/components/@atoms/RegistrationTimeComparisonBanner/RegistrationTimeComparisonBanner.tsx
@@ -113,6 +113,15 @@ const yearsToGasPercent = (targetYears: bigint, f: bigint, y: bigint) => {
   return rounded
 }
 
+const MINIMUM_SAVINGS_THRESHOLD = 5
+
+export const hasMeaningfulGasSavings = (yearlyFee: bigint, transactionFee: bigint): boolean => {
+  const oneYearGasPercent = yearsToGasPercent(1n, transactionFee, yearlyFee)
+  const fiveYearGasPercent = yearsToGasPercent(5n, transactionFee, yearlyFee)
+  const savingsPercent = oneYearGasPercent - fiveYearGasPercent
+  return savingsPercent >= MINIMUM_SAVINGS_THRESHOLD
+}
+
 const gasPercentToYears = (targetPercent: bigint, f: bigint, y: bigint, min: number) => {
   const fp = f / 100n
   const yp = y / 100n

--- a/src/components/pages/profile/[name]/registration/steps/Pricing/Pricing.tsx
+++ b/src/components/pages/profile/[name]/registration/steps/Pricing/Pricing.tsx
@@ -21,7 +21,10 @@ import {
 
 import MoonpayLogo from '@app/assets/MoonpayLogo.svg'
 import MobileFullWidth from '@app/components/@atoms/MobileFullWidth'
-import { RegistrationTimeComparisonBanner } from '@app/components/@atoms/RegistrationTimeComparisonBanner/RegistrationTimeComparisonBanner'
+import {
+  hasMeaningfulGasSavings,
+  RegistrationTimeComparisonBanner,
+} from '@app/components/@atoms/RegistrationTimeComparisonBanner/RegistrationTimeComparisonBanner'
 import { Spacer } from '@app/components/@atoms/Spacer'
 import { ConnectButton } from '@app/components/@molecules/ConnectButton/ConnectButton'
 import { DateSelection } from '@app/components/@molecules/DateSelection/DateSelection'
@@ -582,7 +585,8 @@ const Pricing = ({
       ) : (
         !!unsafeDisplayYearlyFee &&
         !!unsafeDisplayEstimatedGasFee &&
-        !!gasPrice && (
+        !!gasPrice &&
+        hasMeaningfulGasSavings(unsafeDisplayYearlyFee, unsafeDisplayEstimatedGasFee) && (
           <RegistrationTimeComparisonBanner
             yearlyFee={unsafeDisplayYearlyFee}
             transactionFee={unsafeDisplayEstimatedGasFee}


### PR DESCRIPTION
## Summary
- Hide the gas savings comparison banner on the registration page when savings are less than 5%
- Add `hasMeaningfulGasSavings` helper function that compares gas costs between 1-year and 5-year registrations
- Only show the banner when registering for longer periods provides meaningful savings

This addresses the feedback that the gas price card is irrelevant most of the time now due to minimal savings for multiple year registrations when gas is cheap.

## Test plan
- [ ] Register a name when gas is expensive relative to yearly fee - banner should appear
- [ ] Register a name when gas is cheap relative to yearly fee - banner should be hidden
- [ ] Unit tests pass for `hasMeaningfulGasSavings` function

Slack thread: https://enslabsworkspace.slack.com/archives/C04AZ53GNMS/p1778864694210649?thread_ts=1773033607.850559&cid=C04AZ53GNMS

https://claude.ai/code/session_012TQzGpEtg5DwZ6rMSNNGWd

---
_Generated by [Claude Code](https://claude.ai/code/session_012TQzGpEtg5DwZ6rMSNNGWd)_