### PR TITLE
feat(avatar): browse NFT avatars from manager, owner and eth-record addresses (WEB-95)

### DIFF
--- a/public/locales/en/transactionFlow.json
+++ b/public/locales/en/transactionFlow.json
@@ -15,8 +15,8 @@
             "loadError": "NFT cannot be loaded",
             "noNFTs": "No NFTs found for this address.",
             "address": {
-              "owned": "Owned",
-              "other": "Other"
+              "owned": "Your wallet",
+              "other": "ETH record"
             },
             "selected": {
               "title": "Selected NFT",

--- a/src/components/@molecules/ProfileEditor/Avatar/AvatarNFT.test.tsx
+++ b/src/components/@molecules/ProfileEditor/Avatar/AvatarNFT.test.tsx
@@ -1,11 +1,20 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { fireEvent, mockFunction, render, screen, userEvent, waitFor } from '@app/test-utils'
+import {
+  fireEvent,
+  mockFunction,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from '@app/test-utils'
 
 import * as ReactQuery from '@tanstack/react-query'
 import React from 'react'
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest'
 import { useAccount, useClient } from 'wagmi'
 
+import { useNameDetails } from '@app/hooks/useNameDetails'
 import * as UseInfiniteQuery from '@app/utils/query/useInfiniteQuery'
 
 import { makeMockIntersectionObserver } from '../../../../../test/mock/makeMockIntersectionObserver'
@@ -18,9 +27,22 @@ vi.mock('@app/hooks/chain/useCurrentBlockTimestamp', () => ({
 vi.mock('@app/hooks/chain/useChainName', () => ({
   useChainName: () => 'mainnet',
 }))
+vi.mock('@app/hooks/useNameDetails')
 
 const mockUseClient = mockFunction(useClient)
 const mockUseAccount = mockFunction(useAccount)
+const mockUseNameDetails = mockFunction(useNameDetails)
+
+const CONNECTED_ADDRESS = '0x0000000000000000000000000000000000000001'
+const MANAGER_ADDRESS = '0x0000000000000000000000000000000000000002'
+const REGISTRANT_ADDRESS = '0x0000000000000000000000000000000000000003'
+const ETH_RECORD_ADDRESS = '0x0000000000000000000000000000000000000004'
+
+// The `owner` query param each getNfts fetch was called with, in call order.
+const fetchedOwners = () =>
+  (fetch as unknown as Mock).mock.calls.map((call) =>
+    new URL(call[0] as string).searchParams.get('owner'),
+  )
 
 const mockHandleSubmit = vi.fn()
 const mockHandleCancel = vi.fn()
@@ -81,7 +103,15 @@ global.fetch = vi.fn(() => Promise.resolve({ json: mockFetch }))
 beforeEach(() => {
   mockFetch.mockClear()
   mockFetch = vi.fn()
+  ;(fetch as unknown as Mock).mockClear()
   mockUseAccount.mockReturnValue({ address: `0x${Date.now()}` })
+  // Default: no owner rows and no eth record, so the only source is the connected
+  // wallet and the source selector stays hidden (matching pre-feature behaviour).
+  mockUseNameDetails.mockReturnValue({
+    profile: { coins: [] },
+    ownerData: undefined,
+    wrapperData: undefined,
+  })
   mockUseClient.mockReturnValue({
     chain: {
       id: 1,
@@ -172,7 +202,7 @@ describe('<AvatarNFT />', () => {
 
     render(<AvatarNFT {...props} />)
 
-    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled())
     await waitFor(() =>
       expect(
         screen.queryByTestId('nft-0-0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85'),
@@ -241,7 +271,7 @@ describe('<AvatarNFT />', () => {
       pageParam: 'test123',
     }
     await queryFn(mockContext as any)
-    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(3))
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
     // @ts-ignore
     expect(fetch.mock.lastCall[0]).toMatch(/pageKey=test123/)
   })
@@ -296,5 +326,144 @@ describe('<AvatarNFT />', () => {
     await waitFor(() =>
       expect(screen.getByText('input.profileEditor.tabs.avatar.nft.noResults')).toBeVisible(),
     )
+  })
+
+  describe('avatar source selector', () => {
+    // Legacy (unwrapped) name owned by manager + registrant, with an eth address record.
+    const mockLegacyName = () => {
+      mockUseAccount.mockReturnValue({ address: CONNECTED_ADDRESS })
+      mockUseNameDetails.mockReturnValue({
+        profile: { coins: [{ id: 60, name: 'eth', value: ETH_RECORD_ADDRESS }] },
+        ownerData: { owner: MANAGER_ADDRESS, registrant: REGISTRANT_ADDRESS },
+        wrapperData: undefined,
+      })
+    }
+
+    beforeEach(() => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ownedNfts: Array.from({ length: 5 }, generateNFT(true)),
+          totalCount: 5,
+        }),
+      )
+    })
+
+    const clickSource = (testId: string) =>
+      fireEvent.click(within(screen.getByTestId(testId)).getByRole('button', { hidden: true }))
+
+    it('defaults to browsing the connected wallet NFTs', async () => {
+      mockLegacyName()
+      render(<AvatarNFT {...props} />)
+
+      await waitFor(() => expect(fetch).toHaveBeenCalled())
+      expect(fetchedOwners()[0]).toBe(CONNECTED_ADDRESS)
+    })
+
+    it('lists connected wallet, manager, owner and eth record as deduped sources', async () => {
+      mockLegacyName()
+      render(<AvatarNFT {...props} />)
+
+      const selector = await screen.findByTestId('nft-source-selector')
+      expect(within(selector).getByTestId('nft-source-wallet')).toBeInTheDocument()
+      expect(within(selector).getByTestId('nft-source-owner-button-owner')).toBeInTheDocument()
+      expect(
+        within(selector).getByTestId('nft-source-owner-button-registrant'),
+      ).toBeInTheDocument()
+      expect(within(selector).getByTestId('nft-source-eth-record')).toBeInTheDocument()
+
+      // Assert each source's rendered label key, so a swapped labelKey (e.g. manager vs
+      // owner, or wallet vs eth record) fails here even though the testIds are unchanged.
+      // (The test i18n mock ignores the `ns` option, so namespace routing isn't asserted.)
+      expect(
+        within(screen.getByTestId('nft-source-wallet')).getByText(
+          'input.profileEditor.tabs.avatar.nft.address.owned',
+        ),
+      ).toBeInTheDocument()
+      expect(
+        within(screen.getByTestId('nft-source-owner-button-owner')).getByText('name.manager'),
+      ).toBeInTheDocument()
+      expect(
+        within(screen.getByTestId('nft-source-owner-button-registrant')).getByText('name.owner'),
+      ).toBeInTheDocument()
+      expect(
+        within(screen.getByTestId('nft-source-eth-record')).getByText(
+          'input.profileEditor.tabs.avatar.nft.address.other',
+        ),
+      ).toBeInTheDocument()
+    })
+
+    it('refetches with the selected source address as owner', async () => {
+      mockLegacyName()
+      render(<AvatarNFT {...props} />)
+
+      await screen.findByTestId('nft-source-selector')
+
+      clickSource('nft-source-owner-button-registrant')
+      await waitFor(() => expect(fetchedOwners()).toContain(REGISTRANT_ADDRESS))
+
+      clickSource('nft-source-eth-record')
+      await waitFor(() => expect(fetchedOwners()).toContain(ETH_RECORD_ADDRESS))
+    })
+
+    it('collapses to a single source and hides the selector when addresses match case-insensitively', async () => {
+      const lower = `0x${'a'.repeat(40)}` as `0x${string}`
+      const upper = `0x${'A'.repeat(40)}` as `0x${string}`
+      mockUseAccount.mockReturnValue({ address: lower })
+      mockUseNameDetails.mockReturnValue({
+        profile: { coins: [{ id: 60, name: 'eth', value: upper }] },
+        ownerData: { owner: upper, registrant: upper },
+        wrapperData: undefined,
+      })
+
+      render(<AvatarNFT {...props} />)
+
+      await waitFor(() => expect(screen.getByTestId('avatar-search-input')).toBeInTheDocument())
+      expect(screen.queryByTestId('nft-source-selector')).not.toBeInTheDocument()
+      expect(fetchedOwners().every((owner) => owner === lower)).toBe(true)
+    })
+
+    it('surfaces a wrapped name owner as one source without a separate registrant', async () => {
+      mockUseAccount.mockReturnValue({ address: CONNECTED_ADDRESS })
+      mockUseNameDetails.mockReturnValue({
+        profile: { coins: [] },
+        ownerData: { owner: MANAGER_ADDRESS, registrant: REGISTRANT_ADDRESS },
+        wrapperData: {
+          owner: MANAGER_ADDRESS,
+          fuses: { parent: { PARENT_CANNOT_CONTROL: false } },
+        },
+      })
+
+      render(<AvatarNFT {...props} />)
+
+      const selector = await screen.findByTestId('nft-source-selector')
+      expect(within(selector).getByTestId('nft-source-owner-button-manager')).toBeInTheDocument()
+      expect(
+        within(selector).queryByTestId('nft-source-owner-button-registrant'),
+      ).not.toBeInTheDocument()
+      expect(within(selector).queryByTestId('nft-source-eth-record')).not.toBeInTheDocument()
+    })
+
+    it('submits an NFT picked from a non-connected source', async () => {
+      mockLegacyName()
+      render(<AvatarNFT {...props} />)
+
+      await screen.findByTestId('nft-source-selector')
+      clickSource('nft-source-owner-button-owner')
+      await waitFor(() => expect(fetchedOwners()).toContain(MANAGER_ADDRESS))
+
+      await waitFor(() => expect(screen.getByTestId('nft-0-0x0')).toBeVisible())
+      fireEvent.load(screen.getByTestId('nft-image-0-0x0'))
+      await waitFor(() => expect(screen.getByTestId('nft-0-0x0')).toBeEnabled())
+      fireEvent.click(screen.getByTestId('nft-0-0x0'))
+      await waitFor(() => expect(screen.getByText('NFT 0 description')).toBeVisible())
+      fireEvent.click(screen.getByText('action.confirm'))
+      await waitFor(() =>
+        expect(mockHandleSubmit).toHaveBeenCalledWith(
+          'nft',
+          'eip155:1/erc1155:0x0/0',
+          'https://localhost/test-media-gateway.png',
+        ),
+      )
+    })
   })
 })

--- a/src/components/@molecules/ProfileEditor/Avatar/AvatarNFT.tsx
+++ b/src/components/@molecules/ProfileEditor/Avatar/AvatarNFT.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { keepPreviousData } from '@tanstack/react-query'
-import { ReactNode, useCallback, useState } from 'react'
+import { Key, ReactNode, useCallback, useMemo, useState } from 'react'
 import { TFunction, useTranslation } from 'react-i18next'
 import styled, { css, DefaultTheme, keyframes } from 'styled-components'
 import { useAccount, useClient } from 'wagmi'
@@ -14,9 +14,11 @@ import {
   Typography,
 } from '@ensdomains/thorin'
 
+import { LegacyDropdown } from '@app/components/@molecules/LegacyDropdown/LegacyDropdown'
 import { SpinnerRow } from '@app/components/@molecules/ScrollBoxWithSpinner'
 import { useChainName } from '@app/hooks/chain/useChainName'
 import { useNameDetails } from '@app/hooks/useNameDetails'
+import { useOwners } from '@app/hooks/useOwners'
 import { getSupportedChainContractAddress } from '@app/utils/getSupportedChainContractAddress'
 import { useInfiniteQuery } from '@app/utils/query/useInfiniteQuery'
 
@@ -242,13 +244,18 @@ const FilterContainer = styled.div(
     @media (min-width: ${theme.breakpoints.sm}px) {
       margin-bottom: ${theme.space['6']};
     }
+  `,
+)
 
-    & > button {
-      flex-basis: 100px;
-      margin-bottom: -${theme.space['4']};
-      @media (min-width: ${theme.breakpoints.sm}px) {
-        margin-bottom: -${theme.space['6']};
-      }
+// Keeps the source selector at its content width (so the search input takes the rest)
+// and bottom-aligns it with the DialogInput, which pulls itself up by the same amount.
+const SourceSelectorContainer = styled.div(
+  ({ theme }) => css`
+    flex-shrink: 0;
+    margin-bottom: -${theme.space['4']};
+
+    @media (min-width: ${theme.breakpoints.sm}px) {
+      margin-bottom: -${theme.space['6']};
     }
   `,
 )
@@ -338,16 +345,63 @@ const NftItem = ({
   )
 }
 
-function useProfileAddresses(name: string) {
-  const { profile } = useNameDetails({ name })
+type AvatarSource = {
+  address: string
+  // i18n key for the source's role label. Owner rows resolve in the `common`
+  // namespace (see `ns`); wallet/eth rows use the component's `transactionFlow` default.
+  labelKey: string
+  ns?: 'common'
+  testId: string
+}
 
-  const addresses = (profile?.coins ?? []).filter((x) => ['eth'].includes(x.name.toLowerCase()))
+// Ordered, case-insensitively deduped set of addresses whose NFTs can be browsed as
+// an avatar source: the connected wallet (default), the name's manager/owner rows
+// (from `useOwners`), and the eth address record. Connected wallet is kept first so
+// the default browsing behaviour is unchanged.
+function useAvatarSources(name: string, connectedAddress?: string): readonly AvatarSource[] {
+  const { profile, ownerData, wrapperData } = useNameDetails({ name })
+  const owners = useOwners({ ownerData, wrapperData })
 
-  const ethAddress = addresses[0]?.value
+  return useMemo(() => {
+    const ethAddress = (profile?.coins ?? []).find((coin) => coin.name.toLowerCase() === 'eth')
+      ?.value
 
-  return {
-    ethAddress,
-  }
+    const candidates: AvatarSource[] = [
+      ...(connectedAddress
+        ? [
+            {
+              address: connectedAddress,
+              labelKey: 'input.profileEditor.tabs.avatar.nft.address.owned',
+              testId: 'nft-source-wallet',
+            },
+          ]
+        : []),
+      ...owners.map<AvatarSource>((owner) => ({
+        address: owner.address,
+        labelKey: owner.label,
+        ns: 'common',
+        testId: `nft-source-${owner.testId}`,
+      })),
+      ...(ethAddress
+        ? [
+            {
+              address: ethAddress,
+              labelKey: 'input.profileEditor.tabs.avatar.nft.address.other',
+              testId: 'nft-source-eth-record',
+            },
+          ]
+        : []),
+    ]
+
+    const seen = new Set<string>()
+    return candidates.filter((source) => {
+      if (!source.address) return false
+      const key = source.address.toLowerCase()
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+  }, [profile, owners, connectedAddress])
 }
 
 export const AvatarNFT = ({
@@ -365,13 +419,22 @@ export const AvatarNFT = ({
   const { address: _address } = useAccount()
   const address = _address!
 
-  const { ethAddress } = useProfileAddresses(name)
+  const sources = useAvatarSources(name, _address)
 
   const [searchedInput, setSearchedInput] = useState('')
   const [selectedAddress, setSelectedAddress] = useState<string>(address)
   const [selectedNFT, setSelectedNFT] = useState<number | null>(null)
 
-  const { data: NFTPages, fetchNextPage, isLoading } = useNtfs(chain, selectedAddress)
+  // Resolve the selected source from the (possibly async-changing) source list, falling
+  // back to the first source. Both the dropdown label and the NFT query read the resolved
+  // source's address, so they can never disagree even if `selectedAddress` drops out of
+  // `sources` (e.g. owner data refetches).
+  const selectedSource =
+    sources.find((source) => source.address.toLowerCase() === selectedAddress.toLowerCase()) ??
+    sources[0]
+  const fetchAddress = selectedSource?.address ?? selectedAddress
+
+  const { data: NFTPages, fetchNextPage, isLoading } = useNtfs(chain, fetchAddress)
 
   const NFTs = (NFTPages?.pages ?? [])
     .reduce((prev, curr) => [...prev, ...curr.ownedNfts], [] as OwnedNFT[])
@@ -381,11 +444,8 @@ export const AvatarNFT = ({
   const hasNextPage = !!NFTPages?.pages[NFTPages.pages.length - 1].pageKey
   const fetchPage = useCallback(() => fetchNextPage(), [fetchNextPage])
 
-  const handleSelectAddress = () => {
-    if (!ethAddress) return
-
-    setSelectedAddress((prev) => (prev === address ? ethAddress : address))
-  }
+  const getSourceLabel = (source: AvatarSource) =>
+    t(source.labelKey, source.ns ? { ns: source.ns } : undefined)
 
   if (selectedNFT !== null) {
     const nftReference = NFTs?.[selectedNFT]!
@@ -432,16 +492,31 @@ export const AvatarNFT = ({
 
   const searchBox = (
     <FilterContainer>
-      {!ethAddress ||
-        (address !== ethAddress && (
-          <Button onClick={handleSelectAddress}>
-            {t(
-              `input.profileEditor.tabs.avatar.nft.address.${
-                selectedAddress === address ? 'other' : 'owned'
-              }`,
-            )}
-          </Button>
-        ))}
+      {sources.length > 1 && (
+        <SourceSelectorContainer>
+          <LegacyDropdown
+            shortThrow
+            keepMenuOnTop
+            inheritContentWidth
+            data-testid="nft-source-selector"
+            label={selectedSource ? getSourceLabel(selectedSource) : ''}
+            items={sources.map((source) => ({
+              label: getSourceLabel(source),
+              value: source.address,
+              color: 'text',
+              onClick: () => {
+                setSelectedAddress(source.address)
+                setSelectedNFT(null)
+              },
+              wrapper: (children: ReactNode, key: Key) => (
+                <div data-testid={source.testId} key={key}>
+                  {children}
+                </div>
+              ),
+            }))}
+          />
+        </SourceSelectorContainer>
+      )}
       <DialogInput
         icon={<MagnifyingGlassSVG />}
         hideLabel


### PR DESCRIPTION
Ref: WEB-95

## What & why

Users could only source an NFT avatar from the connected wallet or the name's ETH address record — a binary toggle. This lets them browse and pick NFT avatars held by **any** of the name's associated addresses: the connected wallet, the manager (or wrapped owner), the owner/registrant, and the ETH address record.

## Changes

- **`AvatarNFT.tsx`** — replaced the local `useProfileAddresses` helper with a pure `useAvatarSources(name, connectedAddress)` hook that returns an ordered, case-insensitively deduped source list `[connected wallet, ...useOwners rows, eth record]`. The binary toggle button is replaced with a thorin `LegacyDropdown` source selector that sets `selectedAddress`. The connected wallet stays the default (regression-safe) and the selector is hidden when a name has a single source. The fetch layer, pagination, grid, selected-NFT confirm screen, and the `eip155` URI builder are untouched.
- **`transactionFlow.json`** — repurposed the existing `nft.address.owned`/`other` keys to `"Your wallet"` / `"ETH record"`; manager/owner labels come from `useOwners` via the `common` namespace.
- **`AvatarNFT.test.tsx`** — extended the Vitest suite: default source = connected wallet (regression guard), per-source refetch with the selected address as `owner`, case-insensitive dedup, wrapped-name handling (single wrapper owner, no separate registrant), and an end-to-end pick from a non-connected source calling `handleSubmit` with the `eip155` URI.

## Notes / scope

- **No new fetch or service** — `getNfts` already accepts any address; changing `selectedAddress` auto-refetches via the React Query key.
- **No ownership check** (unchanged): external spec-compliant clients (metadata.ens.domains, wallets) verify NFT ownership against the name's associated addresses. The connected wallet still signs the `setRecords` transaction and the `canEditRecords` permission gate is unchanged — browsing another address's NFTs does not change who can write records.
- The `eip155` chain id remains hardcoded to `1` in the URI builder (pre-existing, out of scope).

## Testing

- `pnpm test src/components/@molecules/ProfileEditor/Avatar/AvatarNFT.test.tsx` — 14/14 pass.
- `pnpm lint` → exit 0. `pnpm lint:types` → the change adds zero type errors (repo has pre-existing baseline errors in unrelated `.test`/`.spec` files).
