### PR TITLE
Fix invisible renew link in disabled extension banner

### DIFF
--- a/src/transaction-flow/input/ExtendNames/ExtendNames-flow.tsx
+++ b/src/transaction-flow/input/ExtendNames/ExtendNames-flow.tsx
@@ -41,27 +41,31 @@ import { deriveYearlyFee, formatDurationOfDates } from '@app/utils/utils'
 import { ShortExpiry } from '../../../components/@atoms/ExpiryComponents/ExpiryComponents'
 import GasDisplay from '../../../components/@atoms/GasDisplay'
 import { SearchViewLoadingView } from '../SendName/views/SearchView/views/SearchViewLoadingView'
+import { getManagerRenewUrl } from './utils/getManagerRenewUrl'
 import { validateExtendNamesDuration } from './utils/validateExtendNamesDuration'
 
 type View = 'name-list' | 'no-ownership-warning' | 'registration' | 'disabled'
-
-const MANAGER_BASE_URL = 'https://app.ens.dev'
-
-/**
- * When the legacy ETHRegistrarController has been removed as a controller of
- * BaseRegistrarImplementation (e.g. Sepolia post ENS v2 beta), renewals via
- * the v1 controller revert on-chain. For a single name we deep-link to the
- * new Manager renewal page; for bulk renewal (which the new Manager does not
- * yet support) we fall back to the Manager homepage.
- */
-const getManagerRenewUrl = (names: string[]) =>
-  names.length === 1 ? `${MANAGER_BASE_URL}/renew/${names[0]}` : MANAGER_BASE_URL
 
 const DisabledContainer = styled.div(
   ({ theme }) => css`
     display: flex;
     justify-content: center;
     padding: ${theme.space['2']} 0;
+  `,
+)
+
+// The global stylesheet resets anchors to `color: inherit; text-decoration:
+// none`, which makes a bare <a> inside the banner look like plain text. Style
+// it explicitly so the "here" link reads as a clickable link.
+const ManagerLink = styled.a(
+  ({ theme }) => css`
+    color: ${theme.colors.accent};
+    text-decoration: underline;
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: none;
+    }
   `,
 )
 
@@ -403,7 +407,13 @@ const ExtendNames = ({
                   i18nKey="input.extendNames.disabled.banner"
                   components={{
                     // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-                    ManagerLink: <a href={getManagerRenewUrl(names)} />,
+                    ManagerLink: (
+                      <ManagerLink
+                        href={getManagerRenewUrl(names)}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                      />
+                    ),
                   }}
                 />
               </Banner>

--- a/src/transaction-flow/input/ExtendNames/utils/getManagerRenewUrl.test.ts
+++ b/src/transaction-flow/input/ExtendNames/utils/getManagerRenewUrl.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { getManagerRenewUrl, MANAGER_BASE_URL } from './getManagerRenewUrl'
+
+describe('getManagerRenewUrl', () => {
+  it('deep-links a single name to the Manager renew route as /renew/<name>', () => {
+    // The Manager route is `/renew/$name`; the reversed `/<name>/renew` 404s.
+    expect(getManagerRenewUrl(['nick.eth'])).toBe(`${MANAGER_BASE_URL}/renew/nick.eth`)
+  })
+
+  it('supports subnames and emoji/unicode labels in the path', () => {
+    expect(getManagerRenewUrl(['sub.nick.eth'])).toBe(`${MANAGER_BASE_URL}/renew/sub.nick.eth`)
+  })
+
+  it('falls back to the Manager homepage for bulk renewals', () => {
+    expect(getManagerRenewUrl(['nick.eth', 'alice.eth'])).toBe(MANAGER_BASE_URL)
+  })
+
+  it('falls back to the Manager homepage when there are no names', () => {
+    expect(getManagerRenewUrl([])).toBe(MANAGER_BASE_URL)
+  })
+})

--- a/src/transaction-flow/input/ExtendNames/utils/getManagerRenewUrl.ts
+++ b/src/transaction-flow/input/ExtendNames/utils/getManagerRenewUrl.ts
@@ -1,0 +1,15 @@
+export const MANAGER_BASE_URL = 'https://app.ens.dev'
+
+/**
+ * When the legacy ETHRegistrarController has been removed as a controller of
+ * BaseRegistrarImplementation (e.g. Sepolia post ENS v2 beta), renewals via
+ * the v1 controller revert on-chain. For a single name we deep-link to the
+ * new Manager renewal page; for bulk renewal (which the new Manager does not
+ * yet support) we fall back to the Manager homepage.
+ *
+ * The Manager renewal route is `/renew/$name` (see the apps-monorepo manager
+ * app: `apps/manager/src/routes/renew/$name.tsx`). The reversed form
+ * `/$name/renew` does not exist and 404s, so keep the order as `/renew/<name>`.
+ */
+export const getManagerRenewUrl = (names: string[]) =>
+  names.length === 1 ? `${MANAGER_BASE_URL}/renew/${names[0]}` : MANAGER_BASE_URL


### PR DESCRIPTION
## Problem

In the **Extend/Renew** modal, when renewal is disabled (legacy `ETHRegistrarController` removed as a controller — e.g. Sepolia post ENS v2 beta), the banner titled *"ENS v2 beta is now deployed on Sepolia"* shows a **"click here"** link to the new Manager. The link appeared dead — it didn't look or behave like a link.

### Root cause

The link already had a correct `href`, but it was rendered as a **bare `<a>`**. The global stylesheet in `src/pages/_app.tsx` resets all anchors:

```css
a { color: inherit; text-decoration: none; }
```

So `here` rendered as plain text — no colour, no underline, no affordance. Unlike the registration banner (which auto-redirects after 1s), this view has **no auto-redirect**, so the link is the *only* way to reach the Manager — making the dead-looking link especially impactful.

## URL verification

I verified the correct Manager renewal route two ways:

- **Route source** (`apps-monorepo`): `apps/manager/src/routes/renew/$name.tsx` declares `createFileRoute('/renew/$name')`.
- **HTTP probe**: `https://app.ens.dev/renew/nick.eth` → `200`, while the reversed `https://app.ens.dev/nick.eth/renew` → `404`.

So `app.ens.dev/renew/<name>` is correct and was already what the code produced. The order is **not** `/<name>/renew` (that 404s).

## Changes

- **Style the link** (`accent` colour + underline, pointer) so it clearly reads as a link, and open it with `target="_blank" rel="noreferrer noopener"` to preserve the user's current modal/session.
- **Extract `getManagerRenewUrl`** into a pure, documented util (`utils/getManagerRenewUrl.ts`) — single name → `/renew/<name>`; bulk renewal → Manager homepage (the new app doesn't support bulk renewal yet).
- **Add unit tests** (`utils/getManagerRenewUrl.test.ts`) that lock in the `/renew/<name>` format and document why the reversed form is wrong, preventing a regression.

## Testing

- `pnpm vitest run src/transaction-flow/input/ExtendNames` → **18/18 pass** (incl. 4 new).
- ESLint on changed files → **0 errors**.
- Type check: changed files are clean. Remaining `lint:types` errors are **pre-existing** and unrelated (`metadataCache.test.ts`, `loadPara.test.ts`, `routes.test.ts`, `getSendAbilities.test.ts`, `getEditAbilities.test.ts`) — confirmed by reproducing them with these changes stashed.

## Note

`RegistrationDisabledBanner.tsx` uses the same bare-`<a>` pattern, so its link is visually dead too — but it auto-redirects after 1s, so it's far less noticeable. Left out of scope here; happy to apply the same styling fix in a follow-up if desired.
