### PR TITLE
fix(FET-3203): don't surface transient CommitmentTooNew as a revert

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -324,6 +324,8 @@
         "title": "Confirm Details",
         "message": "Double check these details before confirming in your wallet.",
         "waitingForWallet": "Waiting for Wallet",
+        "waitingForBlock": "Waiting for confirmation",
+        "waitingForBlockMessage": "Waiting for your commitment to be confirmed on-chain. This usually takes a few seconds.",
         "openWallet": "Open Wallet",
         "openPara": "Start",
         "insufficientFunds": "Insufficient funds"

--- a/src/components/@molecules/TransactionDialogManager/stage/TransactionStageModal.tsx
+++ b/src/components/@molecules/TransactionDialogManager/stage/TransactionStageModal.tsx
@@ -35,7 +35,7 @@ import {
 } from '@app/transaction-flow/types'
 import { ConfigWithEns } from '@app/types'
 import { sendEvent } from '@app/utils/analytics/events'
-import { getReadableError } from '@app/utils/errors'
+import { getReadableError, isCommitmentTooNewError } from '@app/utils/errors'
 import { getIsCachedData } from '@app/utils/getIsCachedData'
 import { useQuery } from '@app/utils/query/useQuery'
 import { computeCacheBustFlags } from '@app/utils/transactionCacheBust'
