### PR TITLE
feat: custom RPC endpoint in settings (WEB-139)

### DIFF
--- a/e2e/specs/stateless/settings.spec.ts
+++ b/e2e/specs/stateless/settings.spec.ts
@@ -160,3 +160,63 @@ test.describe('Select Primary Name', () => {
     await expect(settingsPage.getPrimaryNameLabel()).toHaveText(name, { timeout: 15000 })
   })
 })
+
+test.describe('Custom RPC endpoint', () => {
+  test('validates, probes, persists and resets a custom RPC endpoint', async ({
+    page,
+    login,
+    makePageObject,
+  }) => {
+    const settingsPage = makePageObject('SettingsPage')
+
+    await page.goto('/')
+    await login.connect()
+    await settingsPage.goto()
+    await expect(settingsPage.rpcSection).toBeVisible()
+
+    // Use a same-origin sentinel so the probe fetch needs no CORS, and intercept it to report
+    // the active (anvil) chain id 0x539 = 1337 so the save-time liveness probe passes.
+    const { origin } = new URL(page.url())
+    const customUrl = `${origin}/__ens_custom_rpc`
+    let probed = false
+    await page.route('**/__ens_custom_rpc', async (route) => {
+      probed = true
+      const body = route.request().postDataJSON()
+      const reply = (req: { id?: number }) => ({
+        jsonrpc: '2.0',
+        id: req?.id ?? 1,
+        result: '0x539',
+      })
+      const payload = Array.isArray(body) ? body.map(reply) : reply(body)
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify(payload) })
+    })
+
+    const readStore = () => page.evaluate(() => window.localStorage.getItem('customRpcUrls'))
+
+    // Invalid URL: inline error and save disabled.
+    await settingsPage.rpcUrlInput.fill('not a url')
+    await expect(page.getByText(/Enter a valid URL/i)).toBeVisible()
+    await expect(settingsPage.rpcSaveButton).toBeDisabled()
+
+    // Valid URL: probe succeeds and a reload prompt appears.
+    await settingsPage.rpcUrlInput.fill(customUrl)
+    await expect(settingsPage.rpcSaveButton).toBeEnabled()
+    await settingsPage.rpcSaveButton.click()
+    await expect(settingsPage.rpcReloadButton).toBeVisible()
+    expect(probed).toBe(true)
+    expect(await readStore()).toContain('__ens_custom_rpc')
+
+    // Reset clears the stored entry for the active chain.
+    await settingsPage.rpcResetButton.click()
+    await expect(settingsPage.rpcUrlInput).toHaveValue('')
+    expect(await readStore()).not.toContain('__ens_custom_rpc')
+
+    // Re-save, then confirm the override survives a full page reload (per-device persistence).
+    await settingsPage.rpcUrlInput.fill(customUrl)
+    await expect(settingsPage.rpcSaveButton).toBeEnabled()
+    await settingsPage.rpcSaveButton.click()
+    await expect(settingsPage.rpcReloadButton).toBeVisible()
+    await page.reload()
+    expect(await readStore()).toContain('__ens_custom_rpc')
+  })
+})

--- a/playwright/pageObjects/settingsPage.ts
+++ b/playwright/pageObjects/settingsPage.ts
@@ -12,12 +12,33 @@ export class SettingsPage {
 
   readonly walletAddress: Locator
 
+  readonly rpcSection: Locator
+
+  readonly rpcUrlInput: Locator
+
+  readonly rpcExclusiveToggle: Locator
+
+  readonly rpcExclusiveWarning: Locator
+
+  readonly rpcSaveButton: Locator
+
+  readonly rpcResetButton: Locator
+
+  readonly rpcReloadButton: Locator
+
   constructor(page: Page) {
     this.page = page
     this.changePrimaryNameButton = this.page.getByTestId('change-primary-name-button')
     this.removePrimaryNameButton = this.page.getByTestId('remove-primary-name-button')
     this.choosePrimaryNameButton = this.page.getByTestId('set-primary-name-button')
     this.walletAddress = this.page.getByTestId('name-details-address-address')
+    this.rpcSection = this.page.getByTestId('rpc-section')
+    this.rpcUrlInput = this.page.getByTestId('rpc-url-input')
+    this.rpcExclusiveToggle = this.page.getByTestId('rpc-exclusive-toggle')
+    this.rpcExclusiveWarning = this.page.getByTestId('rpc-exclusive-warning')
+    this.rpcSaveButton = this.page.getByTestId('rpc-save-button')
+    this.rpcResetButton = this.page.getByTestId('rpc-reset-button')
+    this.rpcReloadButton = this.page.getByTestId('rpc-reload-button')
   }
 
   async goto() {

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -19,6 +19,35 @@
         "clearHistory": "Clear search history"
       }
     },
