### PR TITLE
Add Claude-driven manual test workflow for PRs

### DIFF
--- a/.github/claude/manual-test-instructions.md
+++ b/.github/claude/manual-test-instructions.md
@@ -1,0 +1,173 @@
+# Claude manual-test run book
+
+You are doing exploratory **manual** testing of a pull request against a fully local ENS stack,
+driving a real browser through the Playwright MCP server. You are not writing automated tests.
+
+## Environment (already running — verify, don't rebuild)
+
+| Thing | Where | Notes |
+| --- | --- | --- |
+| App (Next.js dev server) | http://localhost:3000 | started with `pnpm dev:glocal` |
+| Chain (anvil) | http://localhost:8545 | chain id `1337`, started by `pnpm denv` |
+| Subgraph (ensnode) | http://localhost:42069/subgraph | lags the chain — always re-sync before asserting on lists |
+| Wallet control server | http://127.0.0.1:8546 | starts with your first browser navigation, see below |
+
+Sanity-check by opening http://localhost:3000. If the app or the chain is not up, **stop and report
+that** instead of guessing.
+
+### Wallet
+
+Every browser tab gets the same mock wallet the e2e suite uses
+(`@ensdomains/headless-web3-provider`, injected by `.github/scripts/manual-test/init-page.cjs`). In
+the connect modal it is **"Headless Web3 Provider"** — pick that, exactly as the e2e specs do. Every
+request kind is pre-authorized, so there is no extension popup and no "Confirm connection in the
+extension" step to wait on: a transaction is signed and submitted the moment the app asks.
+
+The accounts are the standard anvil test accounts (`test test test ... junk`), named `user`,
+`user2`, `user3`, `user4` — the same names the e2e suite uses. `user` is active by default.
+
+The control server comes up with the first tab, so navigate once before using it:
+
+```bash
+curl -s http://127.0.0.1:8546/state                                          # active account, chain, block time
+curl -sXPOST http://127.0.0.1:8546/account      -d '{"user":"user2"}'        # switch account (all tabs)
+curl -sXPOST http://127.0.0.1:8546/time/advance -d '{"seconds":7776000}'     # chain + page clock forward 90 days
+curl -sXPOST http://127.0.0.1:8546/clock/sync                               # re-pin page clock to chain time
+```
+
+### Clock
+
+Local anvil does not run on real time. The page clock is installed at the anvil block timestamp
+(same as the `time` e2e fixture), and `/time/advance` moves the chain and the page clock together.
+Reload the page after time travel so the app re-reads state. Never reason about expiry using today's
+real-world date — use `curl -s http://127.0.0.1:8546/state | jq .blockTimestamp`.
+
+### Creating test data
+
+Do not try to hand-register names through the UI just to get fixtures. Use the seeder, which is the
+same `makeName` helper the e2e suite uses:
+
+```bash
+SEED_NAMES='[
+  {"label":"claude-legacy","type":"legacy","owner":"user"},
+  {"label":"claude-wrapped","type":"wrapped","owner":"user","duration":31536000},
+  {"label":"claude-grace","type":"legacy","owner":"user","duration":-86400}
+]' pnpm seed
+```
+
+* `type`: `legacy` (legacy + config), `legacy-register`, or `wrapped`
+* negative `duration` puts a name in the grace period; other options (`manager`, `fuses`,
+  `records`, `subnames`, `resolver`, `addr`) are documented in `playwright/fixtures/makeName/`
+* the seeder appends a unique suffix to each label and prints the real names as
+  `SEEDED: [...]` — always use those, not the label you asked for
+* prefix your labels (e.g. `claude-…`) so they are recognisable in the report
+* it waits for the subgraph before returning, and needs no browser
+
+Read the existing specs in `e2e/specs/stateless/` for realistic usage patterns of any flow you are
+about to exercise (they show the actual routes, test ids and expected copy).
+
+**Scope:** if `MANUAL_TEST_SCOPE` is `baseline`, run Phase 0 and the report only — skip Phases 1-3.
+That mode is for rehearsing this workflow itself, not for reviewing a PR.
+
+## Phase 0 — Baseline flows (always run, whatever the PR changes)
+
+Every PR gets these two flows exercised end to end, before anything PR-specific. They are the app's
+core money paths, they cover the harness itself, and they give a PR with no user-facing change
+something meaningful to report.
+
+**1. Register a name**
+
+* connect as `user`, search for a fresh unregistered label (prefix it, e.g. `claude-reg-<something>`)
+* run the full flow: duration, payment step, commit, the countdown, then the register transaction
+* the commit countdown is chain-time based — if it stalls, advance the chain
+  (`curl -sXPOST http://127.0.0.1:8546/time/advance -d '{"seconds":60}'`) and reload
+* **oracles**: after completion the name resolves to a profile page; the expiry is the registration
+  block timestamp advanced by the duration you chose **as calendar time**, not a fixed number of
+  seconds (see the note below); the owner is `user`'s address; the name shows up under My Names once
+  the subgraph catches up
+
+**2. Extend a name**
+
+* use an existing owned name — seed one rather than registering a second time:
+  `SEED_NAMES='[{"label":"claude-ext-<something>","type":"legacy","owner":"user"}]' pnpm seed`
+* note the expiry shown before extending, then extend by 1 year and confirm the transaction
+* **oracles**: new expiry = the same calendar date one year after the old expiry (state both
+  timestamps in the report); the quoted price is the rent price for that duration, not a
+  placeholder; the profile and My Names both show the new expiry after the subgraph syncs
+
+> **Durations are calendar years, not 31,536,000s.** `DateSelection` computes the duration with
+> `secondsFromDateDiff` → `setFullYear(year + n)` (`src/utils/date.ts`), so a year spanning Feb 29 is
+> 366 days (31,622,400s). Expiry 2027-07-30 → 2028-07-30 crosses the 2028 leap day and is *correctly*
+> one day longer than a naive `+31536000`. Derive the expected value by calendar arithmetic and only
+> flag a mismatch against that — do not report the leap-day difference as a regression.
+
+Report these as their own section. If either fails, that is a finding regardless of what the PR
+touched — say so plainly and continue to the PR-specific work.
+
+## Phase 1 — Understand the change (do NOT skip)
+
+1. Read `gh pr view $PR` (title + body — it often states intended behaviour, edge cases, and
+   explicit non-goals) and `gh pr diff $PR`.
+2. For each changed file decide: does it have a user-facing runtime surface? Build a list of the
+   concrete behaviours a user can observe. Note anything the author calls out of scope — do not
+   test that as if it were new.
+3. Find the UI entry points for those behaviours by exploring the running app yourself. Verify real
+   routes and control selectors; never assume URLs or labels from the PR description.
+4. Work out what test data you need (name type, ownership, expiry state, records, fuses,
+   wrapped vs unwrapped, subnames) and seed it up front with the seeder above.
+
+## Phase 2 — Derive a test plan
+
+Write a comprehensive scenario list covering:
+
+* the happy path(s) the PR is meant to enable
+* edge cases: empty/unset, invalid or malformed input, boundary values, pre-existing/legacy data,
+  and whatever the diff's branches and error handling imply
+* regression: adjacent features sharing code with this change still work
+* state-dependent rendering: if output depends on account / chain time / name state / device,
+  VARY that state and confirm the output tracks it
+
+For each scenario state the **oracle** up front — the exact rule that makes it pass or fail. Where
+the expected value is computable (a price, a duration, a date, a derived string), compute it
+yourself and show the arithmetic. Never judge by "looks plausible".
+
+Post the plan as the first section of your report before executing it.
+
+## Phase 3 — Execute
+
+Drive the app with the Playwright MCP tools. For every scenario:
+
+* navigate, act, and capture evidence (`browser_snapshot`, and `browser_take_screenshot` for
+  anything visual or anything that failed)
+* wait for transaction modals to reach their final state — transactions auto-approve but still need
+  a block; the subgraph then needs a moment to index
+* watch the browser console for errors (`browser_console_messages`) and note them
+* when something fails, try to isolate it: retry once, vary one input, and check whether it also
+  fails on `origin/main` behaviour you can reason about from the diff
+
+Record for each scenario: what you did, expected (with the oracle), actual, PASS/FAIL/BLOCKED.
+
+## Phase 4 — Report
+
+Write the full report to `/tmp/manual-test-report.md` and post it:
+
+```bash
+gh pr comment $PR --body-file /tmp/manual-test-report.md
+```
+
+**Dry run:** if `MANUAL_TEST_DRY_RUN` is `true` (local `act` runs), do not comment on the PR — write
+the file and print the report to stdout instead.
+
+Report structure:
+
+1. **Verdict** — one line: `✅ looks good` / `⚠️ issues found` / `❌ blocked`, plus a one-sentence
+   summary and the count of pass/fail/blocked.
+2. **What I understood the PR to do** — 3-6 bullets, plus stated non-goals.
+3. **Test plan** — the scenarios with their oracles.
+4. **Results table** — scenario | expected | actual | verdict.
+5. **Issues found** — for each: severity, exact reproduction steps (route, account, seeded data,
+   clicks), expected vs actual with the arithmetic where relevant, console errors.
+6. **Not covered** — anything you could not test, and why.
+
+Be blunt about failures and equally blunt about uncertainty — mark a scenario BLOCKED rather than
+guessing a verdict. Screenshots live in the workflow artifacts; reference them by filename.

