### PR TITLE
chore: upgrade @ensdomains/ensjs to ^4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@ensdomains/content-hash": "^3.1.1",
     "@ensdomains/ens-contracts": "1.6.0",
     "@ensdomains/ens-test-env": "1.0.1",
-    "@ensdomains/ensjs": "^4.2.2",
+    "@ensdomains/ensjs": "^4.3.0",
     "@ensdomains/thorin": "1.0.0-beta.28",
     "@getpara/rainbowkit": "1.4.0",
     "@getpara/rainbowkit-wallet": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,8 +152,8 @@ importers:
         specifier: 1.0.1
         version: 1.0.1(patch_hash=b597d2dae9a4a8d52bd7729b3a106b767b262d1014e17b17537bdac1edf9468b)
       '@ensdomains/ensjs':
-        specifier: ^4.2.2
-        version: 4.2.2(typescript@5.7.3)(viem@2.19.4(patch_hash=459ff6674e27f2eb2b856948748da6c10623d32d4bbda67b2f2635ac46351dff)(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.75))(zod@3.25.75)
+        specifier: ^4.3.0
+        version: 4.3.0(typescript@5.7.3)(viem@2.19.4(patch_hash=459ff6674e27f2eb2b856948748da6c10623d32d4bbda67b2f2635ac46351dff)(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.75))(zod@3.25.75)
       '@ensdomains/thorin':
         specifier: 1.0.0-beta.28
         version: 1.0.0-beta.28(@vanilla-extract/css@1.15.5(babel-plugin-macros@3.1.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1370,11 +1370,11 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@ensdomains/ensjs@4.2.2':
-    resolution: {integrity: sha512-nnnceOb1sWYNp9UrSVXjV8tXuT9OzoRhRZz8S69vYlbVkFBoHKn1Cme+SC618iJH9xu8Ia2XsB3CDlzR1ejlHQ==}
+  '@ensdomains/ensjs@4.3.0':
+    resolution: {integrity: sha512-FDTpcg/VhNk1xtxMXjKZBKHg6Nq4IeYrAmWhGNyaojvevfkXK8z+8iA0tIn6cLgS9hnl2TJOBFC/8lsHaBtKng==}
     engines: {node: '>=22'}
     peerDependencies:
-      viem: ^2.9.2
+      viem: ^2.35.0
 
   '@ensdomains/hardhat-toolbox-viem-extended@0.0.5':
     resolution: {integrity: sha512-swnGEV5shoHXOrTRkTJgWvMrem9RU6NPr76TsaLJQlJ0RQYKHZ67CvstaQrFHTk6eKP8TE4ktDDw2jURPXwtnQ==}
@@ -7547,9 +7547,6 @@ packages:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
-  sax@1.4.1:
-    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
-
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -10098,7 +10095,7 @@ snapshots:
       - bare-buffer
       - debug
 
-  '@ensdomains/ensjs@4.2.2(typescript@5.7.3)(viem@2.19.4(patch_hash=459ff6674e27f2eb2b856948748da6c10623d32d4bbda67b2f2635ac46351dff)(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.75))(zod@3.25.75)':
+  '@ensdomains/ensjs@4.3.0(typescript@5.7.3)(viem@2.19.4(patch_hash=459ff6674e27f2eb2b856948748da6c10623d32d4bbda67b2f2635ac46351dff)(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.75))(zod@3.25.75)':
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
       '@ensdomains/address-encoder': 1.1.4
@@ -17505,8 +17502,6 @@ snapshots:
 
   safe-stable-stringify@2.5.0: {}
 
-  sax@1.4.1: {}
-
   sax@1.6.0: {}
 
   saxes@6.0.0:
@@ -17633,7 +17628,7 @@ snapshots:
       '@types/node': 17.0.45
       '@types/sax': 1.2.7
       arg: 5.0.2
-      sax: 1.4.1
+      sax: 1.6.0
 
   slash@3.0.0: {}
 
@@ -18891,7 +18886,7 @@ snapshots:
 
   xml2js@0.6.2:
     dependencies:
-      sax: 1.4.1
+      sax: 1.6.0
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}

--- a/src/utils/contenthash.ts
+++ b/src/utils/contenthash.ts
@@ -9,6 +9,7 @@ export type ContentHashProtocol =
   | 'sia'
   | 'arweave'
   | 'ar'
+  | 'adnl'
 
 export type ContentHashProvider = 'ipfs' | 'swarm' | 'onion' | 'skynet' | 'arweave'
 
@@ -67,16 +68,19 @@ export const contentHashToString = (
   return ''
 }
 
-const contentHashProtocolToProviderMap = {
-  ipfs: 'ipfs',
-  ipns: 'ipfs',
-  bzz: 'swarm',
-  onion: 'onion',
-  onion3: 'onion',
-  sia: 'skynet',
-  arweave: 'arweave',
-  ar: 'arweave',
-} as const
+const contentHashProtocolToProviderMap: Partial<Record<ContentHashProtocol, ContentHashProvider>> =
+  {
+    ipfs: 'ipfs',
+    ipns: 'ipfs',
+    bzz: 'swarm',
+    onion: 'onion',
+    onion3: 'onion',
+    sia: 'skynet',
+    arweave: 'arweave',
+    ar: 'arweave',
+    // 'adnl' (TON) has no editable content hash provider
+  }
 
-export const getContentHashProvider = (protocol: ContentHashProtocol): ContentHashProvider =>
-  contentHashProtocolToProviderMap[protocol]
+export const getContentHashProvider = (
+  protocol: ContentHashProtocol,
+): ContentHashProvider | undefined => contentHashProtocolToProviderMap[protocol]


### PR DESCRIPTION
## Description

Upgrades `@ensdomains/ensjs` from `^4.2.2` to `^4.3.0`.

## Why

### 1. TON `adnl` content hash fix

ensjs v4.3.0 adds support for the TON `adnl` codec (`0xb69910`) in both `getDisplayCodec` and `matchProtocol`.

Previously, TON site content hashes (e.g. `tonnet.eth`) were decoded by `@ensdomains/content-hash` but ensjs's `getDisplayCodec` had no `adnl` case, so it fell through to `default → null`. This produced `{ protocolType: null, decoded: '<adnl hash>' }`, which rendered on the profile page as:

```
null://<adnl hash>
```

With v4.3.0, `getDisplayCodec` maps the `adnl` codec, so it now correctly resolves to:

```
adnl://<adnl hash>
```

The `matchProtocol` regex was also extended to include `adnl`, so `adnl://` input is now parseable/encodable in the editor and validator.

### 2. Latest Universal Resolver

v4.3.0 also updates the bundled chain contract addresses to use the latest Universal Resolver:

```
ensUniversalResolver: 0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe
```

on both mainnet and Sepolia. The app reads the UR address from the chain config (e.g. `getChainContractAddress(..., 'ensUniversalResolver')` and `client.chain.contracts.ensUniversalResolver.address`), so name/address resolution and reverse (primary name) lookups now flow through the latest UR.

## Changes

- `package.json`: `@ensdomains/ensjs` `^4.2.2` → `^4.3.0`
- `pnpm-lock.yaml`: regenerated

## Notes

This is the upstream fix for the `null://` TON content hash issue — no app-level workaround is required.