+    "rpc": {
+      "title": "Custom RPC endpoint",
+      "description": "By default the app uses an ENS-operated RPC endpoint. You can point it at your own JSON-RPC endpoint instead. This is stored on this device only and applies to the network this app serves.",
+      "label": "RPC URL",
+      "placeholder": "https://your-node.example",
+      "exclusive": {
+        "title": "Use only my RPC endpoint",
+        "description": "Disable the ENS-operated fallback so all requests go to your endpoint.",
+        "warning": "With no fallback, the app may stop working if your endpoint goes down or blocks browser requests."
+      },
+      "action": {
+        "save": "Save",
+        "reset": "Reset",
+        "reload": "Reload to apply"
+      },
+      "errors": {
+        "validate": {
+          "required": "Enter an RPC URL",
+          "invalidUrl": "Enter a valid URL",
+          "invalidProtocol": "URL must start with http:// or https://"
+        },
+        "probe": {
+          "wrongChain": "This endpoint reports a different network (chain ID {{chainId}}) and cannot be used here.",
+          "unreachable": "Could not reach this endpoint. Check the URL and that it allows browser (CORS) requests.",
+          "timeout": "This endpoint took too long to respond.",
+          "invalidResponse": "This endpoint did not return a valid JSON-RPC response."
+        }
+      }
+    },
     "primary": {
       "title": "Primary Name",
       "noNameDescription": "A primary name links your address to a name, allowing dApps to display a name as your profile when connected to them. Only normalized names are shown. <primaryNameLink>Learn about primary names</primaryNameLink>",

--- a/src/components/pages/profile/settings/RpcSection/index.test.tsx
+++ b/src/components/pages/profile/settings/RpcSection/index.test.tsx
@@ -1,0 +1,226 @@
+import { fireEvent, mockFunction, render, screen, waitFor } from '@app/test-utils'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useLocalStorage } from '@app/hooks/useLocalStorage'
+import { probeRpcUrl } from '@app/utils/query/probeRpcUrl'
+import type { CustomRpcUrls } from '@app/utils/query/customRpc'
+
+import { RpcSection } from './index'
+
+vi.mock('@app/hooks/useLocalStorage', () => ({
+  useLocalStorage: vi.fn(),
+}))
+
+vi.mock('@app/utils/query/probeRpcUrl', () => ({
+  probeRpcUrl: vi.fn(),
+}))
+
+const mockUseLocalStorage = mockFunction(useLocalStorage)
+// vi.mocked (not mockFunction) so the async ProbeResult return type is preserved for
+// mockResolvedValue — mockFunction DeepPartials the Promise and breaks the typing.
+const mockProbeRpcUrl = vi.mocked(probeRpcUrl)
+
+// test-utils mocks the wagmi config to a single mainnet chain, so useChainId() === 1.
+const CHAIN_ID = 1
+
+const typeUrl = (value: string) =>
+  fireEvent.change(screen.getByTestId('rpc-url-input'), { target: { value } })
+
+// The component writes via functional updaters (setCustomRpcUrls(prev => ...)) so a late
+// probe composes with the latest stored value; apply the recorded updater to inspect its result.
+const applyLastUpdater = (setter: ReturnType<typeof vi.fn>, prev: CustomRpcUrls): CustomRpcUrls => {
+  const updater = setter.mock.calls.at(-1)?.[0]
+  return typeof updater === 'function' ? updater(prev) : updater
+}
+
+describe('RpcSection', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders with an empty form and disabled save/reset when nothing is stored', () => {
+    mockUseLocalStorage.mockReturnValue([{}, vi.fn()])
+
+    render(<RpcSection />)
+
+    expect(screen.getByTestId('rpc-section')).toBeInTheDocument()
+    expect(screen.getByTestId('rpc-url-input')).toHaveValue('')
+    expect(screen.getByTestId('rpc-save-button')).toBeDisabled()
+    expect(screen.getByTestId('rpc-reset-button')).toBeDisabled()
+  })
+
+  it('pre-populates the form from a stored value for the active chain (persistence across reloads)', () => {
+    mockUseLocalStorage.mockReturnValue([
+      { [CHAIN_ID]: { url: 'https://stored.example', exclusive: true } },
+      vi.fn(),
+    ])
+
+    render(<RpcSection />)
+
+    expect(screen.getByTestId('rpc-url-input')).toHaveValue('https://stored.example')
+    expect(screen.getByTestId('rpc-exclusive-toggle')).toBeChecked()
+    expect(screen.getByTestId('rpc-exclusive-warning')).toBeInTheDocument()
+  })
+
+  it('shows an inline error and keeps save disabled for an invalid url', async () => {
+    mockUseLocalStorage.mockReturnValue([{}, vi.fn()])
+
+    render(<RpcSection />)
+
+    typeUrl('not a url')
+
+    expect(await screen.findByText('section.rpc.errors.validate.invalidUrl')).toBeInTheDocument()
+    expect(screen.getByTestId('rpc-save-button')).toBeDisabled()
+    expect(mockProbeRpcUrl).not.toHaveBeenCalled()
+  })
+
+  it('probes, persists and prompts a reload on a valid save', async () => {
+    const setUrls = vi.fn()
+    mockUseLocalStorage.mockReturnValue([{}, setUrls])
+    mockProbeRpcUrl.mockResolvedValue({ success: true })
+
+    render(<RpcSection />)
+
+    typeUrl('https://my.node.example')
+    await waitFor(() => expect(screen.getByTestId('rpc-save-button')).toBeEnabled())
+
+    fireEvent.click(screen.getByTestId('rpc-save-button'))
+
+    await waitFor(() =>
+      expect(mockProbeRpcUrl).toHaveBeenCalledWith({
+        url: 'https://my.node.example',
+        chainId: CHAIN_ID,
+      }),
+    )
+    expect(applyLastUpdater(setUrls, {})).toEqual({
+      [CHAIN_ID]: { url: 'https://my.node.example', exclusive: false },
+    })
+    expect(await screen.findByTestId('rpc-reload-button')).toBeInTheDocument()
+  })
+
+  it('composes the save with the latest stored value rather than a stale snapshot', async () => {
+    const setUrls = vi.fn()
+    // Another chain's entry must survive a save for the active chain.
+    mockUseLocalStorage.mockReturnValue([{ 999: { url: 'https://other', exclusive: false } }, setUrls])
+    mockProbeRpcUrl.mockResolvedValue({ success: true })
+
+    render(<RpcSection />)
+
+    typeUrl('https://my.node.example')
+    await waitFor(() => expect(screen.getByTestId('rpc-save-button')).toBeEnabled())
+    fireEvent.click(screen.getByTestId('rpc-save-button'))
+
+    await waitFor(() => expect(setUrls).toHaveBeenCalled())
+    // Apply the updater to a DIFFERENT prev than render-time to prove it isn't a stale snapshot.
+    expect(applyLastUpdater(setUrls, { 999: { url: 'https://other', exclusive: false } })).toEqual({
+      999: { url: 'https://other', exclusive: false },
+      [CHAIN_ID]: { url: 'https://my.node.example', exclusive: false },
+    })
+  })
+
+  it('persists the exclusive flag and shows the warning when enabled', async () => {
+    const setUrls = vi.fn()
+    mockUseLocalStorage.mockReturnValue([{}, setUrls])
+    mockProbeRpcUrl.mockResolvedValue({ success: true })
+
+    render(<RpcSection />)
+
+    typeUrl('https://my.node.example')
+    fireEvent.click(screen.getByTestId('rpc-exclusive-toggle'))
+
+    expect(await screen.findByTestId('rpc-exclusive-warning')).toBeInTheDocument()
+
+    await waitFor(() => expect(screen.getByTestId('rpc-save-button')).toBeEnabled())
+    fireEvent.click(screen.getByTestId('rpc-save-button'))
+
+    await waitFor(() => expect(setUrls).toHaveBeenCalled())
+    expect(applyLastUpdater(setUrls, {})).toEqual({
+      [CHAIN_ID]: { url: 'https://my.node.example', exclusive: true },
+    })
+  })
+
+  it('surfaces a probe failure and does not persist', async () => {
+    const setUrls = vi.fn()
+    mockUseLocalStorage.mockReturnValue([{}, setUrls])
+    mockProbeRpcUrl.mockResolvedValue({ success: false, reason: 'wrongChain', reportedChainId: 5 })
+
+    render(<RpcSection />)
+
+    typeUrl('https://my.node.example')
+    await waitFor(() => expect(screen.getByTestId('rpc-save-button')).toBeEnabled())
+    fireEvent.click(screen.getByTestId('rpc-save-button'))
+
+    expect(await screen.findByText('section.rpc.errors.probe.wrongChain')).toBeInTheDocument()
+    expect(setUrls).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('rpc-reload-button')).not.toBeInTheDocument()
+  })
+
+  it('keeps Save enabled after a probe failure so the same URL can be retried', async () => {
+    const setUrls = vi.fn()
+    mockUseLocalStorage.mockReturnValue([{}, setUrls])
+    mockProbeRpcUrl.mockResolvedValueOnce({ success: false, reason: 'timeout' })
+
+    render(<RpcSection />)
+
+    typeUrl('https://my.node.example')
+    await waitFor(() => expect(screen.getByTestId('rpc-save-button')).toBeEnabled())
+    fireEvent.click(screen.getByTestId('rpc-save-button'))
+
+    // Probe failed, but the URL is still valid — Save must remain usable to retry it.
+    expect(await screen.findByText('section.rpc.errors.probe.timeout')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByTestId('rpc-save-button')).toBeEnabled())
+
+    // Retry the same URL; this time the probe succeeds and it persists.
+    mockProbeRpcUrl.mockResolvedValueOnce({ success: true })
+    fireEvent.click(screen.getByTestId('rpc-save-button'))
+    await waitFor(() => expect(setUrls).toHaveBeenCalled())
+    expect(applyLastUpdater(setUrls, {})).toEqual({
+      [CHAIN_ID]: { url: 'https://my.node.example', exclusive: false },
+    })
+  })
+
+  it('keeps the reload prompt visible when a later save attempt fails', async () => {
+    mockUseLocalStorage.mockReturnValue([{}, vi.fn()])
+    mockProbeRpcUrl.mockResolvedValueOnce({ success: true })
+
+    render(<RpcSection />)
+
+    // First save succeeds -> reload prompt appears.
+    typeUrl('https://good.example')
+    await waitFor(() => expect(screen.getByTestId('rpc-save-button')).toBeEnabled())
+    fireEvent.click(screen.getByTestId('rpc-save-button'))
+    expect(await screen.findByTestId('rpc-reload-button')).toBeInTheDocument()
+
+    // Editing to a second URL whose probe fails must not hide the still-pending reload prompt.
+    mockProbeRpcUrl.mockResolvedValueOnce({ success: false, reason: 'unreachable' })
+    typeUrl('https://bad.example')
+    await waitFor(() => expect(screen.getByTestId('rpc-save-button')).toBeEnabled())
+    fireEvent.click(screen.getByTestId('rpc-save-button'))
+
+    expect(await screen.findByText('section.rpc.errors.probe.unreachable')).toBeInTheDocument()
+    expect(screen.getByTestId('rpc-reload-button')).toBeInTheDocument()
+  })
+
+  it('resets by clearing the active chain entry (leaving others intact)', async () => {
+    const setUrls = vi.fn()
+    mockUseLocalStorage.mockReturnValue([
+      { [CHAIN_ID]: { url: 'https://stored.example', exclusive: false } },
+      setUrls,
+    ])
+
+    render(<RpcSection />)
+
+    const resetButton = screen.getByTestId('rpc-reset-button')
+    expect(resetButton).toBeEnabled()
+    fireEvent.click(resetButton)
+
+    expect(
+      applyLastUpdater(setUrls, {
+        [CHAIN_ID]: { url: 'https://stored.example', exclusive: false },
+        999: { url: 'https://other', exclusive: false },
+      }),
+    ).toEqual({ 999: { url: 'https://other', exclusive: false } })
+    expect(await screen.findByTestId('rpc-reload-button')).toBeInTheDocument()
+  })
+})