--- a/.github/scripts/manual-test/README.md
+++ b/.github/scripts/manual-test/README.md
@@ -1,0 +1,106 @@
+# Manual-test harness
+
+Supports `.github/workflows/claude-manual-test.yaml`, which lets Claude drive the real app in a
+browser (via the Playwright MCP server) against the local ENS stack and post a report on the PR.
+
+The e2e suite gets its wallet and its clock from Playwright fixtures, which a browser driven through
+MCP does not have. `init-page.cjs` restores both by hooking MCP's `--init-page`, which the server
+`require()`s and calls as `default({ page })` for every tab, before that tab navigates:
+
+* injects **the same mock wallet the e2e suite uses** (`@ensdomains/headless-web3-provider`) with
+  every request kind in `permitted`, so nothing needs manual authorization — it shows up in the
+  connect modal as "Headless Web3 Provider", exactly as in `playwright/fixtures/login.ts`
+* installs the page clock at the anvil block timestamp, like the `time` fixture — local chain time is
+  not real time, so without this every name looks expired
+* starts a control server on `127.0.0.1:8546` (with the first tab) so the agent driving the browser
+  can switch accounts and travel in time from the shell
+
+Related files:
+
+| File | Role |
+| --- | --- |
+| `wait-for-stack.mjs` | Blocks until contracts are deployed on chain and the subgraph has caught up. `.env.local` existing is not proof — it survives across runs |
+| `smoke.mjs` | Boots a real MCP server with the hook, loads the app, and asserts the wallet, clock and control server all work. Runs before the Claude session so a broken harness fails in seconds instead of mid-session |
+| `../claude/manual-test-instructions.md` | The run book Claude follows |
+| `../../e2e/seed/seed.spec.ts` | `pnpm seed` — seeds names with the same `makeName` helper as the e2e suite |
+
+Run the smoke test by hand against a running stack with
+`node .github/scripts/manual-test/smoke.mjs` (add `MCP_CONFIG=...` to spawn MCP exactly as the
+workflow does).
+
+## Running it locally
+
+```bash
+pnpm denv         # anvil + subgraph + contracts
+pnpm dev:glocal   # app on :3000
+
+# MCP server with the wallet + clock hook
+npx -y @playwright/mcp@latest install-browser chrome-for-testing   # once
+npx -y @playwright/mcp@latest --init-page "$PWD/.github/scripts/manual-test/init-page.cjs"
+```
+
+Control server (available after the first navigation):
+
+```bash
+curl -s  http://127.0.0.1:8546/state
+curl -sXPOST http://127.0.0.1:8546/account      -d '{"user":"user2"}'
+curl -sXPOST http://127.0.0.1:8546/time/advance -d '{"seconds":7776000}'
+curl -sXPOST http://127.0.0.1:8546/clock/sync
+```
+
+Seeding:
+
+```bash
+SEED_NAMES='[{"label":"demo","type":"legacy","owner":"user","duration":-86400}]' pnpm seed
+```
+
+## Testing the workflow itself with `act`
+
+```bash
+act workflow_dispatch -W .github/workflows/claude-manual-test.yaml --input pr=<number> \
+  -P blacksmith-4vcpu-ubuntu-2404=catthehacker/ubuntu:act-latest \
+  --container-daemon-socket /var/run/docker.sock \
+  --artifact-server-path /tmp/act-artifacts
+```
+
+Add `-n` for a dry run (validates the job graph and expressions only). `act` sets `ACT=true`, and the
+steps that need real GitHub context — `gh pr checkout`, the Claude session, the failure comment — are
+guarded with `if: ${{ !env.ACT }}`, so a local run exercises the stack (deps, browsers, `denv`, the
+app, the harness smoke test) and stops short of spending Claude usage.
+
+To rehearse the Claude session itself locally, add a token and opt in:
+
+```bash
+act workflow_dispatch -W .github/workflows/claude-manual-test.yaml \
+  -P blacksmith-4vcpu-ubuntu-2404=catthehacker/ubuntu:act-latest \
+  --container-daemon-socket /var/run/docker.sock \
+  --artifact-server-path /tmp/act-artifacts \
+  --env CLAUDE_IN_ACT=true \
+  --env MANUAL_TEST_SCOPE=baseline \
+  -s GITHUB_TOKEN="$(gh auth token)" \
+  -s CLAUDE_CODE_OAUTH_TOKEN            # act prompts for the value (from `claude setup-token`)
+```
+
+No `--input pr=` here on purpose: with no PR to read, only a baseline rehearsal makes sense, and the
+workflow fails fast if you ask for full scope without a PR number. Add `--input pr=<number>` (and
+drop `MANUAL_TEST_SCOPE`) once there is a real PR to test.
+
+Get the token with `claude setup-token` — it is not the same as an interactive Claude Code login.
+Instead of `-s`, you can put `CLAUDE_CODE_OAUTH_TOKEN=...` in a `.secrets` file (gitignored, act
+reads it by default).
+
+Two guards make that safe and cheap:
+
+* `MANUAL_TEST_DRY_RUN` is set automatically under `act`, so the session writes
+  `/tmp/manual-test-report.md` and prints it instead of commenting on the real PR
+* `MANUAL_TEST_SCOPE=baseline` limits the session to the Phase 0 register/extend flows, which is
+  enough to prove auth, MCP, the wallet and the report path work
+
+Env overrides: `ANVIL_RPC_URL` (default `http://localhost:8545`), `MANUAL_TEST_CONTROL_PORT`
+(default `8546`), `SECRET_WORDS`, `MANUAL_TEST_WALLET_DEBUG=1` for provider-level logging.
+
+> The wallet signs with the standard anvil test mnemonic and approves everything without prompting.
+> It is for local/CI test chains only — never point it at a real RPC.
+
+Note: `init-page.cjs` runs inside the MCP server process, which speaks JSON-RPC over stdout — all
+logging in it must go to stderr.