@@ -426,6 +426,13 @@ export const TransactionStageModal = ({
     ...preparedOptions,
     enabled: canEnableTransactionRequest,
     refetchOnMount: 'always',
+    // A `CommitmentTooNew` revert means the commitment hasn't aged into the
+    // chain's view of "now" yet, so retry until it has. A normal slot is 12s,
+    // but a missed slot pushes the next block out to 24s - cover that worst
+    // case. `useInvalidateOnBlock` below is the primary recovery mechanism;
+    // this is cover for a slow block watcher.
+    retry: (failureCount, error) => isCommitmentTooNewError(error) && failureCount < 8,
+    retryDelay: 3_000,
   })
 
   const {
@@ -436,6 +443,14 @@ export const TransactionStageModal = ({
   const request = request_?.data
   const requestError = request_?.error || requestError_
   const isTransactionRequestCachedData = getIsCachedData(transactionRequestQuery)
+
+  // `failureReason` holds the error of the most recent failed attempt while
+  // retries are still in flight; `requestError` only becomes set once they're
+  // exhausted. Checking both keeps the waiting state stable for the whole
+  // retry window, then lets the error surface normally if it never resolves.
+  const isWaitingForCommitment =
+    isCommitmentTooNewError(transactionRequestQuery.failureReason) ||
+    isCommitmentTooNewError(requestError)
 
   useInvalidateOnBlock({
     enabled: canEnableTransactionRequest && process.env.NEXT_PUBLIC_ETH_NODE !== 'anvil',
@@ -510,10 +525,14 @@ export const TransactionStageModal = ({
     return (
       <>
         <WalletIcon as={WalletSVG} />
-        <MessageTypography>{t('transaction.dialog.confirm.message')}</MessageTypography>
+        <MessageTypography>
+          {isWaitingForCommitment
+            ? t('transaction.dialog.confirm.waitingForBlockMessage')
+            : t('transaction.dialog.confirm.message')}
+        </MessageTypography>
       </>
     )
-  }, [stage, t, transaction.sendTime])
+  }, [stage, t, transaction.sendTime, isWaitingForCommitment])
 
   const HelperContent = useMemo(() => {
     if (!helper) return null
@@ -584,6 +603,18 @@ export const TransactionStageModal = ({
       )
     }
 
+    if (isWaitingForCommitment) {
+      return (
+        <Button
+          disabled
+          suffix={() => <Spinner color="background" />}
+          data-testid="transaction-modal-confirm-button"
+        >
+          {t('transaction.dialog.confirm.waitingForBlock')}
+        </Button>
+      )
+    }
+
     if (preTransactionError?.type === 'insufficientFunds')
       return <Button disabled>{t('transaction.dialog.confirm.insufficientFunds')}</Button>
 
@@ -621,6 +652,7 @@ export const TransactionStageModal = ({
     actionName,
     preTransactionError,
     isParaConnected,
+    isWaitingForCommitment,
   ])
 
   return (
@@ -638,7 +670,9 @@ export const TransactionStageModal = ({
             {t('transaction.viewEtherscan')}
           </Outlink>
         )}
-        {preTransactionError && <Helper alert="error">{preTransactionError.message}</Helper>}
+        {preTransactionError && !isWaitingForCommitment && (
+          <Helper alert="error">{preTransactionError.message}</Helper>
+        )}
       </Dialog.Content>
       <Dialog.Footer
         currentStep={currentStep}

--- a/src/components/@molecules/TransactionDialogManager/stage/query.ts
+++ b/src/components/@molecules/TransactionDialogManager/stage/query.ts
@@ -24,7 +24,7 @@ import {
   CreateQueryKey,
 } from '@app/types'
 import { CURRENCY_FLUCTUATION_BUFFER_PERCENTAGE } from '@app/utils/constants'
-import { getReadableError } from '@app/utils/errors'
+import { getReadableError, isCommitmentTooNewError } from '@app/utils/errors'
 import { createAccessList } from '@app/utils/query/createAccessList'
 import { wagmiConfig } from '@app/utils/query/wagmi'
 import { connectorIsMetaMask, connectorIsPhantom, hasParaConnection } from '@app/utils/utils'
@@ -270,6 +270,11 @@ export const createTransactionRequestQueryFn =
         error: null,
       }
     } catch (e) {
+      // `CommitmentTooNew` is transient - the commitment is valid, the block we
+      // executed against is just older than `commitment + minCommitmentAge`.
+      // Rethrow so react-query treats it as a real error and retries it, rather
+      // than caching it as a terminal failure the way we do for genuine reverts.
+      if (isCommitmentTooNewError(e)) throw e
       return {
         data: null,
         error: e as Error,

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -1,0 +1,65 @@
+import { EstimateGasExecutionError, RawContractError, RpcRequestError } from 'viem'
+import { describe, expect, it } from 'vitest'
+
+import { getReadableError, isCommitmentTooNewError } from './errors'
+
+// Real payload captured from a mainnet register pre-flight (FET-3203).
+// CommitmentTooNew(bytes32 commitment, uint256 minimumCommitmentTimestamp, uint256 currentTimestamp)
+const COMMITMENT_TOO_NEW_DATA =
+  '0x74480cc9ae290bbaa3282c9bf6ccbc240c630120d38c5edda4089fe86e3afc462b7a6a060000000000000000000000000000000000000000000000000000000069d61c9f0000000000000000000000000000000000000000000000000000000069d61c93' as const
+
+describe('errors', () => {
+  it('detects CommitmentTooNew from an RpcRequestError', () => {
+    // eth_createAccessList uses a raw client.request, so the revert reaches us
+    // as an RpcRequestError whose `details` used to win over the revert data.
+    const err = new RpcRequestError({
+      body: {},
+      error: { code: 3, message: 'execution reverted', data: COMMITMENT_TOO_NEW_DATA } as never,
+      url: 'https://example.com',
+    })
+
+    expect(isCommitmentTooNewError(err)).toBe(true)
+  })
+
+  it('decodes a contract error wrapped in an EstimateGasExecutionError', () => {
+    // Regression: this previously short-circuited on the EstimateGasExecutionError
+    // branch and returned null, surfacing a generic "execution reverted".
+    const err = new EstimateGasExecutionError(
+      new RawContractError({
+        data: COMMITMENT_TOO_NEW_DATA,
+        message: 'execution reverted',
+      }) as never,
+      {},
+    )
+
+    expect(getReadableError(err)).toEqual({ message: 'CommitmentTooNew', type: 'contract' })
+  })
+
+  it('still reports insufficient funds after the reorder', () => {
+    const err = new EstimateGasExecutionError(
+      new RawContractError({
+        data: undefined,
+        message:
+          'insufficient funds for gas * price + value: address 0xCe5eCf6d9E2181Ad77b53305E2b1b6eCa54728F0 have 19481180979346279 want 158177686389512923',
+      }) as never,
+      {},
+    )
+
+    expect(getReadableError(err)).toEqual({
+      message: 'Wallet balance too low. Minimum required balance: 0.158177686389512923 ETH',
+      type: 'insufficientFunds',
+    })
+  })
+
+  it('does not throw on an unknown error selector', () => {
+    // decodeErrorResult throws on an unrecognised selector, so it must be guarded.
+    const err = new RpcRequestError({
+      body: {},
+      error: { code: 3, message: 'execution reverted', data: '0xdeadbeef' } as never,
+      url: 'https://example.com',
+    })
+
+    expect(() => getReadableError(err)).not.toThrow()
+    expect(isCommitmentTooNewError(err)).toBe(false)
+  })
+})

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -66,19 +66,48 @@ const getTransactionRejectedRpcErrorMessage = (
   } satisfies ReadableError
 }
 
+/**
+ * Attempts to decode a revert reason into one of the known ENS contract errors.
+ *
+ * `decodeErrorResult` throws (rather than returning a nullish value) when the
+ * selector isn't present in the ABI, so the call must be guarded.
+ */
+export const decodeContractError = (err: unknown) => {
+  const data = getViemRevertErrorData(err)
+  if (!data) return null
+  try {
+    return decodeErrorResult({
+      abi: allContractErrors,
+      data,
+    })
+  } catch {
+    return null
+  }
+}
+
+/**
+ * `CommitmentTooNew` means the block the call was executed against is still
+ * older than `commitment + minCommitmentAge`. This is a transient condition:
+ * the commitment simply hasn't aged into the chain's view of "now" yet, and the
+ * call will succeed once the next block is mined.
+ */
+export const isCommitmentTooNewError = (err: unknown): boolean =>
+  decodeContractError(err)?.errorName === 'CommitmentTooNew'
+
 export const getReadableError = (err: unknown): ReadableError | null => {
+  // Decode revert data first: an execution revert can reach us wrapped in any of
+  // the error types below (e.g. `eth_createAccessList` surfaces one as an
+  // `RpcRequestError`), and the decoded contract error is always more useful
+  // than the generic viem message those branches fall back to.
+  const decodedError = decodeContractError(err)
+  if (decodedError)
+    return {
+      message: decodedError.errorName,
+      type: 'contract',
+    } as const
+
   if (err instanceof EstimateGasExecutionError) return getEstimateGasExecutionErrorMessage(err)
   if (err instanceof TransactionRejectedRpcError) return getTransactionRejectedRpcErrorMessage(err)
   if (err instanceof RpcRequestError) return getTransactionRejectedRpcErrorMessage(err)
-  const data = getViemRevertErrorData(err)
-  if (!data) return null
-  const decodedError = decodeErrorResult({
-    abi: allContractErrors,
-    data,
-  })
-  if (!decodedError) return null
-  return {
-    message: decodedError.errorName,
-    type: 'contract',
-  } as const
+  return null
 }


### PR DESCRIPTION
Fixes [FET-3203](https://linear.app/enslabs/issue/FET-3203/execution-reverted-error-appearing-on-the-register-modal).

## Root cause

The error data from the ticket decodes cleanly:

```
$ cast error-decode 0x74480cc9ae290bba...69d61c9f...69d61c93
CommitmentTooNew(bytes32,uint256,uint256)
0xae290bbaa3282c9bf6ccbc240c630120d38c5edda4089fe86e3afc462b7a6a06
1775639711   # minimumCommitmentTimestamp
1775639699   # currentTimestamp  <- 12s behind, exactly one slot
```

The 60s gate on the register step is **wall-clock** based: `commitTx.finaliseTime` is the commit *block header* timestamp (`transactionStore.ts` -> `reducer.ts` -> `Transactions.tsx`), and thorin's `CountdownCircle` fires `setCommitComplete(true)` at `commitBlockTs + 60` per `Date.now()`. The pre-flight in the modal (`eth_createAccessList` + `estimateGas`) then executes against a block header that can be up to one slot behind wall clock, so `block.timestamp < commitment + minCommitmentAge` and the controller reverts.

The commitment is valid - the chain just hasn't caught up yet. Click the instant the circle hits zero and you hit it; hesitate a few seconds and you don't, which is why it reproduces intermittently.

Three separate things made this user-visible:

1. **`getReadableError` threw the detail away.** It short-circuited on `EstimateGasExecutionError` and returned `null` for anything that wasn't "insufficient funds", never reaching the `decodeErrorResult` branch below it - so every custom ENS contract revert collapsed into viem's generic `"execution reverted"`.
2. **Nothing retried.** `createTransactionRequestQueryFn` swallows failures into `{ data: null, error }`, which react-query treats as *success* - so no retry, and the failure was persisted to IndexedDB.
3. **The modal treated it as terminal.** The confirm button is hard-disabled on `!!requestError`, so the only escape was `refetchOnMount: 'always'` - i.e. literally closing and reopening the modal, exactly as the ticket describes.

## Changes

**`src/utils/errors.ts`** - decode revert data *before* the `EstimateGasExecutionError` / `RpcRequestError` branches. This matters because `eth_createAccessList` uses a raw `client.request`, so its revert arrives as an `RpcRequestError` whose `details` used to win over the decodable data. Adds `decodeContractError` + `isCommitmentTooNewError`.

Also fixes a latent crash: `decodeErrorResult` **throws** on an unrecognised selector rather than returning nullish, so the old `if (!decodedError) return null` guard was dead code and `getReadableError` could throw on any unknown revert. Now guarded.

**`stage/query.ts`** - rethrow `CommitmentTooNew` only, so it becomes a real react-query error. All other errors keep the existing swallow-into-`data.error` behaviour.

**`stage/TransactionStageModal.tsx`** - retry that error 8x at 3s. A normal slot is 12s but a *missed* slot pushes the next block to 24s, so this covers the worst case; `useInvalidateOnBlock` remains the primary recovery path and this is cover for a slow block watcher. `isWaitingForCommitment` reads both `failureReason` (set while retries are in flight) and the settled error so the state is stable for the whole window. While waiting: disabled button + spinner reading **"Waiting for confirmation"**, confirm-stage copy explaining we're waiting for on-chain confirmation, and the red `Helper` suppressed. If it genuinely never resolves it falls through to the normal error path - now naming `CommitmentTooNew` rather than "execution reverted".

**`public/locales/en/common.json`** - two new keys. `fallbackLng: 'en'` so the other 7 locales inherit them.

## Testing

4 regression tests in `src/utils/errors.test.ts` using the real payload from the ticket: detection through `RpcRequestError` (the `createAccessList` path) and `EstimateGasExecutionError` (the `estimateGas` path), an insufficient-funds guard for the reorder, and the unknown-selector no-throw case.

`pnpm vitest` - 47 existing `TransactionDialogManager` tests + 4 new pass. `pnpm lint` clean. `pnpm lint:types` reports 5 errors, all pre-existing in `metadataCache.test.ts` / `routes.test.ts`, neither touched here.

## Notes for the reviewer

- **The race still exists; this makes it invisible.** The countdown is deliberately untouched - it still fires on wall clock, so the pre-flight will keep reverting for up to a slot and the modal now absorbs it. Gating the button on chain time would mean it stays disabled for up to 12s *after* the circle visibly hits zero, which is worse UX for a condition that resolves itself.
- **The ticket reports this only happens with "use as primary name" enabled.** I could not find a code path that makes it conditional on `reverseRecord` - nothing branches on it in `registerName.ts`, `query.ts` or the estimation hooks, and the controller checks `CommitmentTooNew` before it touches records. Most likely a timing correlation (the extra profile step shifts when the commit lands relative to slot boundaries). The fix is correct either way, but flagging that I haven't fully explained that detail.
- **Separate latent bug, not fixed here:** `finaliseTime` is milliseconds at `transactionStore.ts:446` but **seconds** at `transactionStore.ts:126` (the Etherscan-recovery path used for replaced/sped-up txs). If a commit is recovered that way, `commitTimestamp + 60000 < Date.now()` is instantly true, the countdown completes immediately, and `CommitmentTooNew` is guaranteed with a delta far larger than the 24s retry window here would cover. Worth its own ticket.