--- a/src/components/pages/profile/settings/RpcSection/index.tsx
+++ b/src/components/pages/profile/settings/RpcSection/index.tsx
@@ -1,0 +1,183 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import styled, { css } from 'styled-components'
+import { useChainId } from 'wagmi'
+
+import { Button, Input, Typography } from '@ensdomains/thorin'
+
+import { useLocalStorage } from '@app/hooks/useLocalStorage'
+import { DetailedSwitch } from '@app/transaction-flow/input/ProfileEditor/components/DetailedSwitch'
+import { CUSTOM_RPC_STORAGE_KEY, type CustomRpcUrls } from '@app/utils/query/customRpc'
+import { probeRpcUrl } from '@app/utils/query/probeRpcUrl'
+import { validateRpcUrl } from '@app/validators/validateRpcUrl'
+
+import { SectionContainer } from '../Section'
+
+const Container = styled.div(
+  ({ theme }) => css`
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    gap: ${theme.space['4']};
+  `,
+)
+
+const ButtonRow = styled.div(
+  ({ theme }) => css`
+    display: flex;
+    flex-direction: row;
+    gap: ${theme.space['2']};
+  `,
+)
+
+const Warning = styled(Typography)(
+  ({ theme }) => css`
+    color: ${theme.colors.redPrimary};
+  `,
+)
+
+type FormData = { url: string; exclusive: boolean }
+
+// Stable reference so useLocalStorage's `value !== defaultValue` guard doesn't treat a fresh
+// `{}` literal as a change on every keystroke-driven re-render (which would re-persist and
+// dispatch a synthetic storage event each keystroke).
+const EMPTY_CUSTOM_RPC_URLS: CustomRpcUrls = {}
+
+export function RpcSection() {
+  const { t } = useTranslation('settings')
+  const chainId = useChainId()
+  const queryClient = useQueryClient()
+
+  const [customRpcUrls, setCustomRpcUrls] = useLocalStorage<CustomRpcUrls>(
+    CUSTOM_RPC_STORAGE_KEY,
+    EMPTY_CUSTOM_RPC_URLS,
+  )
+  const current = customRpcUrls[chainId]
+
+  const [needsReload, setNeedsReload] = useState(false)
+  const [isProbing, setIsProbing] = useState(false)
+  // Probe failures are kept separate from react-hook-form validation errors: a format error
+  // must block Save, but a liveness-probe failure must not wedge Save disabled — the user has
+  // to be able to retry the same URL after a transient outage.
+  const [probeError, setProbeError] = useState<string>()
+
+  const { register, handleSubmit, watch, reset, formState } = useForm<FormData>({
+    mode: 'onChange',
+    defaultValues: { url: current?.url ?? '', exclusive: current?.exclusive ?? false },
+  })
+
+  const urlValue = watch('url')
+  const exclusive = watch('exclusive')
+  const validationError = formState.errors.url?.message
+
+  // Clear a stale probe error as soon as the URL is edited.
+  useEffect(() => {
+    setProbeError(undefined)
+  }, [urlValue])
+
+  const onSubmit = handleSubmit(async ({ url, exclusive: exclusiveValue }) => {
+    // Don't clear needsReload here: a change still needs a reload to apply, and a later
+    // failed save attempt must not hide the prompt for an earlier successful one.
+    setProbeError(undefined)
+    setIsProbing(true)
+    try {
+      const result = await probeRpcUrl({ url, chainId })
+      if (!result.success) {
+        setProbeError(
+          t(`section.rpc.errors.probe.${result.reason}`, { chainId: result.reportedChainId }),
+        )
+        return
+      }
+      // Functional updater so a probe that resolves after an intervening Reset composes with
+      // the latest stored value rather than resurrecting a stale snapshot.
+      setCustomRpcUrls((prev) => ({ ...prev, [chainId]: { url, exclusive: exclusiveValue } }))
+      // The IndexedDB React-Query cache survives reload, so drop it to avoid serving stale
+      // data from the previous endpoint after the transport switches.
+      queryClient.invalidateQueries()
+      setNeedsReload(true)
+    } finally {
+      setIsProbing(false)
+    }
+  })
+
+  const onReset = () => {
+    setCustomRpcUrls((prev) => {
+      const next = { ...prev }
+      delete next[chainId]
+      return next
+    })
+    reset({ url: '', exclusive: false })
+    queryClient.invalidateQueries()
+    setNeedsReload(true)
+  }
+
+  // Only a format-validation error blocks Save; a probe failure is shown but still retryable.
+  const canSave = !!urlValue && !validationError && !isProbing
+
+  return (
+    <SectionContainer data-testid="rpc-section" title={t('section.rpc.title')}>
+      <Container>
+        <Typography fontVariant="small">{t('section.rpc.description')}</Typography>
+        <Input
+          data-testid="rpc-url-input"
+          label={t('section.rpc.label')}
+          placeholder={t('section.rpc.placeholder')}
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
+          error={validationError ?? probeError}
+          {...register('url', {
+            validate: (value) => {
+              const result = validateRpcUrl(value)
+              return result === true ? true : t(`section.rpc.errors.validate.${result}`)
+            },
+          })}
+        />
+        <DetailedSwitch
+          data-testid="rpc-exclusive-toggle"
+          title={t('section.rpc.exclusive.title')}
+          description={t('section.rpc.exclusive.description')}
+          {...register('exclusive')}
+        />
+        {exclusive && (
+          <Warning fontVariant="small" data-testid="rpc-exclusive-warning">
+            {t('section.rpc.exclusive.warning')}
+          </Warning>
+        )}
+        <ButtonRow>
+          <Button
+            data-testid="rpc-save-button"
+            width="fit"
+            onClick={onSubmit}
+            loading={isProbing}
+            disabled={!canSave}
+          >
+            {t('section.rpc.action.save')}
+          </Button>
+          <Button
+            data-testid="rpc-reset-button"
+            width="fit"
+            colorStyle="accentSecondary"
+            onClick={onReset}
+            disabled={!current || isProbing}
+          >
+            {t('section.rpc.action.reset')}
+          </Button>
+        </ButtonRow>
+        {needsReload && (
+          <Button
+            data-testid="rpc-reload-button"
+            width="fit"
+            colorStyle="blueSecondary"
+            onClick={() => window.location.reload()}
+          >
+            {t('section.rpc.action.reload')}
+          </Button>
+        )}
+      </Container>
+    </SectionContainer>
+  )
+}