--- a/.github/scripts/manual-test/init-page.cjs
+++ b/.github/scripts/manual-test/init-page.cjs
@@ -1,0 +1,208 @@
+/**
+ * Playwright MCP `--init-page` module: gives an MCP-driven browser the same wallet and the same
+ * clock handling the e2e suite gets from its Playwright fixtures.
+ *
+ * The MCP server calls `module.exports.default({ page })` once per tab, before the tab navigates,
+ * so this is the equivalent of the `wallet` + `time` fixtures in playwright/index.ts:
+ *   - injects @ensdomains/headless-web3-provider (the mock wallet the e2e suite uses), with every
+ *     request kind in `permitted` so nothing needs manual authorization
+ *   - installs the page clock at the anvil block timestamp (local chain time is not real time)
+ *
+ * It also exposes a small control server so the agent driving the browser can switch accounts and
+ * travel in time from the shell — see README.md.
+ *
+ * IMPORTANT: this runs inside the MCP server process, which speaks JSON-RPC over stdout. All
+ * logging must go to stderr.
+ */
+const { createServer } = require('node:http')
+
+const { injectHeadlessWeb3Provider, Web3RequestKind } = require('@ensdomains/headless-web3-provider')
+const { bytesToHex, createPublicClient, createTestClient, http } = require('viem')
+const { mnemonicToAccount } = require('viem/accounts')
+const { anvil } = require('viem/chains')
+
+const RPC_URL = process.env.ANVIL_RPC_URL || 'http://localhost:8545'
+const CONTROL_PORT = Number(process.env.MANUAL_TEST_CONTROL_PORT || 8546)
+const MNEMONIC = process.env.SECRET_WORDS || 'test test test test test test test test test test test junk'
+
+// Same account ordering/naming as playwright/fixtures/accounts.ts
+const USERS = ['user', 'user2', 'user3', 'user4']
+const accounts = USERS.map((_, addressIndex) => mnemonicToAccount(MNEMONIC, { addressIndex }))
+const privateKeys = accounts.map((account) => bytesToHex(account.getHdKey().privateKey))
+
+const log = (...parts) => console.error('[manual-test]', ...parts)
+
+// Every request kind is pre-authorized: there is no human to confirm a popup.
+const permitted = Object.values(Web3RequestKind)
+
+const state = {
+  chainId: null,
+  activeUser: 'user',
+  tabs: [], // { page, wallet }
+  controlServer: null,
+  clients: null,
+}
+
+const clients = () => {
+  if (!state.clients) {
+    const chain = { ...anvil, id: state.chainId }
+    const transport = http(RPC_URL)
+    state.clients = {
+      publicClient: createPublicClient({ chain, transport }),
+      testClient: createTestClient({ chain, transport, mode: 'anvil' }),
+    }
+  }
+  return state.clients
+}
+
+const rpc = async (method, params = []) => {
+  const res = await fetch(RPC_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  })
+  const json = await res.json()
+  if (json.error) throw new Error(json.error.message)
+  return json.result
+}
+
+// ens-test-env runs anvil with --chain-id 1337, but read it back: signing against the wrong chain
+// id fails with a confusing "invalid chain id for signer".
+const chainId = async () => {
+  if (state.chainId === null) state.chainId = Number(await rpc('eth_chainId'))
+  return state.chainId
+}
+
+const currentBlockTimestamp = async () => Number((await clients().publicClient.getBlock()).timestamp)
+
+const liveTabs = () => {
+  state.tabs = state.tabs.filter(({ page }) => !page.isClosed())
+  return state.tabs
+}
+
+const privateKeysFor = (user) => {
+  const index = USERS.indexOf(user)
+  // active account first - the mock wallet reports accounts in order
+  return [privateKeys[index], ...privateKeys.filter((_, i) => i !== index)]
+}
+
+// Pull every open page onto the current chain time. Used after time travel, and available on
+// /clock/sync for when a flow has left the page clock behind.
+const syncClock = async () => {
+  const timestamp = await currentBlockTimestamp()
+  await Promise.all(
+    liveTabs().map(({ page }) =>
+      page.clock.setSystemTime(new Date(timestamp * 1000)).catch((error) => {
+        log('clock sync failed', error.message)
+      }),
+    ),
+  )
+  return timestamp
+}
+
+const controlState = async () => ({
+  user: state.activeUser,
+  address: accounts[USERS.indexOf(state.activeUser)].address,
+  chainId: state.chainId,
+  blockTimestamp: await currentBlockTimestamp(),
+  tabs: liveTabs().length,
+})
+
+const readBody = (req) =>
+  new Promise((resolve, reject) => {
+    let body = ''
+    req.on('data', (chunk) => {
+      body += chunk
+    })
+    req.on('end', () => {
+      try {
+        resolve(body ? JSON.parse(body) : {})
+      } catch (error) {
+        reject(error)
+      }
+    })
+    req.on('error', reject)
+  })
+
+const send = (res, status, payload) => {
+  res.writeHead(status, {
+    'content-type': 'application/json',
+    'access-control-allow-origin': '*',
+    'cache-control': 'no-store',
+  })
+  res.end(JSON.stringify(payload, (_, value) => (typeof value === 'bigint' ? value.toString() : value)))
+}
+
+const startControlServer = () => {
+  if (state.controlServer) return
+
+  state.controlServer = createServer(async (req, res) => {
+    try {
+      const { pathname } = new URL(req.url, 'http://127.0.0.1')
+
+      if (pathname === '/state') return send(res, 200, await controlState())
+
+      if (pathname === '/account') {
+        const { user } = await readBody(req)
+        if (!USERS.includes(user)) return send(res, 400, { error: `unknown user: ${user}` })
+        state.activeUser = user
+        const keys = privateKeysFor(user)
+        await Promise.all(liveTabs().map(({ wallet }) => wallet.changeAccounts(keys)))
+        log('active account ->', user, accounts[USERS.indexOf(user)].address)
+        return send(res, 200, await controlState())
+      }
+
+      if (pathname === '/time/advance') {
+        const { seconds } = await readBody(req)
+        const { testClient } = clients()
+        await testClient.increaseTime({ seconds: Number(seconds) })
+        await testClient.mine({ blocks: 1 })
+        const timestamp = await syncClock()
+        log(`advanced chain by ${seconds}s, page clock now ${new Date(timestamp * 1000).toISOString()}`)
+        return send(res, 200, await controlState())
+      }
+
+      if (pathname === '/clock/sync') {
+        const timestamp = await syncClock()
+        log('page clock synced to block time', new Date(timestamp * 1000).toISOString())
+        return send(res, 200, await controlState())
+      }
+
+      return send(res, 404, { error: 'not found' })
+    } catch (error) {
+      log('control error', error.message)
+      return send(res, 500, { error: error.message })
+    }
+  })
+
+  state.controlServer.on('error', (error) => log('control server error', error.message))
+  state.controlServer.listen(CONTROL_PORT, '127.0.0.1', () =>
+    log(`control server on http://127.0.0.1:${CONTROL_PORT}`),
+  )
+  state.controlServer.unref()
+}
+
+module.exports.default = async ({ page }) => {
+  const id = await chainId()
+
+  const wallet = await injectHeadlessWeb3Provider({
+    page,
+    privateKeys: privateKeysFor(state.activeUser),
+    chains: [{ ...anvil, id }],
+    permitted,
+    debug: !!process.env.MANUAL_TEST_WALLET_DEBUG,
+    logger: log,
+  })
+
+  // Mirrors the `time` fixture: the browser must run on chain time, or every name looks expired.
+  const timestamp = await currentBlockTimestamp()
+  await page.clock.install({ time: new Date(timestamp * 1000) })
+
+  state.tabs.push({ page, wallet })
+  startControlServer()
+
+  log(
+    `tab ready - chain ${id}, account ${state.activeUser} ` +
+      `(${accounts[USERS.indexOf(state.activeUser)].address}), clock ${new Date(timestamp * 1000).toISOString()}`,
+  )
+}

