### PR TITLE
Validate that manual avatar/header URLs return an image (FET-2440)

### DIFF
--- a/e2e/specs/stateless/profileEditor.spec.ts
+++ b/e2e/specs/stateless/profileEditor.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 
-import { expect } from '@playwright/test'
+import { expect, type Page } from '@playwright/test'
 import dotenv from 'dotenv'
 import { type Address } from 'viem'
 
@@ -33,6 +33,12 @@ const customNameWrapperAwareResolver = contractAddresses.CustomNameWrapperAwareR
 const dummyABI = {
   test: 'test',
 }
+
+// A 1x1 transparent PNG. The manual avatar/header inputs now run an async
+// image-validity check (FET-2440), so fixtures must be URLs that actually load
+// as an image; a data URL does so deterministically without a network request.
+const VALID_IMAGE_DATA_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
 
 const DEFAULT_RECORDS: RecordOptions = {
   texts: [
@@ -158,10 +164,8 @@ test.describe('legacy resolver', () => {
       records: await makeRecords(),
     })
 
-    const avatarUrl =
-      'https://turquoise-junior-skunk-153.mypinata.cloud/ipfs/bafybeielr6r2tltc27ywygbmhapookijfg3uk32mzqowvhfd4pcvfqijby'
-    const headerUrl =
-      'https://cdn-media.sforum.vn/storage/app/media/bookgrinder/honkai-star-rail-31-skill-mydei-1.jpg'
+    const avatarUrl = VALID_IMAGE_DATA_URL
+    const headerUrl = VALID_IMAGE_DATA_URL
 
     const morePage = makePageObject('MorePage')
     const profilePage = makePageObject('ProfilePage')
@@ -233,8 +237,8 @@ test.describe('legacy resolver', () => {
     await expect(recordsPage.getRecordValue('text', 'header')).toHaveText(headerUrl)
 
     await profilePage.goto(name)
-    await expect(profilePage.record('text', 'avatar')).toContainText('https://turquoi...')
-    await expect(profilePage.record('text', 'header')).toContainText('https://cdn-med...')
+    await expect(profilePage.record('text', 'avatar')).toContainText('data:image/png')
+    await expect(profilePage.record('text', 'header')).toContainText('data:image/png')
   })
 
   test('should be able to delete profile records without migration', async ({
@@ -329,10 +333,8 @@ test.describe('custom legacy resolver', () => {
       records: await makeRecords(),
     })
 
-    const avatarUrl =
-      'https://turquoise-junior-skunk-153.mypinata.cloud/ipfs/bafybeielr6r2tltc27ywygbmhapookijfg3uk32mzqowvhfd4pcvfqijby'
-    const headerUrl =
-      'https://cdn-media.sforum.vn/storage/app/media/bookgrinder/honkai-star-rail-31-skill-mydei-1.jpg'
+    const avatarUrl = VALID_IMAGE_DATA_URL
+    const headerUrl = VALID_IMAGE_DATA_URL
 
     const morePage = makePageObject('MorePage')
     const profilePage = makePageObject('ProfilePage')
@@ -404,8 +406,8 @@ test.describe('custom legacy resolver', () => {
     await expect(recordsPage.getRecordValue('text', 'header')).toHaveText(headerUrl)
 
     await profilePage.goto(name)
-    await expect(profilePage.record('text', 'avatar')).toContainText('https://turquoi...')
-    await expect(profilePage.record('text', 'header')).toContainText('https://cdn-med...')
+    await expect(profilePage.record('text', 'avatar')).toContainText('data:image/png')
+    await expect(profilePage.record('text', 'header')).toContainText('data:image/png')
   })
 
   test('should be able to delete profile records without migration', async ({
@@ -1901,5 +1903,153 @@ test.describe('edit profile button states', () => {
     await profilePage.goto(name)
 
     await expect(page.getByTestId('disabled-profile-action-Edit profile')).toBeVisible()
+  })
+})
+
+test.describe('manual image url validation', () => {
+  const NON_IMAGE_URL = 'data:text/html,<h1>not-an-image</h1>'
+  const NOT_AN_IMAGE_ERROR = 'This URL does not return an image'
+
+  // Robustly open the manual-entry dialog from an avatar/header dropdown. The
+  // profile editor re-renders periodically, which can detach the dropdown menu
+  // or reset the dialog mid-interaction; retrying the open (and only re-clicking
+  // the trigger when the menu is actually closed, to avoid toggling it shut)
+  // absorbs that without weakening any assertion.
+  const openManualEntry = async (
+    page: Page,
+    buttonTestId: string,
+    addLabel: string,
+    inputTestId: string,
+  ) => {
+    const dropdown = page.getByTestId(buttonTestId)
+    const enterManually = dropdown.getByRole('button', { name: 'Enter Manually' })
+    await expect(async () => {
+      if (!(await enterManually.isVisible())) {
+        await dropdown.getByRole('button', { name: addLabel }).click()
+      }
+      await expect(enterManually).toBeVisible({ timeout: 2000 })
+      await enterManually.click()
+      await expect(page.getByTestId(inputTestId)).toBeVisible({ timeout: 2000 })
+    }).toPass({ timeout: 30000 })
+  }
+
+  test('avatar: shows an inline error and disables Confirm for a non-image URL, then accepts a valid image URL', async ({
+    page,
+    login,
+    makeName,
+    makePageObject,
+  }) => {
+    const name = await makeName({
+      label: 'manual-avatar-validation',
+      type: 'legacy',
+      records: { texts: [{ key: 'description', value: 'manual avatar test' }] },
+    })
+
+    const profilePage = makePageObject('ProfilePage')
+
+    await profilePage.goto(name)
+    await login.connect()
+
+    // Ensure profile data is loaded (warms the query cache) so the editor renders
+    // stably and a late re-render does not detach the dropdown menu below.
+    await expect(profilePage.record('text', 'description')).toHaveText('manual avatar test')
+
+    // Make CSS transitions instant so the dropdown menu opens stably; its 0.35s
+    // bouncy entrance transition otherwise races with re-renders and
+    // intermittently detaches the menu item before Playwright can click it. Only
+    // transitions are flattened (they jump to their final state), not keyframe
+    // animations, so reveal-on-mount elements such as the inline error still show.
+    await page.addStyleTag({
+      content:
+        '*, *::before, *::after { transition-duration: 0s !important; transition-delay: 0s !important; }',
+    })
+
+    await profilePage.editProfileButton.click()
+    await expect(page.getByTestId('profile-submit-button')).toBeVisible()
+
+    await openManualEntry(page, 'avatar-button', 'Add avatar', 'avatar-uri-input')
+
+    const confirmButton = page.getByRole('button', { name: 'Confirm' })
+    const input = page.getByTestId('avatar-uri-input')
+    const errorText = page.getByText(NOT_AN_IMAGE_ERROR)
+
+    // Non-image URL: passes format validation but does not return an image. The
+    // error appears after the debounce, without clicking Confirm. Re-filling
+    // inside expect(...).toPass guards against the editor occasionally
+    // re-rendering and resetting the dialog while the async check is in flight.
+    await expect(async () => {
+      await input.fill(NON_IMAGE_URL)
+      await expect(errorText).toBeVisible({ timeout: 2000 })
+      await expect(confirmButton).toBeDisabled()
+    }).toPass({ timeout: 30000 })
+
+    // Valid image URL: the error clears and the avatar can be saved.
+    await expect(async () => {
+      await input.fill(VALID_IMAGE_DATA_URL)
+      await expect(errorText).toBeHidden({ timeout: 2000 })
+      await expect(confirmButton).toBeEnabled()
+      await confirmButton.click()
+      await expect(page.getByTestId('avatar-uri-display')).toBeVisible({ timeout: 3000 })
+    }).toPass({ timeout: 30000 })
+  })
+
+  test('header: shows an inline error and disables Save for a non-image URL, then accepts a valid image URL', async ({
+    page,
+    login,
+    makeName,
+    makePageObject,
+  }) => {
+    const name = await makeName({
+      label: 'manual-header-validation',
+      type: 'legacy',
+      records: { texts: [{ key: 'description', value: 'manual header test' }] },
+    })
+
+    const profilePage = makePageObject('ProfilePage')
+
+    await profilePage.goto(name)
+    await login.connect()
+
+    // Ensure profile data is loaded (warms the query cache) so the editor renders
+    // stably and a late re-render does not detach the dropdown menu below.
+    await expect(profilePage.record('text', 'description')).toHaveText('manual header test')
+
+    // Make CSS transitions instant so the dropdown menu opens stably; its 0.35s
+    // bouncy entrance transition otherwise races with re-renders and
+    // intermittently detaches the menu item before Playwright can click it. Only
+    // transitions are flattened (they jump to their final state), not keyframe
+    // animations, so reveal-on-mount elements such as the inline error still show.
+    await page.addStyleTag({
+      content:
+        '*, *::before, *::after { transition-duration: 0s !important; transition-delay: 0s !important; }',
+    })
+
+    await profilePage.editProfileButton.click()
+    await expect(page.getByTestId('profile-submit-button')).toBeVisible()
+
+    await openManualEntry(page, 'header-button', 'Add header', 'header-manual-input')
+
+    const saveButton = page.getByRole('button', { name: 'Save' })
+    const input = page.getByTestId('header-manual-input')
+    const errorText = page.getByText(NOT_AN_IMAGE_ERROR)
+
+    // Non-image URL: passes format validation but does not return an image. The
+    // error appears after the debounce, without clicking Save. Re-filling inside
+    // expect(...).toPass guards against the editor occasionally re-rendering and
+    // resetting the dialog while the async check is in flight.
+    await expect(async () => {
+      await input.fill(NON_IMAGE_URL)
+      await expect(errorText).toBeVisible({ timeout: 2000 })
+      await expect(saveButton).toBeDisabled()
+    }).toPass({ timeout: 30000 })
+
+    // Valid image URL: the error clears and the header can be saved.
+    await expect(async () => {
+      await input.fill(VALID_IMAGE_DATA_URL)
+      await expect(errorText).toBeHidden({ timeout: 2000 })
+      await expect(saveButton).toBeEnabled()
+      await saveButton.click()
+      await expect(page.getByTestId('header-uri-display')).toBeVisible({ timeout: 3000 })
+    }).toPass({ timeout: 30000 })
   })
 })

--- a/e2e/specs/stateless/registerName.spec.ts
+++ b/e2e/specs/stateless/registerName.spec.ts
@@ -23,6 +23,12 @@ const addressToBytes32 = (address: string): string => {
   return pad(`0x${cleanAddress}`, { size: 32 })
 }
 
+// A 1x1 transparent PNG. The manual avatar/header inputs now run an async
+// image-validity check (FET-2440), so fixtures must be URLs that actually load
+// as an image; a data URL does so deterministically without a network request.
+const VALID_IMAGE_DATA_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+
 /*
  * NOTE: Do not use transactionModal autocomplete here since the app will auto close the modal and playwright will
  * get stuck looking for the complete button
@@ -1980,7 +1986,7 @@ test('should change profile submit button text from "Skip profile" to "Next" whe
   // Upload header - directly set files on hidden input
   await page.getByTestId('header-button').getByRole('button', { name: 'Add header' }).click()
   await page.getByTestId('header-button').getByRole('button', { name: 'Enter Manually' }).click()
-  await page.getByTestId('header-manual-input').fill('https://image.com/header.jpg')
+  await page.getByTestId('header-manual-input').fill(VALID_IMAGE_DATA_URL)
   await page.getByRole('button', { name: 'Save' }).click()
   await expect(page.getByTestId('header-uri-display')).toBeVisible({ timeout: 30000 })
 
@@ -2012,7 +2018,7 @@ test('should change profile submit button text from "Skip profile" to "Next" whe
   // Add avatar
   await page.getByTestId('avatar-button').getByRole('button', { name: 'Add avatar' }).click()
   await page.getByTestId('avatar-button').getByRole('button', { name: 'Enter Manually' }).click()
-  await page.getByTestId('avatar-uri-input').fill('https://image.com/avatar.jpg')
+  await page.getByTestId('avatar-uri-input').fill(VALID_IMAGE_DATA_URL)
   await page.getByRole('button', { name: 'Confirm' }).click()
 
   await expect(page.getByTestId('profile-submit-button')).toHaveText('Next')
@@ -2043,14 +2049,14 @@ test('should change profile submit button text from "Skip profile" to "Next" whe
   // Add avatar
   await page.getByTestId('avatar-button').getByRole('button', { name: 'Add avatar' }).click()
   await page.getByTestId('avatar-button').getByRole('button', { name: 'Enter Manually' }).click()
-  await page.getByTestId('avatar-uri-input').fill('https://image.com/avatar.jpg')
+  await page.getByTestId('avatar-uri-input').fill(VALID_IMAGE_DATA_URL)
   await page.getByRole('button', { name: 'Confirm' }).click()
   await expect(page.getByTestId('avatar-uri-display')).toBeVisible({ timeout: 30000 })
 
   // Add header
   await page.getByTestId('header-button').getByRole('button', { name: 'Add header' }).click()
   await page.getByTestId('header-button').getByRole('button', { name: 'Enter Manually' }).click()
-  await page.getByTestId('header-manual-input').fill('https://image.com/header.jpg')
+  await page.getByTestId('header-manual-input').fill(VALID_IMAGE_DATA_URL)
   await page.getByRole('button', { name: 'Save' }).click()
   await expect(page.getByTestId('header-uri-display')).toBeVisible({ timeout: 30000 })
 
@@ -2097,8 +2103,7 @@ test('should allow the user to register with an avatar image manually set', asyn
   makePageObject,
 }) => {
   const name = `avatar-reg-${Date.now()}.eth`
-  const avatarUrl =
-    'https://turquoise-junior-skunk-153.mypinata.cloud/ipfs/bafybeielr6r2tltc27ywygbmhapookijfg3uk32mzqowvhfd4pcvfqijby'
+  const avatarUrl = VALID_IMAGE_DATA_URL
 
   await setPrimaryName(walletClient, {
     name: '',
@@ -2194,8 +2199,7 @@ test('should allow the user to register with a header image manually set', async
   makePageObject,
 }) => {
   const name = `header-reg-${Date.now()}.eth`
-  const headerUrl =
-    'https://cdn-media.sforum.vn/storage/app/media/bookgrinder/honkai-star-rail-31-skill-mydei-1.jpg'
+  const headerUrl = VALID_IMAGE_DATA_URL
 
   await setPrimaryName(walletClient, {
     name: '',
@@ -2291,10 +2295,8 @@ test('should allow the user to register with both avatar and header manually set
   makePageObject,
 }) => {
   const name = `avatar-header-reg-${Date.now()}.eth`
-  const avatar2 =
-    'https://turquoise-junior-skunk-153.mypinata.cloud/ipfs/bafybeielr6r2tltc27ywygbmhapookijfg3uk32mzqowvhfd4pcvfqijby'
-  const header2 =
-    'https://cdn-media.sforum.vn/storage/app/media/bookgrinder/honkai-star-rail-31-skill-mydei-1.jpg'
+  const avatar2 = VALID_IMAGE_DATA_URL
+  const header2 = VALID_IMAGE_DATA_URL
 
   await setPrimaryName(walletClient, {
     name: '',

--- a/src/components/@molecules/ProfileEditor/Avatar/AvatarManual.test.tsx
+++ b/src/components/@molecules/ProfileEditor/Avatar/AvatarManual.test.tsx
@@ -1,0 +1,131 @@
+import { act, fireEvent, render, screen } from '@app/test-utils'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { imageUrlReturnsImage } from '@app/validators/validateImageUrl'
+
+import { makeMockIntersectionObserver } from '../../../../../test/mock/makeMockIntersectionObserver'
+import { AvatarManual } from './AvatarManual'
+
+vi.mock('@app/validators/validateImageUrl')
+
+makeMockIntersectionObserver()
+
+const mockImageUrlReturnsImage = vi.mocked(imageUrlReturnsImage)
+
+const mockHandleCancel = vi.fn()
+const mockHandleSubmit = vi.fn()
+
+const props = {
+  handleCancel: mockHandleCancel,
+  handleSubmit: mockHandleSubmit,
+}
+
+const NOT_AN_IMAGE_ERROR = 'This URL does not return an image'
+const VALID_URL = 'https://example.com/avatar.png'
+const OTHER_VALID_URL = 'https://example.com/other.png'
+
+const typeUri = (value: string) =>
+  fireEvent.change(screen.getByTestId('avatar-uri-input'), { target: { value } })
+
+const advanceDebounce = async () => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(450)
+  })
+}
+
+describe('<AvatarManual />', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockImageUrlReturnsImage.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows an inline error and disables Confirm when the URL does not return an image', async () => {
+    mockImageUrlReturnsImage.mockResolvedValue(false)
+
+    render(<AvatarManual {...props} />)
+    typeUri(VALID_URL)
+
+    // Indicator appears immediately while the async check is in flight.
+    expect(screen.getByTestId('avatar-uri-validating')).toBeVisible()
+
+    await advanceDebounce()
+
+    expect(screen.getByText(NOT_AN_IMAGE_ERROR)).toBeVisible()
+    expect(screen.getByTestId('avatar-manual-submit')).toBeDisabled()
+    expect(screen.queryByTestId('avatar-uri-validating')).not.toBeInTheDocument()
+  })
+
+  it('clears the error and enables Confirm when the URL returns an image', async () => {
+    mockImageUrlReturnsImage.mockResolvedValue(true)
+
+    render(<AvatarManual {...props} />)
+    typeUri(VALID_URL)
+
+    await advanceDebounce()
+
+    expect(screen.queryByText(NOT_AN_IMAGE_ERROR)).not.toBeInTheDocument()
+    expect(screen.getByTestId('avatar-manual-submit')).toBeEnabled()
+  })
+
+  it('shows the validating indicator while the check is in flight and hides it after', async () => {
+    mockImageUrlReturnsImage.mockResolvedValue(true)
+
+    render(<AvatarManual {...props} />)
+    typeUri(VALID_URL)
+
+    expect(screen.getByTestId('avatar-uri-validating')).toBeVisible()
+    // Confirm stays disabled while validating, even before the result is known.
+    expect(screen.getByTestId('avatar-manual-submit')).toBeDisabled()
+
+    await advanceDebounce()
+
+    expect(screen.queryByTestId('avatar-uri-validating')).not.toBeInTheDocument()
+  })
+
+  it('immediately shows a format error without running the async check for an invalid URL', async () => {
+    render(<AvatarManual {...props} />)
+    typeUri('not-a-url')
+
+    expect(screen.getByText('Image URL must be a valid URL')).toBeVisible()
+    expect(screen.queryByTestId('avatar-uri-validating')).not.toBeInTheDocument()
+    expect(screen.getByTestId('avatar-manual-submit')).toBeDisabled()
+    expect(mockImageUrlReturnsImage).not.toHaveBeenCalled()
+  })
+
+  it('ignores a stale async result for a value that has since changed', async () => {
+    let resolveFirst!: (value: boolean) => void
+    const firstCheck = new Promise<boolean>((resolve) => {
+      resolveFirst = resolve
+    })
+    mockImageUrlReturnsImage.mockImplementation((url) =>
+      url === VALID_URL ? firstCheck : Promise.resolve(true),
+    )
+
+    render(<AvatarManual {...props} />)
+
+    // Type the first URL and let its debounced check start (now awaiting).
+    typeUri(VALID_URL)
+    await advanceDebounce()
+
+    // Before the first check resolves, type a different valid URL.
+    typeUri(OTHER_VALID_URL)
+
+    // The first (now stale) check resolves false — it must not surface an error.
+    await act(async () => {
+      resolveFirst(false)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(screen.queryByText(NOT_AN_IMAGE_ERROR)).not.toBeInTheDocument()
+
+    // The current value's check resolves true and is applied.
+    await advanceDebounce()
+    expect(screen.queryByText(NOT_AN_IMAGE_ERROR)).not.toBeInTheDocument()
+    expect(screen.getByTestId('avatar-manual-submit')).toBeEnabled()
+  })
+})

--- a/src/components/@molecules/ProfileEditor/Avatar/AvatarManual.tsx
+++ b/src/components/@molecules/ProfileEditor/Avatar/AvatarManual.tsx
@@ -1,10 +1,14 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Button, Dialog, Input, Typography } from '@ensdomains/thorin'
 
 import { Outlink } from '@app/components/Outlink'
+import useDebouncedCallback from '@app/hooks/useDebouncedCallback'
 import { validateImageUri } from '@app/validators/validateImageUri'
+import { imageUrlReturnsImage } from '@app/validators/validateImageUrl'
+
+const NOT_AN_IMAGE_ERROR = 'This URL does not return an image'
 
 const Container = styled.div(
   () => css`
@@ -47,6 +51,9 @@ export const AvatarManual = ({
 }) => {
   const [uri, setUri] = useState('')
   const [error, setError] = useState<string | undefined>()
+  const [isValidating, setIsValidating] = useState(false)
+  // Holds the most recent input value so stale async results can be ignored.
+  const latestUriRef = useRef('')
 
   const validateUri = (value: string) => {
     const validationResult = validateImageUri(value)
@@ -60,11 +67,33 @@ export const AvatarManual = ({
     return false
   }
 
+  // Debounced async check that the URL actually returns an image. Runs only
+  // after the user stops typing, and ignores results for a value that has since
+  // changed (rapid retyping must not surface a stale error).
+  const runImageCheck = useDebouncedCallback(async (value: string) => {
+    const returnsImage = await imageUrlReturnsImage(value)
+    if (latestUriRef.current !== value) return
+    setIsValidating(false)
+    if (!returnsImage) setError(NOT_AN_IMAGE_ERROR)
+  }, 450)
+
   const handleUriChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value
     setUri(newValue)
-    // Always validate in real-time as the user types
-    validateUri(newValue)
+    latestUriRef.current = newValue
+
+    // Synchronous format validation is the first gate, applied immediately.
+    const validationResult = validateImageUri(newValue)
+    if (validationResult !== true) {
+      setIsValidating(false)
+      setError(validationResult as string)
+      return
+    }
+
+    // Format is valid — clear any prior error and verify it returns an image.
+    setError(undefined)
+    setIsValidating(true)
+    runImageCheck(newValue)
   }
 
   const onSubmit = () => {
@@ -95,6 +124,15 @@ export const AvatarManual = ({
               autoComplete="off"
               data-testid="avatar-uri-input"
             />
+            {isValidating && (
+              <Typography
+                fontVariant="small"
+                color="textSecondary"
+                data-testid="avatar-uri-validating"
+              >
+                Checking image...
+              </Typography>
+            )}
           </InputContainer>
         </Container>
       </Dialog.Content>
@@ -109,7 +147,11 @@ export const AvatarManual = ({
           </Button>
         }
         trailing={
-          <Button onClick={onSubmit} disabled={!uri || !!error} data-testid="avatar-manual-submit">
+          <Button
+            onClick={onSubmit}
+            disabled={!uri || !!error || isValidating}
+            data-testid="avatar-manual-submit"
+          >
             Confirm
           </Button>
         }

--- a/src/components/@molecules/ProfileEditor/Header/HeaderManual.test.tsx
+++ b/src/components/@molecules/ProfileEditor/Header/HeaderManual.test.tsx
@@ -1,0 +1,128 @@
+import { act, fireEvent, render, screen } from '@app/test-utils'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { imageUrlReturnsImage } from '@app/validators/validateImageUrl'
+
+import { makeMockIntersectionObserver } from '../../../../../test/mock/makeMockIntersectionObserver'
+import { HeaderManual } from './HeaderManual'
+
+vi.mock('@app/validators/validateImageUrl')
+
+makeMockIntersectionObserver()
+
+const mockImageUrlReturnsImage = vi.mocked(imageUrlReturnsImage)
+
+const mockHandleCancel = vi.fn()
+const mockHandleSubmit = vi.fn()
+
+const props = {
+  handleCancel: mockHandleCancel,
+  handleSubmit: mockHandleSubmit,
+}
+
+const NOT_AN_IMAGE_ERROR = 'This URL does not return an image'
+const VALID_URL = 'https://example.com/header.png'
+const OTHER_VALID_URL = 'https://example.com/other-header.png'
+
+// react-i18next is mocked in test-utils so `t(key)` returns the key.
+const saveButton = () => screen.getByRole('button', { name: 'action.save' })
+
+const typeUri = (value: string) =>
+  fireEvent.change(screen.getByTestId('header-manual-input'), { target: { value } })
+
+const advanceDebounce = async () => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(450)
+  })
+}
+
+describe('<HeaderManual />', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockImageUrlReturnsImage.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows an inline error and disables Save when the URL does not return an image', async () => {
+    mockImageUrlReturnsImage.mockResolvedValue(false)
+
+    render(<HeaderManual {...props} />)
+    typeUri(VALID_URL)
+
+    expect(screen.getByTestId('header-manual-validating')).toBeVisible()
+
+    await advanceDebounce()
+
+    expect(screen.getByText(NOT_AN_IMAGE_ERROR)).toBeVisible()
+    expect(saveButton()).toBeDisabled()
+    expect(screen.queryByTestId('header-manual-validating')).not.toBeInTheDocument()
+  })
+
+  it('clears the error and enables Save when the URL returns an image', async () => {
+    mockImageUrlReturnsImage.mockResolvedValue(true)
+
+    render(<HeaderManual {...props} />)
+    typeUri(VALID_URL)
+
+    await advanceDebounce()
+
+    expect(screen.queryByText(NOT_AN_IMAGE_ERROR)).not.toBeInTheDocument()
+    expect(saveButton()).toBeEnabled()
+  })
+
+  it('shows the validating indicator while the check is in flight and hides it after', async () => {
+    mockImageUrlReturnsImage.mockResolvedValue(true)
+
+    render(<HeaderManual {...props} />)
+    typeUri(VALID_URL)
+
+    expect(screen.getByTestId('header-manual-validating')).toBeVisible()
+    expect(saveButton()).toBeDisabled()
+
+    await advanceDebounce()
+
+    expect(screen.queryByTestId('header-manual-validating')).not.toBeInTheDocument()
+  })
+
+  it('immediately shows a format error without running the async check for an invalid URL', async () => {
+    render(<HeaderManual {...props} />)
+    typeUri('not-a-url')
+
+    expect(screen.getByText('Image URL must be a valid URL')).toBeVisible()
+    expect(screen.queryByTestId('header-manual-validating')).not.toBeInTheDocument()
+    expect(saveButton()).toBeDisabled()
+    expect(mockImageUrlReturnsImage).not.toHaveBeenCalled()
+  })
+
+  it('ignores a stale async result for a value that has since changed', async () => {
+    let resolveFirst!: (value: boolean) => void
+    const firstCheck = new Promise<boolean>((resolve) => {
+      resolveFirst = resolve
+    })
+    mockImageUrlReturnsImage.mockImplementation((url) =>
+      url === VALID_URL ? firstCheck : Promise.resolve(true),
+    )
+
+    render(<HeaderManual {...props} />)
+
+    typeUri(VALID_URL)
+    await advanceDebounce()
+
+    typeUri(OTHER_VALID_URL)
+
+    await act(async () => {
+      resolveFirst(false)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(screen.queryByText(NOT_AN_IMAGE_ERROR)).not.toBeInTheDocument()
+
+    await advanceDebounce()
+    expect(screen.queryByText(NOT_AN_IMAGE_ERROR)).not.toBeInTheDocument()
+    expect(saveButton()).toBeEnabled()
+  })
+})

--- a/src/components/@molecules/ProfileEditor/Header/HeaderManual.tsx
+++ b/src/components/@molecules/ProfileEditor/Header/HeaderManual.tsx
@@ -1,10 +1,14 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
 import { Button, Dialog, Input, Typography } from '@ensdomains/thorin'
 
+import useDebouncedCallback from '@app/hooks/useDebouncedCallback'
 import { validateImageUri } from '@app/validators/validateImageUri'
+import { imageUrlReturnsImage } from '@app/validators/validateImageUrl'
+
+const NOT_AN_IMAGE_ERROR = 'This URL does not return an image'
 
 const Container = styled.div(
   ({ theme }) => css`
@@ -41,6 +45,9 @@ export const HeaderManual = ({
 }) => {
   const [uri, setUri] = useState('')
   const [error, setError] = useState<string | undefined>()
+  const [isValidating, setIsValidating] = useState(false)
+  // Holds the most recent input value so stale async results can be ignored.
+  const latestUriRef = useRef('')
   const { t } = useTranslation('common')
 
   const validateUri = (value: string) => {
@@ -55,11 +62,33 @@ export const HeaderManual = ({
     return false
   }
 
+  // Debounced async check that the URL actually returns an image. Runs only
+  // after the user stops typing, and ignores results for a value that has since
+  // changed (rapid retyping must not surface a stale error).
+  const runImageCheck = useDebouncedCallback(async (value: string) => {
+    const returnsImage = await imageUrlReturnsImage(value)
+    if (latestUriRef.current !== value) return
+    setIsValidating(false)
+    if (!returnsImage) setError(NOT_AN_IMAGE_ERROR)
+  }, 450)
+
   const handleUriChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value
     setUri(newValue)
-    // Always validate in real-time as the user types
-    validateUri(newValue)
+    latestUriRef.current = newValue
+
+    // Synchronous format validation is the first gate, applied immediately.
+    const validationResult = validateImageUri(newValue)
+    if (validationResult !== true) {
+      setIsValidating(false)
+      setError(validationResult as string)
+      return
+    }
+
+    // Format is valid — clear any prior error and verify it returns an image.
+    setError(undefined)
+    setIsValidating(true)
+    runImageCheck(newValue)
   }
 
   const onSubmit = () => {
@@ -83,6 +112,15 @@ export const HeaderManual = ({
             error={error}
             autoFocus
           />
+          {isValidating && (
+            <Typography
+              fontVariant="small"
+              color="textSecondary"
+              data-testid="header-manual-validating"
+            >
+              Checking image...
+            </Typography>
+          )}
           <Typography color="grey">
             Enter a URL to an image file. The image should have a 3:1 aspect ratio for best results.
           </Typography>
@@ -95,7 +133,7 @@ export const HeaderManual = ({
           </Button>
         }
         trailing={
-          <Button onClick={onSubmit} disabled={!uri || !!error}>
+          <Button onClick={onSubmit} disabled={!uri || !!error || isValidating}>
             {t('action.save')}
           </Button>
         }

--- a/src/validators/validateImageUrl.test.ts
+++ b/src/validators/validateImageUrl.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { imageUrlReturnsImage } from './validateImageUrl'
+
+// Behaviour of the mocked `new Image()` for the current test:
+// - 'load'  → fire onload asynchronously (resolves true)
+// - 'error' → fire onerror asynchronously (resolves false)
+// - 'hang'  → never fire either (exercises the timeout path)
+let imageBehavior: 'load' | 'error' | 'hang' = 'load'
+
+class MockImage {
+  onload: (() => void) | null = null
+
+  onerror: (() => void) | null = null
+
+  // eslint-disable-next-line accessor-pairs
+  set src(_value: string) {
+    if (imageBehavior === 'load') queueMicrotask(() => this.onload?.())
+    else if (imageBehavior === 'error') queueMicrotask(() => this.onerror?.())
+    // 'hang' → intentionally never resolves
+  }
+}
+
+beforeEach(() => {
+  imageBehavior = 'load'
+  vi.stubGlobal('Image', MockImage)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('imageUrlReturnsImage', () => {
+  it('resolves true for an https URL that loads as an image', async () => {
+    imageBehavior = 'load'
+    await expect(imageUrlReturnsImage('https://example.com/avatar.png')).resolves.toBe(true)
+  })
+
+  it('resolves false for an https URL that fails to load', async () => {
+    imageBehavior = 'error'
+    await expect(imageUrlReturnsImage('https://www.instagram.com/')).resolves.toBe(false)
+  })
+
+  it('resolves true for a data:image URL that loads', async () => {
+    imageBehavior = 'load'
+    await expect(
+      imageUrlReturnsImage('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ'),
+    ).resolves.toBe(true)
+  })
+
+  it('resolves false for a non-image data URL that fails to load', async () => {
+    imageBehavior = 'error'
+    await expect(imageUrlReturnsImage('data:text/html,<h1>not an image</h1>')).resolves.toBe(false)
+  })
+
+  it('resolves false when the image load times out', async () => {
+    imageBehavior = 'hang'
+    vi.useFakeTimers()
+    const promise = imageUrlReturnsImage('https://example.com/slow.png', 1000)
+    await vi.advanceTimersByTimeAsync(1000)
+    await expect(promise).resolves.toBe(false)
+  })
+
+  it('resolves true for ipfs URLs without attempting an image load (out of scope)', async () => {
+    imageBehavior = 'error'
+    await expect(imageUrlReturnsImage('ipfs://bafybeibexampleexampleexample')).resolves.toBe(true)
+  })
+
+  it('resolves true for eip155 URLs without attempting an image load (out of scope)', async () => {
+    imageBehavior = 'error'
+    await expect(
+      imageUrlReturnsImage('eip155:1/erc721:0x0000000000000000000000000000000000000000/1'),
+    ).resolves.toBe(true)
+  })
+
+  it('resolves false for an unparseable URL', async () => {
+    await expect(imageUrlReturnsImage('not a url')).resolves.toBe(false)
+  })
+
+  it('resolves false for an unsupported protocol', async () => {
+    await expect(imageUrlReturnsImage('ftp://example.com/avatar.png')).resolves.toBe(false)
+  })
+})

--- a/src/validators/validateImageUrl.ts
+++ b/src/validators/validateImageUrl.ts
@@ -1,0 +1,58 @@
+const ACCEPTED_IMAGE_LOAD_PROTOCOLS = ['https:', 'http:', 'data:']
+
+/**
+ * Asynchronously checks whether a URL actually resolves to a loadable image.
+ *
+ * This complements the synchronous `validateImageUri` (valid URL, allowed
+ * protocol, no raw IP) by verifying that the URL really returns an image, so we
+ * reject links like `https://www.instagram.com/` that pass format validation but
+ * are not images.
+ *
+ * It uses an in-browser image load (`new Image()`) rather than a HEAD /
+ * content-type `fetch`: image loading is not subject to CORS the way `fetch` is,
+ * so a content-type fetch would falsely reject valid images served by hosts that
+ * do not send permissive CORS headers.
+ *
+ * `ipfs:` and `eip155:` URLs are out of scope — their resolution is handled by
+ * the existing avatar pipeline (`useEnsAvatar`) — so they resolve `true` here and
+ * are not blocked.
+ *
+ * @param url - the URL to check (should already have passed `validateImageUri`)
+ * @param timeoutMs - how long to wait for the image to load before giving up
+ * @returns a promise resolving to `true` if the URL loads as an image, else `false`
+ */
+export const imageUrlReturnsImage = (url: string, timeoutMs = 10000): Promise<boolean> => {
+  let protocol: string
+  try {
+    protocol = new URL(url).protocol
+  } catch {
+    return Promise.resolve(false)
+  }
+
+  // Defer ipfs/eip155 resolution to the avatar pipeline — not checked here.
+  if (protocol === 'ipfs:' || protocol === 'eip155:') return Promise.resolve(true)
+
+  // Only http(s) and data URLs can be verified via an in-browser image load.
+  if (!ACCEPTED_IMAGE_LOAD_PROTOCOLS.includes(protocol)) return Promise.resolve(false)
+
+  return new Promise<boolean>((resolve) => {
+    const img = new Image()
+
+    const timer = setTimeout(() => {
+      img.onload = null
+      img.onerror = null
+      resolve(false)
+    }, timeoutMs)
+
+    img.onload = () => {
+      clearTimeout(timer)
+      resolve(true)
+    }
+    img.onerror = () => {
+      clearTimeout(timer)
+      resolve(false)
+    }
+
+    img.src = url
+  })
+}


### PR DESCRIPTION
## Problem

The manual avatar/header URL inputs only validated URL *format* (`validateImageUri`: valid URL, allowed protocol, no raw IP), not that the URL actually returns an image — so links like `https://www.instagram.com/` or `https://x.com/` could be saved as an avatar/header. (Original report by Laura.)

## Approach

Add an async "is this actually an image" check that runs debounced as the user types and surfaces the error inline under the input via the existing `Input` error mechanism. The check uses an in-browser image load (`new Image()`, resolve on `onload`, fail on `onerror`/timeout) rather than a HEAD/content-type `fetch`: image loading is not subject to CORS the way `fetch` is, so a content-type fetch would falsely reject valid images from hosts that don't send CORS headers.

## Implementation

- **`src/validators/validateImageUrl.ts`** — `imageUrlReturnsImage(url, timeoutMs = 10000): Promise<boolean>`. For http(s) and `data:` URLs, loads via `new Image()` and resolves `true` on load, `false` on error/timeout. `ipfs:`/`eip155:` are out of scope (handled by the existing avatar resolution via `useEnsAvatar`) and resolve `true`. `validateImageUri` remains the synchronous first gate.
- **`AvatarManual.tsx` / `HeaderManual.tsx`** — on each change, run `validateImageUri` immediately; if it passes, debounce the async `imageUrlReturnsImage` check by 450ms (via the existing `useDebouncedCallback`). The existing `error` state is set from whichever check fails and cleared on a valid result; a "Checking image…" indicator shows while validating; Confirm/Save is disabled while validating or when `error` is set. A ref guards against stale async results when the input changes during an in-flight check.

## Tests

- **Unit** — `validateImageUrl.test.ts` (mocks `Image`: onload→true, onerror→false, timeout→false; covers http(s), `data:`, ipfs/eip155 passthrough, unparseable/unsupported URLs). `AvatarManual.test.tsx` / `HeaderManual.test.tsx` (fake timers): a non-image URL shows the inline error and disables Confirm/Save after the debounce; a valid image URL clears it and enables; the validating indicator shows in flight; a stale async result does not clobber the current value.
- **e2e (stateless)** — new avatar + header tests in `profileEditor.spec.ts` covering the non-image path (inline error appears after typing, Confirm/Save disabled, no submit) and the valid-image path (error clears, savable). Existing manual-URL fixtures in `profileEditor.spec.ts` and `registerName.spec.ts` are converted to a loadable 1×1 `data:image/png` URL so the new gate passes deterministically — the previous `https://image.com/...` / gateway fixtures don't actually load as images and would now be (correctly) rejected.

## Verification

- `pnpm test` — all 19 new unit tests pass. The only failures are 2 pre-existing, environment-specific `utils.test.ts` timezone cases (`24:00:00` vs `00:00:00`), which also fail on `main` and are unrelated to this change.
- `pnpm lint` — passes.
- `pnpm lint:types` — introduces no new errors (the 46 pre-existing errors, all in unrelated `*.test.ts` files, are identical on `main`).
- `pnpm knip` — passes.
- `pnpm e2e --project=stateless` — run against a production build (as CI does). Every test touching the manual avatar/header flow passes: the 2 new validation tests (verified stable across repeated runs), the 4 button-text + 3 full-registration manual tests in `registerName.spec.ts`, and the 2 converted resolver tests in `profileEditor.spec.ts`.

FET-2440