--- a/src/pages/my/settings.tsx
+++ b/src/pages/my/settings.tsx
@@ -6,6 +6,7 @@ import { useAccount } from 'wagmi'
 import { DevSection } from '@app/components/pages/profile/settings/DevSection'
 import { PrimarySection } from '@app/components/pages/profile/settings/PrimarySection/PrimarySection'
 import { PrivacySection } from '@app/components/pages/profile/settings/PrivacySection'
+import { RpcSection } from '@app/components/pages/profile/settings/RpcSection'
 import { TransactionSection } from '@app/components/pages/profile/settings/TransactionSection/TransactionSection'
 import { WalletSection } from '@app/components/pages/profile/settings/WalletSection'
 import { useSubgraphMeta } from '@app/hooks/ensjs/subgraph/useSubgraphMeta'
@@ -47,6 +48,7 @@ export default function Page() {
             <TransactionSection />
             <WalletSection />
             <PrivacySection />
+            <RpcSection />
             {IS_DEV_ENVIRONMENT && <DevSection />}
           </OtherWrapper>
         ),

--- a/src/utils/query/customRpc.test.ts
+++ b/src/utils/query/customRpc.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { stringify } from './persist'
+
+import {
+  CUSTOM_RPC_STORAGE_KEY,
+  CustomRpcUrls,
+  getCustomRpcForChain,
+  getCustomRpcUrls,
+} from './customRpc'
+
+const seed = (urls: CustomRpcUrls) =>
+  localStorage.setItem(CUSTOM_RPC_STORAGE_KEY, stringify(urls))
+
+describe('customRpc storage', () => {
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('getCustomRpcUrls', () => {
+    it('returns an empty map when nothing is stored', () => {
+      expect(getCustomRpcUrls()).toEqual({})
+    })
+
+    it('round-trips a stored map', () => {
+      const urls: CustomRpcUrls = {
+        1: { url: 'https://mainnet.example.com', exclusive: false },
+        11155111: { url: 'https://sepolia.example.com', exclusive: true },
+      }
+      seed(urls)
+      expect(getCustomRpcUrls()).toEqual(urls)
+    })
+
+    it('falls through to an empty map when the stored value is corrupt', () => {
+      localStorage.setItem(CUSTOM_RPC_STORAGE_KEY, '{ not valid json')
+      expect(getCustomRpcUrls()).toEqual({})
+      expect(getCustomRpcForChain(1)).toBeUndefined()
+    })
+  })
+
+  describe('getCustomRpcForChain', () => {
+    it('returns the entry for the requested chain', () => {
+      seed({ 1: { url: 'https://mainnet.example.com', exclusive: true } })
+      expect(getCustomRpcForChain(1)).toEqual({
+        url: 'https://mainnet.example.com',
+        exclusive: true,
+      })
+    })
+
+    it('returns undefined when the chain has no entry', () => {
+      seed({ 1: { url: 'https://mainnet.example.com', exclusive: false } })
+      expect(getCustomRpcForChain(11155111)).toBeUndefined()
+    })
+
+    it('returns undefined when the stored entry has an empty url', () => {
+      seed({ 1: { url: '', exclusive: false } })
+      expect(getCustomRpcForChain(1)).toBeUndefined()
+    })
+
+    it('accepts a pre-read map without hitting storage', () => {
+      const urls: CustomRpcUrls = { 1: { url: 'https://a.example.com', exclusive: false } }
+      expect(getCustomRpcForChain(1, urls)).toEqual(urls[1])
+      expect(getCustomRpcForChain(2, urls)).toBeUndefined()
+    })
+  })
+})

--- a/src/utils/query/customRpc.ts
+++ b/src/utils/query/customRpc.ts
@@ -1,0 +1,39 @@
+import { getStorageValue } from '@app/hooks/useLocalStorage'
+
+/**
+ * Per-device custom RPC endpoint overrides.
+ *
+ * Stored under a single localStorage key, keyed by chainId. Because each ENS deployment
+ * serves exactly one chain per origin (app.ens.domains = mainnet, sepolia.app.ens.domains =
+ * sepolia — separate origins with separate localStorage), only the active chain's entry is
+ * ever exercised on a given device. Cross-device sync is out of scope until SIWE lands.
+ *
+ * The key lives outside the reserved `wagmi*` namespace so it is not touched by wagmi's
+ * own storage middleware.
+ */
+export const CUSTOM_RPC_STORAGE_KEY = 'customRpcUrls'
+
+export type CustomRpcConfig = {
+  url: string
+  /** When true, the custom endpoint is used exclusively with no DRPC/Tenderly fallback. */
+  exclusive: boolean
+}
+
+export type CustomRpcUrls = Record<number, CustomRpcConfig>
+
+export const getCustomRpcUrls = (): CustomRpcUrls =>
+  getStorageValue<CustomRpcUrls>(CUSTOM_RPC_STORAGE_KEY, {})
+
+/**
+ * Returns the configured custom RPC for a chain, or `undefined` when none is set (or the
+ * stored entry has no url). Reads from localStorage by default but accepts a pre-read map
+ * so callers can avoid repeated storage hits.
+ */
+export const getCustomRpcForChain = (
+  chainId: number,
+  urls: CustomRpcUrls = getCustomRpcUrls(),
+): CustomRpcConfig | undefined => {
+  const entry = urls[chainId]
+  if (!entry?.url) return undefined
+  return entry
+}