--- a/.github/scripts/manual-test/smoke.mjs
+++ b/.github/scripts/manual-test/smoke.mjs
@@ -1,0 +1,234 @@
+/**
+ * Fails fast if the manual-test harness is broken, before a Claude session is started.
+ *
+ * Boots a real Playwright MCP server with the --init-page hook, loads the app through it, and checks
+ * that the mock wallet and the chain-time clock are actually in the page, plus that the control
+ * server responds. Exits non-zero with a diagnosis if not.
+ *
+ * Usage: node .github/scripts/manual-test/smoke.mjs [--app http://localhost:3000] [--port 8931]
+ */
+import { spawn } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+
+const args = process.argv.slice(2)
+const getArg = (name, fallback) => {
+  const i = args.indexOf(`--${name}`)
+  return i === -1 ? fallback : args[i + 1]
+}
+
+const APP_URL = getArg('app', process.env.APP_URL ?? 'http://localhost:3000')
+const MCP_PORT = Number(getArg('port', 8931))
+const CONTROL_URL = `http://127.0.0.1:${process.env.MANUAL_TEST_CONTROL_PORT ?? 8546}`
+const INIT_PAGE = new URL('./init-page.cjs', import.meta.url).pathname
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Spawn from the very same MCP config the Claude session gets, when there is one, so the smoke test
+// cannot pass with arguments the real session does not use.
+const fromConfig = () => {
+  if (!process.env.MCP_CONFIG) return null
+  const config = JSON.parse(readFileSync(process.env.MCP_CONFIG, 'utf8'))
+  const server = config.mcpServers?.playwright
+  if (!server?.command) return null
+  console.log(`using MCP config ${process.env.MCP_CONFIG}`)
+  return { command: server.command, args: [...(server.args ?? []), '--port', String(MCP_PORT)] }
+}
+
+const spec = fromConfig() ?? {
+  command: 'npx',
+  args: [
+    '-y',
+    '@playwright/mcp@latest',
+    '--headless',
+    '--isolated',
+    // without this MCP looks for system Chrome at /opt/google/chrome/chrome
+    '--browser',
+    'chromium',
+    '--port',
+    String(MCP_PORT),
+    '--init-page',
+    INIT_PAGE,
+  ],
+}
+
+const mcp = spawn(
+  spec.command,
+  spec.args,
+  // own process group, so the browser and the npx wrapper die with us and free port 8546 for the
+  // MCP server the Claude session starts
+  { stdio: ['ignore', 'pipe', 'pipe'], detached: true },
+)
+const stopMcp = () => {
+  try {
+    process.kill(-mcp.pid, 'SIGKILL')
+  } catch {
+    /* already gone */
+  }
+}
+process.on('exit', stopMcp)
+let mcpOutput = ''
+mcp.stdout.on('data', (chunk) => {
+  mcpOutput += chunk
+})
+mcp.stderr.on('data', (chunk) => {
+  mcpOutput += chunk
+})
+
+const fail = (message) => {
+  console.error(`\n✗ ${message}`)
+  console.error(`\n--- mcp output ---\n${mcpOutput.trim()}`)
+  stopMcp()
+  process.exit(1)
+}
+
+// MCP binds "localhost", which may resolve to ::1 - use the hostname, not 127.0.0.1.
+const ENDPOINT = `http://localhost:${MCP_PORT}/mcp`
+let sessionId = null
+let requestId = 0
+
+const rpc = async (method, params) => {
+  const headers = { 'content-type': 'application/json', accept: 'application/json, text/event-stream' }
+  if (sessionId) headers['mcp-session-id'] = sessionId
+  const res = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ jsonrpc: '2.0', id: ++requestId, method, params }),
+  })
+  if (res.headers.get('mcp-session-id')) sessionId = res.headers.get('mcp-session-id')
+  const body = await res.text()
+  const line = body.split('\n').find((l) => l.startsWith('data: ')) ?? body
+  const json = JSON.parse(line.replace(/^data: /, ''))
+  if (json.error) throw new Error(`${method}: ${JSON.stringify(json.error)}`)
+  return json.result
+}
+
+const callTool = async (name, args_) => {
+  const result = await rpc('tools/call', { name, arguments: args_ })
+  const text = (result.content ?? []).map((c) => c.text).join('\n')
+  if (result.isError || /^### Error/m.test(text)) throw new Error(`${name}: ${text}`)
+  return text
+}
+
+// A tool result looks like "### Result\n<json>\n### Ran Playwright code\n```js ...```" - take just
+// the JSON under the Result heading.
+export const resultValue = (text) => {
+  const start = text.indexOf('### Result')
+  const body = start === -1 ? text : text.slice(start + '### Result'.length)
+  const end = body.indexOf('\n### ')
+  const json = (end === -1 ? body : body.slice(0, end)).trim()
+  return JSON.parse(json.replace(/^```(?:json)?/, '').replace(/```$/, '').trim())
+}
+
+// --- wait for the MCP server to listen ---------------------------------------------------------
+let up = false
+for (let i = 0; i < 60 && !up; i += 1) {
+  try {
+    await rpc('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'manual-test-smoke', version: '1' },
+    })
+    up = true
+  } catch {
+    await sleep(1000)
+  }
+}
+if (!up) fail(`Playwright MCP did not start on port ${MCP_PORT}`)
+
+await fetch(ENDPOINT, {
+  method: 'POST',
+  headers: {
+    'content-type': 'application/json',
+    accept: 'application/json, text/event-stream',
+    'mcp-session-id': sessionId,
+  },
+  body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+})
+console.log('✓ MCP server up')
+
+// --- app reachable? ----------------------------------------------------------------------------
+// The dev server is started in an earlier step and can die in between (a backgrounded child that
+// is not in its own session gets torn down with the step). Diagnose that here with its log, rather
+// than surfacing a bare ERR_CONNECTION_REFUSED from the browser.
+const devLogTail = () => {
+  try {
+    return readFileSync('/tmp/dev.log', 'utf8').trim().split('\n').slice(-15).join('\n')
+  } catch {
+    return '(no /tmp/dev.log)'
+  }
+}
+
+let appUp = false
+for (let i = 0; i < 30 && !appUp; i += 1) {
+  try {
+    const res = await fetch(APP_URL, { redirect: 'manual' })
+    appUp = res.status < 500
+  } catch {
+    await sleep(2000)
+  }
+}
+if (!appUp) {
+  console.error(`\n--- dev server log ---\n${devLogTail()}`)
+  fail(`the app is not serving on ${APP_URL} - the dev server is not running any more`)
+}
+
+// --- load the app ------------------------------------------------------------------------------
+try {
+  await callTool('browser_navigate', { url: APP_URL })
+  console.log(`✓ loaded ${APP_URL}`)
+} catch (error) {
+  console.error(`\n--- dev server log ---\n${devLogTail()}`)
+  fail(`could not load the app at ${APP_URL}: ${error.message}`)
+}
+
+// --- wallet + clock in the page ----------------------------------------------------------------
+let probe
+try {
+  const text = await callTool('browser_evaluate', {
+    function: `async () => {
+      if (!window.ethereum) return { error: 'window.ethereum missing - init-page did not run' }
+      const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' })
+      const chainId = await window.ethereum.request({ method: 'eth_chainId' })
+      const announced = []
+      window.addEventListener('eip6963:announceProvider', (e) => announced.push(e.detail.info.name))
+      window.dispatchEvent(new Event('eip6963:requestProvider'))
+      await new Promise((r) => setTimeout(r, 100))
+      return { accounts, chainId, announced, pageTime: Math.floor(Date.now() / 1000) }
+    }`,
+  })
+  probe = resultValue(text)
+} catch (error) {
+  fail(`wallet probe failed: ${error.message}`)
+}
+
+if (probe.error) fail(probe.error)
+if (!probe.accounts?.length) fail('mock wallet returned no accounts (request was not auto-approved?)')
+if (!probe.announced?.includes('Headless Web3 Provider'))
+  fail(`wallet not announced over EIP-6963 (announced: ${JSON.stringify(probe.announced)})`)
+console.log(`✓ mock wallet: ${probe.accounts[0]} on chain ${probe.chainId}, announced as "Headless Web3 Provider"`)
+
+// --- control server ----------------------------------------------------------------------------
+let state
+try {
+  state = await (await fetch(`${CONTROL_URL}/state`)).json()
+} catch (error) {
+  fail(`control server not reachable at ${CONTROL_URL}: ${error.message}`)
+}
+console.log(`✓ control server: user ${state.user}, chain ${state.chainId}, block time ${new Date(state.blockTimestamp * 1000).toISOString()}`)
+
+const drift = Math.abs(probe.pageTime - state.blockTimestamp)
+if (drift > 300) fail(`page clock is ${drift}s from chain time - the clock hook did not take effect`)
+console.log(`✓ page clock within ${drift}s of chain time`)
+
+// --- app actually rendered ---------------------------------------------------------------------
+try {
+  const snapshot = await callTool('browser_snapshot', {})
+  if (!/connect/i.test(snapshot)) fail('app rendered but no connect control found in the snapshot')
+  console.log('✓ app rendered with a connect control')
+} catch (error) {
+  fail(`snapshot failed: ${error.message}`)
+}
+
+console.log('\nharness OK')
+stopMcp()
+process.exit(0)

