### PR TITLE
chore: remove broken Discord link

### DIFF
--- a/src/components/@molecules/Hamburger/MainMenu.tsx
+++ b/src/components/@molecules/Hamburger/MainMenu.tsx
@@ -16,7 +16,6 @@ import {
   WalletSVG,
 } from '@ensdomains/thorin'
 
-import SocialDiscord from '@app/assets/social/SocialDiscord.svg'
 import SocialDiscourse from '@app/assets/social/SocialDiscourse.svg'
 import SocialDiscourseColour from '@app/assets/social/SocialDiscourseColour.svg'
 import SocialGithub from '@app/assets/social/SocialGithub.svg'
@@ -328,7 +327,6 @@ const MainMenu = ({ setCurrentView }: { setCurrentView: (view: HamburgerView) =>
       <SocialSection>
         <SocialIcon Icon={SocialX} color="black" href={ENS_LINKS.X} />
         <SocialIcon Icon={SocialGithub} color="#0F0F0F" href={ENS_LINKS.GITHUB} />
-        <SocialIcon Icon={SocialDiscord} color="#7F83FF" href={ENS_LINKS.DISCORD} />
         <SocialIcon Icon={SocialMirror} ColoredIcon={SocialMirrorColour} href={ENS_LINKS.MIRROR} />
         <SocialIcon
           Icon={SocialDiscourse}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -25,7 +25,6 @@ export const INVALID_NAME = '[Invalid ENS Name]'
 
 export const ENS_LINKS = {
   X: 'https://x.com/ensdomains',
-  DISCORD: 'https://chat.ens.domains',
   MIRROR: 'https://ens.mirror.xyz',
   DISCOURSE: 'https://discuss.ens.domains',
   GITHUB: 'https://github.com/ensdomains',


### PR DESCRIPTION
## Summary
- The `chat.ens.domains` Discord link is dead (subdomain has no DNS records), so the Discord icon in the hamburger menu currently 404s.
- Removes `ENS_LINKS.DISCORD` from `src/utils/constants.ts` and the corresponding Discord social icon (and its now-unused import) from `src/components/@molecules/Hamburger/MainMenu.tsx`.
- No other references to `ENS_LINKS.DISCORD` or `chat.ens.domains` remain in the codebase.

## Test plan
- [x] `pnpm lint:types` — no new errors (pre-existing errors on `main` are identical before/after this diff)
- [x] `pnpm lint` — passes, only pre-existing unrelated warnings
- [x] `pnpm test` — 8 pre-existing failures (timezone formatting + one mock-data test) confirmed identical on `main` before this change; no new failures introduced