--- a/src/utils/query/probeRpcUrl.test.ts
+++ b/src/utils/query/probeRpcUrl.test.ts
@@ -1,0 +1,121 @@
+import { BaseError, createPublicClient } from 'viem'
+import { afterEach, describe, expect, it, Mock, vi } from 'vitest'
+
+import { classifyProbeError, PROBE_TIMEOUT, probeRpcUrl } from './probeRpcUrl'
+
+vi.mock('viem', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('viem')>()
+  return { ...actual, createPublicClient: vi.fn() }
+})
+
+const mockGetChainId = (impl: () => Promise<number>) => {
+  ;(createPublicClient as unknown as Mock).mockReturnValue({ getChainId: impl })
+}
+
+const namedError = (name: string) => Object.assign(new Error(name), { name })
+// A real viem BaseError with a cause chain — the shape createPublicClient().getChainId()
+// actually throws, exercising classifyProbeError's `err instanceof BaseError` / `.walk()` path.
+const baseErrorWithCause = (causeName: string) =>
+  new BaseError('request failed', { cause: namedError(causeName) })
+
+describe('probeRpcUrl', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('succeeds when the endpoint reports the expected chain', async () => {
+    mockGetChainId(() => Promise.resolve(1))
+    await expect(probeRpcUrl({ url: 'https://a.example', chainId: 1 })).resolves.toEqual({
+      success: true,
+    })
+  })
+
+  it('builds the client transport with the given url, a short timeout and no retries', async () => {
+    let captured: { transport: (opts: object) => { config: Record<string, unknown>; value: { url?: string } } } | undefined
+    ;(createPublicClient as unknown as Mock).mockImplementation((config) => {
+      captured = config
+      return { getChainId: () => Promise.resolve(1) }
+    })
+
+    await probeRpcUrl({ url: 'https://only-this.example', chainId: 1 })
+
+    const transport = captured!.transport({})
+    expect(transport.config.type).toBe('http')
+    expect(transport.value.url).toBe('https://only-this.example')
+    expect(transport.config.timeout).toBe(PROBE_TIMEOUT)
+    expect(transport.config.retryCount).toBe(0)
+  })
+
+  it('classifies a real nested viem error (BaseError with a cause) via err.walk', async () => {
+    mockGetChainId(() => Promise.reject(baseErrorWithCause('TimeoutError')))
+    await expect(probeRpcUrl({ url: 'https://a.example', chainId: 1 })).resolves.toEqual({
+      success: false,
+      reason: 'timeout',
+    })
+  })
+
+  it('fails with wrongChain and reports the mismatched id', async () => {
+    mockGetChainId(() => Promise.resolve(11155111))
+    await expect(probeRpcUrl({ url: 'https://a.example', chainId: 1 })).resolves.toEqual({
+      success: false,
+      reason: 'wrongChain',
+      reportedChainId: 11155111,
+    })
+  })
+
+  it('classifies a network/CORS failure as unreachable', async () => {
+    mockGetChainId(() => Promise.reject(namedError('HttpRequestError')))
+    await expect(probeRpcUrl({ url: 'https://a.example', chainId: 1 })).resolves.toEqual({
+      success: false,
+      reason: 'unreachable',
+    })
+  })
+
+  it('classifies a timeout', async () => {
+    mockGetChainId(() => Promise.reject(namedError('TimeoutError')))
+    await expect(probeRpcUrl({ url: 'https://a.example', chainId: 1 })).resolves.toEqual({
+      success: false,
+      reason: 'timeout',
+    })
+  })
+
+  it('classifies anything else as an invalid response', async () => {
+    mockGetChainId(() => Promise.reject(new Error('unexpected <html> response')))
+    await expect(probeRpcUrl({ url: 'https://a.example', chainId: 1 })).resolves.toEqual({
+      success: false,
+      reason: 'invalidResponse',
+    })
+  })
+})
+
+describe('classifyProbeError', () => {
+  it.each([
+    ['TimeoutError', 'timeout'],
+    ['HttpRequestError', 'unreachable'],
+    ['SomethingElse', 'invalidResponse'],
+  ] as const)('classifies a %s-named error as %s', (name, expected) => {
+    expect(classifyProbeError(namedError(name))).toBe(expected)
+  })
+
+  it('classifies a plain object without a name as invalidResponse', () => {
+    expect(classifyProbeError({})).toBe('invalidResponse')
+    expect(classifyProbeError(null)).toBe('invalidResponse')
+  })
+
+  // The production path: viem throws BaseError subclasses, so the `instanceof BaseError` /
+  // `err.walk()` branch must be exercised, not just the plain-Error fallback.
+  it.each([
+    ['TimeoutError', 'timeout'],
+    ['HttpRequestError', 'unreachable'],
+    ['SomethingElse', 'invalidResponse'],
+  ] as const)('walks a BaseError cause chain to classify %s as %s', (causeName, expected) => {
+    const err = baseErrorWithCause(causeName)
+    expect(err).toBeInstanceOf(BaseError)
+    expect(classifyProbeError(err)).toBe(expected)
+  })
+
+  it('walks a deeply nested BaseError chain to find the timeout', () => {
+    const deep = new BaseError('outer', { cause: baseErrorWithCause('TimeoutError') })
+    expect(classifyProbeError(deep)).toBe('timeout')
+  })
+})