--- a/.github/scripts/manual-test/wait-for-stack.mjs
+++ b/.github/scripts/manual-test/wait-for-stack.mjs
@@ -1,0 +1,80 @@
+/**
+ * Blocks until the local ENS stack is genuinely usable: contracts deployed on the chain and the
+ * subgraph indexed up to the chain head.
+ *
+ * `.env.local` existing is not enough - it is written by the deploy but survives across runs, so a
+ * stale copy in the working tree would let the workflow race ahead of a fresh deploy.
+ */
+import { readFileSync } from 'node:fs'
+
+const RPC_URL = process.env.ANVIL_RPC_URL ?? 'http://localhost:8545'
+const SUBGRAPH_URL = process.env.SUBGRAPH_URL ?? 'http://localhost:42069/subgraph'
+const TIMEOUT_MS = Number(process.env.WAIT_FOR_STACK_TIMEOUT ?? 600_000)
+
+const deadline = Date.now() + TIMEOUT_MS
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const rpc = async (method, params = []) => {
+  const res = await fetch(RPC_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  })
+  const json = await res.json()
+  if (json.error) throw new Error(json.error.message)
+  return json.result
+}
+
+const registryAddress = () => {
+  const env = readFileSync('.env.local', 'utf8')
+  const line = env.split('\n').find((l) => l.startsWith('NEXT_PUBLIC_DEPLOYMENT_ADDRESSES='))
+  if (!line) throw new Error('NEXT_PUBLIC_DEPLOYMENT_ADDRESSES missing from .env.local')
+  const addresses = JSON.parse(line.slice(line.indexOf('=') + 1).replace(/^'|'$/g, ''))
+  if (!addresses.ENSRegistry) throw new Error('ENSRegistry missing from deployment addresses')
+  return addresses.ENSRegistry
+}
+
+const waitFor = async (label, check) => {
+  let lastError = 'no attempt completed'
+  while (Date.now() < deadline) {
+    try {
+      const detail = await check()
+      if (detail) {
+        console.log(`✓ ${label}: ${detail}`)
+        return
+      }
+    } catch (error) {
+      lastError = error.message
+    }
+    await sleep(3000)
+  }
+  throw new Error(`timed out waiting for ${label} (last error: ${lastError})`)
+}
+
+const registry = registryAddress()
+
+await waitFor(`chain ${RPC_URL}`, async () => {
+  const chainId = Number(await rpc('eth_chainId'))
+  return `chain id ${chainId}`
+})
+
+await waitFor(`contracts deployed (ENSRegistry ${registry})`, async () => {
+  const code = await rpc('eth_getCode', [registry, 'latest'])
+  return code && code !== '0x' ? `${(code.length - 2) / 2} bytes of code` : null
+})
+
+await waitFor(`subgraph ${SUBGRAPH_URL} in sync`, async () => {
+  const head = Number(await rpc('eth_blockNumber'))
+  const res = await fetch(SUBGRAPH_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ query: '{ _meta { hasIndexingErrors block { number } } }' }),
+  })
+  const { data, errors } = await res.json()
+  if (errors) throw new Error(JSON.stringify(errors))
+  if (data._meta.hasIndexingErrors) throw new Error('subgraph reports indexing errors')
+  const indexed = data._meta.block.number
+  return indexed >= head ? `block ${indexed} >= chain head ${head}` : null
+})
+
+console.log('stack ready')

