### PR TITLE
Support ENSv2 resolver abstraction layer detection

### DIFF
--- a/public/locales/en/profile.json
+++ b/public/locales/en/profile.json
@@ -277,11 +277,7 @@
         "outdated": "Outdated",
         "wildcard": "Wildcard",
         "version": "Version",
-        "etherscan": "Etherscan",
-        "abstraction": {
-          "label": "ENSv2 resolver",
-          "description": "This name resolves through an ENSv2 abstraction layer. The resolver above is the true resolver; requests are proxied through the abstraction resolver below."
-        }
+        "etherscan": "Etherscan"
       },
       "fuses": {
         "label": "Fuses",

--- a/public/locales/en/profile.json
+++ b/public/locales/en/profile.json
@@ -277,7 +277,11 @@
         "outdated": "Outdated",
         "wildcard": "Wildcard",
         "version": "Version",
-        "etherscan": "Etherscan"
+        "etherscan": "Etherscan",
+        "abstraction": {
+          "label": "ENSv2 resolver",
+          "description": "This name resolves through an ENSv2 abstraction layer. The resolver above is the true resolver; requests are proxied through the abstraction resolver below."
+        }
       },
       "fuses": {
         "label": "Fuses",

--- a/src/components/pages/profile/[name]/tabs/MoreTab/Resolver.tsx
+++ b/src/components/pages/profile/[name]/tabs/MoreTab/Resolver.tsx
@@ -123,8 +123,6 @@ const Resolver = ({
   const { underlyingResolver, isAbstracted } = useUnderlyingResolver({
     name,
     resolverAddress: registryOrSubgraphResolverAddress,
-    enabled:
-      !!registryOrSubgraphResolverAddress && registryOrSubgraphResolverAddress !== emptyAddress,
   })
 
   const displayedResolverAddress =

--- a/src/components/pages/profile/[name]/tabs/MoreTab/Resolver.tsx
+++ b/src/components/pages/profile/[name]/tabs/MoreTab/Resolver.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 import { match, P } from 'ts-pattern'
 
-import { Button, Tag, Typography } from '@ensdomains/thorin'
+import { Button, Typography } from '@ensdomains/thorin'
 
 import { cacheableComponentStyles } from '@app/components/@atoms/CacheableComponent'
 import { DisabledButtonWithTooltip } from '@app/components/@molecules/DisabledButtonWithTooltip'
@@ -74,23 +74,6 @@ const ButtonStack = styled.div(
     @media (max-width: 640px) {
       flex-direction: column;
     }
-  `,
-)
-
-const AbstractionContainer = styled.div(
-  ({ theme }) => css`
-    display: flex;
-    flex-direction: column;
-    gap: ${theme.space['2']};
-  `,
-)
-
-const AbstractionHeading = styled.div(
-  ({ theme }) => css`
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: ${theme.space['2']};
   `,
 )
 
@@ -194,24 +177,6 @@ const Resolver = ({
           </>
         )}
       </ButtonStack>
-      {isAbstracted && (
-        <AbstractionContainer data-testid="resolver-abstraction">
-          <AbstractionHeading>
-            <Typography color="text" fontVariant="bodyBold">
-              {t('tabs.more.resolver.abstraction.label')}
-            </Typography>
-            <Tag colorStyle="accentSecondary">ENSv2</Tag>
-          </AbstractionHeading>
-          <Typography color="textSecondary" fontVariant="small">
-            {t('tabs.more.resolver.abstraction.description')}
-          </Typography>
-          <RecordItem
-            type="text"
-            data-testid="resolver-abstraction-address"
-            value={registryOrSubgraphResolverAddress || ''}
-          />
-        </AbstractionContainer>
-      )}
     </Container>
   )
 }

--- a/src/components/pages/profile/[name]/tabs/MoreTab/Resolver.tsx
+++ b/src/components/pages/profile/[name]/tabs/MoreTab/Resolver.tsx
@@ -2,12 +2,13 @@ import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 import { match, P } from 'ts-pattern'
 
-import { Button, Typography } from '@ensdomains/thorin'
+import { Button, Tag, Typography } from '@ensdomains/thorin'
 
 import { cacheableComponentStyles } from '@app/components/@atoms/CacheableComponent'
 import { DisabledButtonWithTooltip } from '@app/components/@molecules/DisabledButtonWithTooltip'
 import RecordItem from '@app/components/RecordItem'
 import { useResolver } from '@app/hooks/ensjs/public/useResolver'
+import { useUnderlyingResolver } from '@app/hooks/resolver/useUnderlyingResolver'
 import { useTransactionFlow } from '@app/transaction-flow/TransactionFlowProvider'
 import { useBreakpoint } from '@app/utils/BreakpointProvider'
 import { emptyAddress } from '@app/utils/constants'
@@ -76,6 +77,23 @@ const ButtonStack = styled.div(
   `,
 )
 
+const AbstractionContainer = styled.div(
+  ({ theme }) => css`
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.space['2']};
+  `,
+)
+
+const AbstractionHeading = styled.div(
+  ({ theme }) => css`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: ${theme.space['2']};
+  `,
+)
+
 const Resolver = ({
   name,
   canEditResolver,
@@ -117,6 +135,18 @@ const Resolver = ({
     )
     .otherwise(([subgraphResolver]) => subgraphResolver || emptyAddress)
 
+  // Under ENSv2 the registry/subgraph resolver may be the `ENSV1Resolver`
+  // abstraction contract. If so, this reveals the true underlying resolver.
+  const { underlyingResolver, isAbstracted } = useUnderlyingResolver({
+    name,
+    resolverAddress: registryOrSubgraphResolverAddress,
+    enabled:
+      !!registryOrSubgraphResolverAddress && registryOrSubgraphResolverAddress !== emptyAddress,
+  })
+
+  const displayedResolverAddress =
+    isAbstracted && underlyingResolver ? underlyingResolver : registryOrSubgraphResolverAddress
+
   return (
     <Container $isCached={isCachedData}>
       <HeadingContainer>
@@ -130,7 +160,7 @@ const Resolver = ({
         <RecordItem
           type="text"
           data-testid="resolver-address"
-          value={registryOrSubgraphResolverAddress || ''}
+          value={displayedResolverAddress || ''}
         />
         {canEdit && !hasGraphError && (
           <>
@@ -164,6 +194,24 @@ const Resolver = ({
           </>
         )}
       </ButtonStack>
+      {isAbstracted && (
+        <AbstractionContainer data-testid="resolver-abstraction">
+          <AbstractionHeading>
+            <Typography color="text" fontVariant="bodyBold">
+              {t('tabs.more.resolver.abstraction.label')}
+            </Typography>
+            <Tag colorStyle="accentSecondary">ENSv2</Tag>
+          </AbstractionHeading>
+          <Typography color="textSecondary" fontVariant="small">
+            {t('tabs.more.resolver.abstraction.description')}
+          </Typography>
+          <RecordItem
+            type="text"
+            data-testid="resolver-abstraction-address"
+            value={registryOrSubgraphResolverAddress || ''}
+          />
+        </AbstractionContainer>
+      )}
     </Container>
   )
 }

--- a/src/hooks/resolver/useUnderlyingResolver.ts
+++ b/src/hooks/resolver/useUnderlyingResolver.ts
@@ -21,7 +21,6 @@ type UseUnderlyingResolverParameters = {
   name: string
   /** The currently-known resolver, from the registry/subgraph. */
   resolverAddress: string | undefined
-  enabled?: boolean
 }
 
 /**
@@ -36,7 +35,6 @@ type UseUnderlyingResolverParameters = {
 export const useUnderlyingResolver = ({
   name,
   resolverAddress,
-  enabled = true,
 }: UseUnderlyingResolverParameters) => {
   const query = useReadContract({
     abi: ensV1ResolverAbstractionSnippet,
@@ -44,7 +42,7 @@ export const useUnderlyingResolver = ({
     functionName: 'getResolver',
     args: [dnsEncodeName(name)],
     query: {
-      enabled: enabled && !!name && !!resolverAddress && resolverAddress !== emptyAddress,
+      enabled: !!name && !!resolverAddress && resolverAddress !== emptyAddress,
       // The call reverts for resolvers that do not implement `getResolver`.
       // That is an expected outcome, not a transient failure, so never retry.
       retry: false,

--- a/src/hooks/resolver/useUnderlyingResolver.ts
+++ b/src/hooks/resolver/useUnderlyingResolver.ts
@@ -1,0 +1,66 @@
+import { isAddressEqual, parseAbi, type Address } from 'viem'
+import { useReadContract } from 'wagmi'
+
+import { emptyAddress } from '@app/utils/constants'
+import { dnsEncodeName } from '@app/utils/reverse'
+
+/**
+ * ABI snippet for the ENSv2 `ENSV1Resolver` abstraction contract. Under ENSv2
+ * the resolver stored in the registry/subgraph for a v1 name can be a single
+ * abstraction/wrapper contract. Calling `getResolver` on it reveals the true
+ * underlying resolver of the name.
+ *
+ * Normal resolvers do not implement `getResolver`, so this call is expected to
+ * revert for them. A revert simply means "there is no abstraction layer".
+ */
+export const ensV1ResolverAbstractionSnippet = parseAbi([
+  'function getResolver(bytes name) view returns (address resolver, address offchain)',
+])
+
+type UseUnderlyingResolverParameters = {
+  name: string
+  /** The currently-known resolver, from the registry/subgraph. */
+  resolverAddress: string | undefined
+  enabled?: boolean
+}
+
+/**
+ * Attempts to resolve the true underlying resolver of a name when its
+ * registry/subgraph resolver is the ENSv2 `ENSV1Resolver` abstraction contract.
+ *
+ * If `resolverAddress` implements `getResolver` and returns a non-zero resolver,
+ * `isAbstracted` is `true` and `underlyingResolver` holds the true resolver.
+ * Otherwise the call reverts (or returns zero) and `isAbstracted` is `false`,
+ * meaning callers should keep using the original `resolverAddress`.
+ */
+export const useUnderlyingResolver = ({
+  name,
+  resolverAddress,
+  enabled = true,
+}: UseUnderlyingResolverParameters) => {
+  const query = useReadContract({
+    abi: ensV1ResolverAbstractionSnippet,
+    address: resolverAddress as Address | undefined,
+    functionName: 'getResolver',
+    args: [dnsEncodeName(name)],
+    query: {
+      enabled: enabled && !!name && !!resolverAddress && resolverAddress !== emptyAddress,
+      // The call reverts for resolvers that do not implement `getResolver`.
+      // That is an expected outcome, not a transient failure, so never retry.
+      retry: false,
+    },
+  })
+
+  const underlyingResolver = query.data?.[0]
+  const offchainResolver = query.data?.[1]
+
+  const isAbstracted =
+    query.isSuccess && !!underlyingResolver && !isAddressEqual(underlyingResolver, emptyAddress)
+
+  return {
+    ...query,
+    underlyingResolver,
+    offchainResolver,
+    isAbstracted,
+  }
+}


### PR DESCRIPTION
## Summary
Add support for detecting and displaying the true underlying resolver when an ENS name uses the ENSv2 `ENSV1Resolver` abstraction contract. This allows the app to properly handle the resolver abstraction layer introduced in ENSv2 while maintaining backward compatibility with ENSv1 names.

## Key Changes
- **New hook `useUnderlyingResolver`** - Detects when a resolver is the ENSv2 abstraction contract and retrieves the true underlying resolver by calling `getResolver()`. Gracefully handles non-abstracted resolvers by catching reverts.

## Implementation Details
- The hook uses `wagmi`'s `useReadContract` to safely call `getResolver()` on the resolver address, with retry disabled since reverts are expected for non-abstracted resolvers.
- The abstraction detection is only attempted when a valid resolver address exists and is not the empty address.
- Uses `dnsEncodeName` utility to properly encode the name for the contract call.

https://claude.ai/code/session_01QKEuJWAqHKZGWsZTTEAaqn