--- a/src/utils/query/probeRpcUrl.ts
+++ b/src/utils/query/probeRpcUrl.ts
@@ -1,0 +1,59 @@
+import { BaseError, createPublicClient, http } from 'viem'
+
+export type ProbeFailureReason = 'wrongChain' | 'unreachable' | 'timeout' | 'invalidResponse'
+
+export type ProbeResult =
+  | { success: true }
+  | { success: false; reason: ProbeFailureReason; reportedChainId?: number }
+
+export const PROBE_TIMEOUT = 5000
+
+/**
+ * Classifies a thrown probe error into a user-facing reason.
+ *
+ * `fallback()` cannot detect a wrong-chain endpoint at runtime (it answers successfully and
+ * silently returns wrong data), so a save-time liveness probe is the only honest guard. This
+ * also surfaces the common self-hosted-node failure: no CORS headers, which the browser
+ * reports as a network error rather than a helpful message.
+ */
+export const classifyProbeError = (err: unknown): ProbeFailureReason => {
+  const hasName = (e: unknown): e is { name: string } =>
+    typeof (e as { name?: unknown })?.name === 'string'
+
+  if (err instanceof BaseError) {
+    if (err.walk((e) => hasName(e) && e.name === 'TimeoutError')) return 'timeout'
+    if (err.walk((e) => hasName(e) && e.name === 'HttpRequestError')) return 'unreachable'
+    return 'invalidResponse'
+  }
+
+  if (hasName(err)) {
+    if (err.name === 'TimeoutError') return 'timeout'
+    if (err.name === 'HttpRequestError') return 'unreachable'
+  }
+  return 'invalidResponse'
+}
+
+/**
+ * Liveness probe run at save time. Issues a single `eth_chainId` call against the endpoint
+ * and asserts it matches the active chain. No retries, short timeout — this is a fast
+ * accept/reject gate, not part of the request path.
+ */
+export const probeRpcUrl = async ({
+  url,
+  chainId,
+}: {
+  url: string
+  chainId: number
+}): Promise<ProbeResult> => {
+  try {
+    const client = createPublicClient({
+      transport: http(url, { timeout: PROBE_TIMEOUT, retryCount: 0 }),
+    })
+    const reportedChainId = await client.getChainId()
+    if (reportedChainId !== chainId)
+      return { success: false, reason: 'wrongChain', reportedChainId }
+    return { success: true }
+  } catch (err) {
+    return { success: false, reason: classifyProbeError(err) }
+  }
+}

--- a/src/utils/query/transports.test.ts
+++ b/src/utils/query/transports.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildChainTransport, getDefaultTransportSpecs, getTransportSpecs } from './transports'
+
+// Instantiate a viem transport (or fallback) so we can inspect what it actually wired up.
+type InstantiatedTransport = { config: { type: string }; value: { url?: string } }
+const instantiate = (transport: (opts: object) => unknown) =>
+  transport({}) as { value: { transports: InstantiatedTransport[] } }
+
+describe('getTransportSpecs', () => {
+  const chainName = 'mainnet'
+  const defaults = getDefaultTransportSpecs(chainName)
+
+  it('returns only the defaults when no custom rpc is set', () => {
+    expect(getTransportSpecs({ chainName })).toEqual(defaults)
+  })
+
+  it('puts the custom url first as primary, keeping defaults as fallback', () => {
+    const specs = getTransportSpecs({
+      chainName,
+      customRpc: { url: 'https://my.node.example', exclusive: false },
+    })
+    expect(specs[0]).toEqual({ type: 'http', url: 'https://my.node.example' })
+    expect(specs.slice(1)).toEqual(defaults)
+  })
+
+  it('uses only the custom url when exclusive', () => {
+    const specs = getTransportSpecs({
+      chainName,
+      customRpc: { url: 'https://my.node.example', exclusive: true },
+    })
+    expect(specs).toEqual([{ type: 'http', url: 'https://my.node.example' }])
+  })
+
+  it('falls back to defaults when the custom url is invalid', () => {
+    expect(
+      getTransportSpecs({ chainName, customRpc: { url: 'not-a-url', exclusive: false } }),
+    ).toEqual(defaults)
+  })
+
+  it('falls back to defaults when an invalid custom url is marked exclusive (never bricks)', () => {
+    expect(
+      getTransportSpecs({ chainName, customRpc: { url: 'ws://unsupported', exclusive: true } }),
+    ).toEqual(defaults)
+  })
+
+  it('falls back to defaults for an empty custom url', () => {
+    expect(getTransportSpecs({ chainName, customRpc: { url: '', exclusive: true } })).toEqual(
+      defaults,
+    )
+  })
+
+  it('builds sepolia default urls with the sepolia network name', () => {
+    const specs = getDefaultTransportSpecs('sepolia')
+    expect(specs.every((s) => s.url.includes('sepolia'))).toBe(true)
+  })
+
+  it('maps the mainnet chain name to the drpc "ethereum" network', () => {
+    expect(getDefaultTransportSpecs('mainnet').some((s) => s.url.includes('network=ethereum'))).toBe(
+      true,
+    )
+  })
+})
+
+// Independent of the SUT: pin the exact kind + order of the default fallback chain so a
+// dropped/reordered entry (the mechanism behind AC5, auto-degrade to DRPC/Tenderly) is caught.
+describe('getDefaultTransportSpecs shape', () => {
+  it('is exactly [drpc ws, drpc http, tenderly http] in that order', () => {
+    const specs = getDefaultTransportSpecs('mainnet')
+    expect(specs).toHaveLength(3)
+    expect(specs.map((s) => s.type)).toEqual(['ws', 'http', 'http'])
+    expect(specs[0].url).toContain('drpc.org/ogws')
+    expect(specs[1].url).toContain('drpc.org/ogrpc')
+    expect(specs[2].url).toContain('tenderly')
+  })
+})
+
+// buildChainTransport is the function actually wired into wagmi's transport config; assert the
+// spec list is mapped to the right viem transports (ws vs http) and wired into fallback().
+describe('buildChainTransport', () => {
+  it('maps the defaults to a ws primary + two http fallbacks, in order', () => {
+    const { value } = instantiate(buildChainTransport({ chainName: 'mainnet' }))
+    expect(value.transports.map((t) => t.config.type)).toEqual(['webSocket', 'http', 'http'])
+  })
+
+  it('puts a valid custom url first as an http transport, keeping the defaults as fallback', () => {
+    const { value } = instantiate(
+      buildChainTransport({ chainName: 'mainnet', customRpc: { url: 'https://my.node', exclusive: false } }),
+    )
+    expect(value.transports).toHaveLength(4)
+    expect(value.transports[0].config.type).toBe('http')
+    expect(value.transports[0].value.url).toBe('https://my.node')
+  })
+
+  it('uses only the custom url with no fallback when exclusive', () => {
+    const { value } = instantiate(
+      buildChainTransport({ chainName: 'mainnet', customRpc: { url: 'https://only.node', exclusive: true } }),
+    )
+    expect(value.transports).toHaveLength(1)
+    expect(value.transports[0].config.type).toBe('http')
+    expect(value.transports[0].value.url).toBe('https://only.node')
+  })
+
+  it('ignores an invalid custom url and falls back to the defaults', () => {
+    const { value } = instantiate(
+      buildChainTransport({ chainName: 'mainnet', customRpc: { url: 'ws://nope', exclusive: true } }),
+    )
+    expect(value.transports.map((t) => t.config.type)).toEqual(['webSocket', 'http', 'http'])
+  })
+})