--- a/.github/workflows/claude-manual-test.yaml
+++ b/.github/workflows/claude-manual-test.yaml
@@ -1,0 +1,172 @@
+name: Claude Manual Test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to test. Leave empty only for a local `act` rehearsal, where there is no PR to read.'
+        required: false
+
+concurrency:
+  group: claude-manual-test-${{ github.event.pull_request.number || inputs.pr || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write # so the action's OIDC path works on GitHub if the explicit token is ever removed
+
+jobs:
+  manual-test:
+    # Secrets are not available to fork PRs, and the run is expensive - skip both cases.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       !contains(github.event.pull_request.labels.*.name, 'skip-manual-test'))
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 90
+    env:
+      PR: ${{ github.event.pull_request.number || inputs.pr }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # `act` runs against the working tree, and has no PR/token to check out with
+      - name: Checkout PR branch
+        if: ${{ !env.ACT }}
+        run: gh pr checkout "$PR"
+
+      - uses: ./.github/actions/setup
+
+      - run: pnpm rebuild -r
+
+      - name: Install Playwright browsers
+        run: |
+          pnpm exec playwright install --with-deps chromium
+          # the MCP server ships its own playwright, which needs its own browser build
+          npx -y @playwright/mcp@latest install-browser chrome-for-testing
+
+      # --- local stack -------------------------------------------------------------------------
+      # setsid, not just nohup: each step is its own `docker exec`/shell session, and a merely
+      # backgrounded child gets torn down with it (seen under `act`: next dev died between steps).
+      - name: Start test environment (anvil + subgraph + contracts)
+        run: |
+          setsid nohup pnpm denv > /tmp/denv.log 2>&1 < /dev/null &
+          disown || true
+          pnpm wait-on ./.env.local -t 900000
+          pnpm wait-on tcp:8545 tcp:42069 -t 900000
+          # .env.local can be left over from an earlier run (e.g. under `act`), so don't treat it as
+          # proof the deploy finished - wait until the registry actually has code, and the subgraph
+          # has caught up with it.
+          node .github/scripts/manual-test/wait-for-stack.mjs
+
+      - name: Start app
+        run: |
+          setsid nohup pnpm dev:glocal > /tmp/dev.log 2>&1 < /dev/null &
+          disown || true
+          pnpm wait-on http://localhost:3000 -t 900000
+
+      # --- claude ------------------------------------------------------------------------------
+      # --init-page runs .github/scripts/manual-test/init-page.cjs on every tab: it injects the
+      # same mock wallet (@ensdomains/headless-web3-provider) and installs the same chain-time page
+      # clock the e2e fixtures set up, and exposes a control server on :8546.
+      - name: Configure Playwright MCP
+        run: |
+          mkdir -p /tmp/playwright-mcp
+          cat > /tmp/mcp-playwright.json << EOF
+          {
+            "mcpServers": {
+              "playwright": {
+                "command": "npx",
+                "args": [
+                  "-y", "@playwright/mcp@latest",
+                  "--headless",
+                  "--isolated",
+                  "--browser", "chromium",
+                  "--viewport-size", "1280,900",
+                  "--output-dir", "/tmp/playwright-mcp",
+                  "--init-page", "${{ github.workspace }}/.github/scripts/manual-test/init-page.cjs"
+                ]
+              }
+            }
+          }
+          EOF
+
+      # Cheap proof the wallet, the clock and the app are all actually working through MCP - a broken
+      # harness should fail here, not halfway through a Claude session.
+      - name: Smoke-test the harness
+        run: node .github/scripts/manual-test/smoke.mjs
+        env:
+          MCP_CONFIG: /tmp/mcp-playwright.json
+
+      # A full session reads the PR diff, so it needs a PR number. Only a baseline-scope rehearsal
+      # (register + extend, nothing PR-specific) can run without one.
+      - name: Check scope against PR context
+        run: |
+          if [ -z "$PR" ] && [ "${MANUAL_TEST_SCOPE:-full}" != "baseline" ]; then
+            echo "::error::No PR number: pass one via the workflow_dispatch input, or set MANUAL_TEST_SCOPE=baseline."
+            exit 1
+          fi
+          echo "PR=${PR:-<none>} scope=${MANUAL_TEST_SCOPE:-full}"
+
+      # Skipped under `act` by default because it spends Claude usage. To rehearse the real thing:
+      #   act ... --env CLAUDE_IN_ACT=true -s CLAUDE_CODE_OAUTH_TOKEN
+      # MANUAL_TEST_DRY_RUN then keeps it from commenting on the real PR.
+      - name: Run manual test session
+        id: claude
+        if: ${{ !env.ACT || env.CLAUDE_IN_ACT == 'true' }}
+        uses: anthropics/claude-code-action@v1
+        env:
+          MANUAL_TEST_DRY_RUN: ${{ env.ACT == 'true' }}
+          # `--env MANUAL_TEST_SCOPE=baseline` keeps a local rehearsal to the Phase 0 flows
+          MANUAL_TEST_SCOPE: ${{ env.MANUAL_TEST_SCOPE || 'full' }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Without this the action mints its own token via OIDC, which needs
+          # ACTIONS_ID_TOKEN_REQUEST_URL - real GitHub only, so it fails under `act`.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            You are manually testing the checked-out branch of ${{ github.repository }}. The PR
+            number is in `$PR` (empty only in a baseline-scope rehearsal, where there is no PR).
+
+            Read `.github/claude/manual-test-instructions.md` and follow it exactly, end to end:
+            run the Phase 0 baseline flows (register a name, extend a name) whatever the diff
+            contains, understand the diff, derive a test plan with explicit oracles, execute it in
+            the browser through the Playwright MCP tools, then write the report to
+            /tmp/manual-test-report.md and post it with
+            `gh pr comment "$PR" --body-file /tmp/manual-test-report.md`
+            (skip the comment and print the report instead when MANUAL_TEST_DRY_RUN is true).
+
+            The environment is already running - do not start servers, do not run the automated e2e
+            suite, and do not modify application source. `$PR` is available in the shell.
+            Screenshots you take are uploaded as workflow artifacts, so name them meaningfully.
+          claude_args: |
+            --mcp-config /tmp/mcp-playwright.json
+            --allowedTools "mcp__playwright,Bash,Read,Grep,Glob,Write,Edit,TodoWrite,WebFetch"
+            --max-turns 400
+
+      # --- always: evidence + fallback comment ---------------------------------------------------
+      - name: Collect logs
+        if: always()
+        run: |
+          mkdir -p /tmp/manual-test-artifacts
+          cp /tmp/denv.log /tmp/dev.log /tmp/manual-test-artifacts/ 2>/dev/null || true
+          cp /tmp/manual-test-report.md /tmp/manual-test-artifacts/ 2>/dev/null || true
+          cp -r /tmp/playwright-mcp /tmp/manual-test-artifacts/screenshots 2>/dev/null || true
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: claude-manual-test
+          path: /tmp/manual-test-artifacts
+          retention-days: 14
+
+      - name: Comment on failure
+        if: ${{ failure() && !env.ACT }}
+        run: |
+          gh pr comment "$PR" --body "🤖 Claude manual test run did not complete — see [the workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for logs and screenshots."

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ certificates
 .playwright-mcp
 .claude
 /thoughts
+# act local secrets (e.g. CLAUDE_CODE_OAUTH_TOKEN)
+.secrets

--- a/e2e/seed/seed.spec.ts
+++ b/e2e/seed/seed.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Test-data seeder for exploratory / manual testing sessions (used by the Claude manual-test
+ * workflow, but works locally too).
+ *
+ * It is a Playwright "test" only to reuse the runner's TypeScript/path resolution and the `makeName`
+ * helper — it never opens a browser, so it deliberately builds its own fixtures instead of taking
+ * them from the test context (the standard `time` fixture needs a `page`, which would force a
+ * browser launch just to seed a name).
+ *
+ * Usage:
+ *   SEED_NAMES='[{"label":"my-name","type":"legacy","owner":"user"}]' pnpm seed
+ *
+ * `SEED_NAMES` is the exact argument you would pass to `makeName(...)` in an e2e spec, so every
+ * option in playwright/fixtures/makeName is available (type: 'legacy' | 'legacy-register' |
+ * 'wrapped', owner, manager, duration — negative for grace period — fuses, records, subnames...).
+ * Optional: SEED_TIME_OFFSET (seconds), SEED_SYNC_SUBGRAPH ('false' to skip subgraph sync).
+ */
+import { test } from '@playwright/test'
+
+import { createAccounts } from '../../playwright/fixtures/accounts'
+import { testClient } from '../../playwright/fixtures/contracts/utils/addTestContracts'
+import { createMakeNames } from '../../playwright/fixtures/makeName/index'
+import { createSubgraph } from '../../playwright/fixtures/subgraph'
+import type { Time } from '../../playwright/fixtures/time'
+
+// Everything the browser clock would do is a no-op here; chain-side time travel still works.
+const headlessTime: Time = {
+  sync: async () => {},
+  syncFixed: async () => {},
+  logBrowserTime: async () => {},
+  logBlockTime: async () => {},
+  increaseTime: async ({ seconds }) => {
+    await testClient.increaseTime({ seconds })
+    await testClient.mine({ blocks: 1 })
+  },
+  increaseTimeByTimestamp: async ({ seconds }) => {
+    await testClient.increaseTime({ seconds })
+    await testClient.mine({ blocks: 1 })
+  },
+}
+
+test('seed names', async () => {
+  const raw = process.env.SEED_NAMES
+  test.skip(!raw, 'SEED_NAMES not set')
+  test.setTimeout(300_000)
+
+  const makeName = createMakeNames({
+    accounts: createAccounts(),
+    time: headlessTime,
+    subgraph: createSubgraph(),
+  })
+
+  const names = JSON.parse(raw!)
+  const result = await makeName(Array.isArray(names) ? names : [names], {
+    timeOffset: process.env.SEED_TIME_OFFSET ? Number(process.env.SEED_TIME_OFFSET) : undefined,
+    syncSubgraph: process.env.SEED_SYNC_SUBGRAPH !== 'false',
+  })
+
+  console.log(`SEEDED: ${JSON.stringify(result)}`)
+})

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "e2e:stateful": "playwright test --project=stateful",
     "e2e:wallet": "playwright test --project=wallets",
     "e2e:wallet:debug": "playwright test --project=wallets --debug",
+    "seed": "playwright test --project=seed --reporter=list",
     "e2e:ci": "E2E=true CI=true STABLE_MODE=true SLOW_MODE=true pnpm tenv start --extra-time 11368000 --verbosity 1",
     "wrangle": "wrangler pages dev ./out --local --log-level none",
     "wrangle:dev": "wrangler pages dev ./next",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,6 +23,12 @@ export default defineConfig({
       },
     },
     {
+      // Test-data seeder for manual/exploratory sessions - see e2e/seed/seed.spec.ts
+      name: 'seed',
+      testDir: './e2e/seed',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
       name: 'wallets',
       testDir: './e2e/specs/wallets',
       timeout: 300000, // 5 minutes for wallet tests


### PR DESCRIPTION
Runs an exploratory manual test on every PR: boots the local ENS stack, drives the real app in a browser via the Playwright MCP server, and posts a report as a PR comment.

An MCP-driven browser has none of the Playwright fixtures the e2e suite relies on, so init-page.cjs restores the two that matter via MCP's --init-page hook: it injects the same mock wallet the e2e suite uses (@ensdomains/headless-web3-provider, every request kind pre-authorized so nothing needs manual approval) and installs the page clock at the anvil block timestamp, since local chain time is not real time and every name would otherwise look expired. It also exposes a control server on :8546 for switching accounts and travelling in time from the shell.

Supporting pieces:
- wait-for-stack.mjs gates on contracts actually having code on chain and the subgraph reaching the chain head. A leftover .env.local is not proof the deploy finished.
- smoke.mjs boots a real MCP server, loads the app and asserts the wallet, clock and control server work, before any Claude usage is spent. It spawns from the same MCP config the session gets, so the two cannot drift.
- pnpm seed seeds fixtures through the existing makeName helper, without launching a browser.
- The run book always exercises register and extend, so a PR with no user-facing change still gets meaningful coverage.

Long-running processes are started with setsid: each step is its own shell session, and a merely backgrounded child is torn down with it.