--- a/src/utils/query/transports.ts
+++ b/src/utils/query/transports.ts
@@ -1,0 +1,59 @@
+import type { Transport } from 'viem'
+import { fallback, http, webSocket } from 'wagmi'
+
+import { isValidRpcUrl } from '@app/validators/validateRpcUrl'
+
+import type { CustomRpcConfig } from './customRpc'
+
+const tenderlyKey = process.env.NEXT_PUBLIC_TENDERLY_KEY || '4imxc4hQfRjxrVB2kWKvTo'
+const drpcKey = process.env.NEXT_PUBLIC_DRPC_KEY || 'AnmpasF2C0JBqeAEzxVO8aRuvzLTrWcR75hmDonbV6cR'
+
+const tenderlyUrl = (chainName: string) => `https://${chainName}.gateway.tenderly.co/${tenderlyKey}`
+
+export const drpcUrl = (chainName: string) =>
+  `https://lb.drpc.org/ogrpc?network=${
+    chainName === 'mainnet' ? 'ethereum' : chainName
+  }&dkey=${drpcKey}`
+
+export const drpcWsUrl = (chainName: string) =>
+  `wss://lb.drpc.org/ogws?network=${
+    chainName === 'mainnet' ? 'ethereum' : chainName
+  }&dkey=${drpcKey}`
+
+export type TransportSpec = { type: 'ws' | 'http'; url: string }
+
+/** The default ENS-adjacent transports (DRPC websocket + DRPC/Tenderly HTTP fallbacks). */
+export const getDefaultTransportSpecs = (chainName: string): TransportSpec[] => [
+  { type: 'ws', url: drpcWsUrl(chainName) }, // Primary: instant block updates via subscription
+  { type: 'http', url: drpcUrl(chainName) }, // Fallback 1: DRPC HTTP
+  { type: 'http', url: tenderlyUrl(chainName) }, // Fallback 2: Tenderly HTTP
+]
+
+/**
+ * Pure transport selection. Given the default specs and an optional user override:
+ *   - no / invalid custom url  -> defaults only
+ *   - valid custom url         -> custom url first (primary), defaults kept as fallback
+ *   - valid custom + exclusive -> custom url only (no ENS-adjacent fallback)
+ *
+ * Invalid custom urls fall through to the defaults so a corrupt localStorage value can
+ * never brick the app.
+ */
+export const getTransportSpecs = ({
+  chainName,
+  customRpc,
+}: {
+  chainName: string
+  customRpc?: CustomRpcConfig
+}): TransportSpec[] => {
+  const defaults = getDefaultTransportSpecs(chainName)
+  if (!customRpc || !isValidRpcUrl(customRpc.url)) return defaults
+
+  const userSpec: TransportSpec = { type: 'http', url: customRpc.url }
+  return customRpc.exclusive ? [userSpec] : [userSpec, ...defaults]
+}
+
+const specToTransport = (spec: TransportSpec): Transport =>
+  spec.type === 'ws' ? webSocket(spec.url) : http(spec.url)
+
+export const buildChainTransport = (args: { chainName: string; customRpc?: CustomRpcConfig }) =>
+  fallback(getTransportSpecs(args).map(specToTransport))

--- a/src/utils/query/wagmi.ts
+++ b/src/utils/query/wagmi.ts
@@ -10,7 +10,7 @@ import {
   type TransactionType,
   type Transport,
 } from 'viem'
-import { createConfig, createStorage, fallback, http, webSocket } from 'wagmi'
+import { createConfig, createStorage, http } from 'wagmi'
 import { localhost, mainnet, sepolia } from 'wagmi/chains'
 
 import { ccipRequest } from '@ensdomains/ensjs/utils'
@@ -18,6 +18,8 @@ import { ccipRequest } from '@ensdomains/ensjs/utils'
 import { getChainsFromUrl, SupportedChain } from '@app/constants/chains'
 
 import { isInsideSafe } from '../safe'
+import { getCustomRpcForChain } from './customRpc'
+import { buildChainTransport, drpcUrl, drpcWsUrl } from './transports'
 import { rainbowKitConnectors } from './wallets'
 
 const isLocalProvider = !!process.env.NEXT_PUBLIC_PROVIDER
@@ -44,27 +46,8 @@ const unicornConnector = inAppWalletConnector({
   },
 })
 
-const tenderlyKey = process.env.NEXT_PUBLIC_TENDERLY_KEY || '4imxc4hQfRjxrVB2kWKvTo'
-const drpcKey = process.env.NEXT_PUBLIC_DRPC_KEY || 'AnmpasF2C0JBqeAEzxVO8aRuvzLTrWcR75hmDonbV6cR'
-
-const tenderlyUrl = (chainName: string) => `https://${chainName}.gateway.tenderly.co/${tenderlyKey}`
-export const drpcUrl = (chainName: string) =>
-  `https://lb.drpc.org/ogrpc?network=${
-    chainName === 'mainnet' ? 'ethereum' : chainName
-  }&dkey=${drpcKey}`
-
-export const drpcWsUrl = (chainName: string) =>
-  `wss://lb.drpc.org/ogws?network=${
-    chainName === 'mainnet' ? 'ethereum' : chainName
-  }&dkey=${drpcKey}`
-
-const initialiseTransports = (chainName: string) => {
-  return fallback([
-    webSocket(drpcWsUrl(chainName)), // Primary: instant block updates via subscription
-    http(drpcUrl(chainName)), // Fallback 1: DRPC HTTP
-    http(tenderlyUrl(chainName)), // Fallback 2: Tenderly HTTP
-  ])
-}
+// Re-exported for backwards compatibility with existing importers/mocks.
+export { drpcUrl, drpcWsUrl }
 
 export const prefix = 'wagmi'
 
@@ -101,6 +84,8 @@ const localStorageWithInvertMiddleware = (): Storage | undefined => {
 }
 
 export const transports = {
+  // The localhost provider is a plain http transport pointed at the dev anvil node; custom
+  // RPC overrides only ever apply to the active production chain (mainnet or sepolia).
   ...(isLocalProvider
     ? ({
         [localhost.id]: http(process.env.NEXT_PUBLIC_PROVIDER!) as unknown as FallbackTransport,
@@ -109,8 +94,14 @@ export const transports = {
         // this is a hack to make the types happy, dont remove pls
         [localhost.id]: HttpTransport
       })),
-  [mainnet.id]: initialiseTransports('mainnet'),
-  [sepolia.id]: initialiseTransports('sepolia'),
+  [mainnet.id]: buildChainTransport({
+    chainName: 'mainnet',
+    customRpc: getCustomRpcForChain(mainnet.id),
+  }),
+  [sepolia.id]: buildChainTransport({
+    chainName: 'sepolia',
+    customRpc: getCustomRpcForChain(sepolia.id),
+  }),
 } as const
 
 // This is a workaround to fix MetaMask defaulting to the wrong transaction type

--- a/src/validators/validateRpcUrl.test.ts
+++ b/src/validators/validateRpcUrl.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { isValidRpcUrl, validateRpcUrl } from './validateRpcUrl'
+
+describe('validateRpcUrl', () => {
+  it.each([
+    ['https://eth.example.com', true],
+    ['https://eth.example.com/v1/key', true],
+    ['http://localhost:8545', true],
+    ['http://127.0.0.1:8545', true],
+    ['http://192.168.1.10:8545', true],
+    ['https://1.2.3.4:8545/rpc', true],
+  ] as const)('accepts %s', (url, expected) => {
+    expect(validateRpcUrl(url)).toBe(expected)
+  })
+
+  it.each([
+    ['', 'required'],
+    [undefined, 'required'],
+  ] as const)('returns "required" for empty input (%s)', (url, expected) => {
+    expect(validateRpcUrl(url)).toBe(expected)
+  })
+
+  it.each([
+    ['not a url'],
+    ['justtext'],
+    ['http://'],
+    ['://missing-protocol'],
+  ] as const)('rejects malformed url %s', (url) => {
+    expect(validateRpcUrl(url)).toBe('invalidUrl')
+  })
+
+  it.each([
+    ['ws://eth.example.com'],
+    ['wss://eth.example.com'],
+    ['ftp://eth.example.com'],
+    ['ipfs://something'],
+    ['file:///etc/passwd'],
+  ] as const)('rejects unsupported protocol %s', (url) => {
+    expect(validateRpcUrl(url)).toBe('invalidProtocol')
+  })
+
+  describe('isValidRpcUrl', () => {
+    it('is true for a valid url', () => {
+      expect(isValidRpcUrl('https://eth.example.com')).toBe(true)
+    })
+
+    it('is false for an invalid url', () => {
+      expect(isValidRpcUrl('ws://eth.example.com')).toBe(false)
+      expect(isValidRpcUrl('')).toBe(false)
+      expect(isValidRpcUrl(undefined)).toBe(false)
+    })
+  })
+})

--- a/src/validators/validateRpcUrl.ts
+++ b/src/validators/validateRpcUrl.ts
@@ -1,0 +1,31 @@
+// Only HTTP(S) JSON-RPC endpoints are supported in v1 (no WebSocket custom endpoints).
+const ACCEPTED_RPC_PROTOCOLS = ['http:', 'https:']
+
+export type RpcUrlError = 'required' | 'invalidUrl' | 'invalidProtocol'
+
+/**
+ * Validates a user supplied JSON-RPC endpoint URL.
+ *
+ * Unlike {@link validateImageUri} this deliberately does NOT block localhost / LAN /
+ * numeric IP addresses: users routinely run their own node (e.g. http://localhost:8545)
+ * and pointing the app at it is the whole point of the feature. The save-time liveness
+ * probe ({@link probeRpcUrl}) is what protects against a dead or wrong-chain endpoint.
+ *
+ * @returns `true` when valid, otherwise a stable error key for i18n lookup.
+ */
+export const validateRpcUrl = (url?: string): true | RpcUrlError => {
+  if (!url) return 'required'
+
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return 'invalidUrl'
+  }
+
+  if (!ACCEPTED_RPC_PROTOCOLS.includes(parsed.protocol)) return 'invalidProtocol'
+
+  return true
+}
+
+export const isValidRpcUrl = (url?: string): boolean => validateRpcUrl(url) === true


### PR DESCRIPTION
## Summary

Adds a **Custom RPC endpoint** section to `/my/settings` that lets a user point the app at their own JSON-RPC endpoint for the network this deployment serves, addressing the privacy (IP exposure) and decentralisation (ENS-operated RPC as a single point of failure) concerns in the ticket.

The override is:
- **Per-device**, stored in `localStorage` under a single `customRpcUrls` key (`Record<chainId, { url, exclusive }>`), outside the reserved `wagmi*` namespace. Cross-device sync is out of scope until SIWE.
- Injected as the **primary** wagmi/viem transport, with the existing DRPC websocket + DRPC/Tenderly HTTP kept as automatic **fallback**.
- Optionally **exclusive** — a "use only my RPC endpoint" toggle drops the ENS-operated fallback entirely (with a warning that the app may break if the endpoint dies).

Because transports are built once at module load and the wagmi config is a runtime singleton, changes are applied via **reload-on-save** (the React-Query cache is invalidated and the user is prompted to reload).

## What's included

- **`validateRpcUrl`** — `new URL()` + `http`/`https` protocol allowlist. Deliberately permits `http://localhost` / LAN / numeric IPs (users run their own node); it does **not** carry `validateImageUri`'s SSRF IP-blocking, since this is a browser-side transport URL the user chooses for themselves.
- **`probeRpcUrl`** — save-time `eth_chainId` liveness probe (`timeout 5s`, `retryCount 0`) asserting the endpoint reports the **active** chain; classifies wrong-chain / unreachable-or-CORS / timeout / invalid-response. `fallback()` cannot detect a wrong-chain endpoint at runtime (it answers successfully with wrong data), so this is the guard.
- **`customRpc` storage** + a **pure transport builder** (`getTransportSpecs`) — custom URL primary when set, defaults-only fallback when absent/invalid (a corrupt localStorage value can never brick the app), custom-only when exclusive.
- **`RpcSection`** UI — react-hook-form input with inline validation, exclusive toggle + warning, Save (probe → persist → invalidate cache → reload prompt) and Reset.
- Custom RPC applies only to mainnet/sepolia; the `NEXT_PUBLIC_PROVIDER` localhost dev transport is intentionally left as a plain `http` transport.

A probe failure (wrong chain / unreachable / timeout) is surfaced but **retryable** — it doesn't wedge Save disabled, so a transient outage can be retried on the same URL; only a format-validation error blocks Save.

## Testing

- **Unit:** `validateRpcUrl` (table-driven), `probeRpcUrl` (healthy / wrong-chain / network / timeout / invalid, plus the real viem `BaseError.walk` classification path and that the probe transport gets the url/timeout/`retryCount:0`), `customRpc` storage round-trip + corrupt-value fallthrough, and the transport builder — both the pure `getTransportSpecs` and the real `buildChainTransport` viem `fallback` wiring (ws→websocket, custom primary, exclusive drops fallback, invalid falls back).
- **Component:** `RpcSection` — pre-populates from a stored value; invalid → error + save disabled; valid → probe + persist (functional updater, composes with concurrent writes) + reload prompt; exclusive flag + warning; probe failure surfaced but retryable; reset clears only the active-chain entry.
- **e2e:** `settings.spec.ts` — validate, probe (request-intercepted), save, per-device persistence across reload, and reset.

> **Coverage note:** the one line that installs the override into the live singleton config — `getCustomRpcForChain(chainId)` at `wagmi.ts` module load — is not unit-testable (the module is globally mocked in `test-utils` and can't be imported in jsdom), and the stateless e2e runs on the localhost/anvil provider where the override intentionally doesn't apply. The spec→transport→`fallback` wiring it depends on is covered by `buildChainTransport` unit tests; the module-load glue itself is verified by manual review.

## Acceptance criteria

- [x] User can enter a custom RPC URL for the active chain; persists across reloads (per device).
- [x] Invalid URL shows an inline error and cannot be saved.
- [x] A URL that doesn't respond / reports the wrong chain is rejected at save with a clear message.
- [x] With a valid custom RPC, app read traffic uses it (transport builder unit-verified; e2e request interception).
- [x] By default a failing custom endpoint auto-degrades to DRPC/Tenderly.
- [x] With "use only my RPC" enabled, no fallback occurs; a warning explains the risk.
- [x] Reset restores the default transport.

Out of scope (tracked separately): holesky support; overriding non-RPC ENS egress — subgraph, metadata, CCIP, workers (WEB-568); WebSocket custom endpoints; cross-device sync.

Ref: WEB-139
