### PR TITLE
Make short .eth names a dead end unless registered

### DIFF
--- a/public/locales/en/profile.json
+++ b/public/locales/en/profile.json
@@ -463,8 +463,10 @@
   },
   "errors": {
     "invalidName": "This name is invalid.",
+    "shortName": ".eth names must be at least 3 characters.",
     "invalidAddress": "Not a valid address",
     "expiringSoon": "The grace period for this name ends on {{date}}. If it isn’t extended before this date, it will become available for registration.",
+    "expiringSoonShortName": "The grace period for this name ends on {{date}}. Extending isn’t available for .eth names under 3 characters, and they can’t be re-registered.",
     "hasExpired": "{{ name }} has expired",
     "ownerManagerChoice": "Must send owner or manager",
     "unknown": "Unknown error",

--- a/public/locales/en/transactionFlow.json
+++ b/public/locales/en/transactionFlow.json
@@ -244,6 +244,10 @@
       "disabled": {
         "title": "ENS v2 beta is now deployed on Sepolia",
         "banner": "Future renewals will be in the new Manager app. Click <ManagerLink>here</ManagerLink> to renew your name there."
+      },
+      "shortName": {
+        "title": "This name cannot be extended",
+        "description": "Extending is not available for .eth names under 3 characters."
       }
     },
     "transferProfile": {

--- a/src/components/@molecules/NameListView/NameListView.test.tsx
+++ b/src/components/@molecules/NameListView/NameListView.test.tsx
@@ -1,12 +1,13 @@
 import { mockFunction, render } from '@app/test-utils'
 
+import { labelhash } from 'viem'
 import { describe, expect, it, vi } from 'vitest'
 
 import { TaggedNameItem } from '@app/components/@atoms/NameDetailItem/TaggedNameItem'
 import { useNamesForAddress } from '@app/hooks/ensjs/subgraph/useNamesForAddress'
 import { createDateAndValue } from '@app/utils/utils'
 
-import { NameListView } from './NameListView'
+import { isNameExtendable, NameListView } from './NameListView'
 
 vi.mock('next/router', async () => await vi.importActual('next-router-mock'))
 vi.mock('@app/components/@atoms/NameDetailItem/TaggedNameItem')
@@ -27,6 +28,19 @@ window.IntersectionObserver = mockIntersectionObserver
 window.scroll = vi.fn() as () => void
 
 describe('NameListView', () => {
+  it('should not offer registered short .eth names for bulk extension', () => {
+    expect(isNameExtendable({ name: 'on.eth', parentName: 'eth' })).toBe(false)
+    expect(isNameExtendable({ name: 'nick.eth', parentName: 'eth' })).toBe(true)
+  })
+
+  // The subgraph hands this list unhealed labels routinely, and `parseInput` calls them short
+  // because it has nothing to measure. They are ordinary names and keep their extend checkbox.
+  it('should still offer a name whose label is an encoded labelhash for bulk extension', () => {
+    const encodedName = `[${labelhash('nick').slice(2)}].eth`
+
+    expect(isNameExtendable({ name: encodedName, parentName: 'eth' })).toBe(true)
+  })
+
   it('should render if there are results', () => {
     mockTaggedNameItem.mockImplementation(mockComponent as any)
     mockUseNamesForAddress.mockReturnValue({

--- a/src/components/@molecules/NameListView/NameListView.tsx
+++ b/src/components/@molecules/NameListView/NameListView.tsx
@@ -22,6 +22,7 @@ import { useNamesForAddress } from '@app/hooks/ensjs/subgraph/useNamesForAddress
 import useDebouncedCallback from '@app/hooks/useDebouncedCallback'
 import { useQueryParameterState } from '@app/hooks/useQueryParameterState'
 import { useTransactionFlow } from '@app/transaction-flow/TransactionFlowProvider'
+import { isShortEth2LDName } from '@app/utils/shortName'
 
 const EmptyDetailContainer = styled.div(
   ({ theme }) => css`
@@ -60,6 +61,12 @@ type NameListViewProps = {
   setError?: (isError: boolean) => void
   setLoading?: (isLoading: boolean) => void
 }
+
+export const isNameExtendable = (name: Pick<Name, 'name' | 'parentName'>) =>
+  name.parentName === 'eth' &&
+  !!name.name &&
+  !name.name.includes('Invalid ENS Name') &&
+  !isShortEth2LDName(name.name)
 
 export const NameListView = ({ address, selfAddress, setError, setLoading }: NameListViewProps) => {
   const { t } = useTranslation('names')
@@ -149,9 +156,6 @@ export const NameListView = ({ address, selfAddress, setError, setLoading }: Nam
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stage])
-
-  const isNameExtendable = (name: Name) =>
-    name.parentName === 'eth' && !!name.name && !name.name.includes('Invalid ENS Name')
 
   const isNameDisabled = useCallback(
     (name: Name) => {

--- a/src/components/@molecules/SearchInput/SearchInput.test.tsx
+++ b/src/components/@molecules/SearchInput/SearchInput.test.tsx
@@ -1,9 +1,18 @@
-import { mockFunction, render, screen, userEvent } from '@app/test-utils'
+import { mockFunction, render, renderHook, screen, userEvent } from '@app/test-utils'
 
+import { QueryClient, useQueryClient } from '@tanstack/react-query'
 import { act, waitFor } from '@testing-library/react'
+import mockRouter from 'next-router-mock'
+import { labelhash } from 'viem'
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest'
 
+import { GetExpiryReturnType, GetWrapperDataReturnType } from '@ensdomains/ensjs/public'
+
+import { mainnetWithEns } from '@app/constants/chains'
+import { UseAddressRecordReturnType } from '@app/hooks/ensjs/public/useAddressRecord'
+import { UseOwnerReturnType } from '@app/hooks/ensjs/public/useOwner'
 import { useLocalStorage } from '@app/hooks/useLocalStorage'
+import { createQueryKey } from '@app/hooks/useQueryOptions'
 import { useBreakpoint } from '@app/utils/BreakpointProvider'
 
 import { SearchInput } from './SearchInput'
@@ -24,10 +33,76 @@ mockSearchResult.mockImplementation(({ searchItem }) => (
 
 window.scroll = vi.fn() as () => void
 
+const desktopBreakpoints = { xs: true, sm: true, md: true, lg: false, xl: false }
+
+type SeededChainData = {
+  ownerData?: UseOwnerReturnType | null
+  wrapperData?: GetWrapperDataReturnType
+  expiryData?: GetExpiryReturnType
+  addrData?: UseAddressRecordReturnType
+}
+
+// `getRouteForSearchItem` reads the chain answers straight out of the query cache, so seeding them
+// here is what lets the status guard — rather than the pending guard — decide. Only the fields
+// passed in are seeded, which is how a partially warm cache gets reproduced.
+const seedChainData = (
+  queryClient: QueryClient,
+  name: string,
+  { ownerData, wrapperData, expiryData, addrData }: SeededChainData,
+) => {
+  const keyFor = (functionName: 'getOwner' | 'getWrapperData' | 'getExpiry' | 'getAddressRecord') =>
+    createQueryKey({
+      address: undefined,
+      chainId: mainnetWithEns.id,
+      functionName,
+      queryDependencyType: 'standard',
+      params: { name },
+    })
+
+  if (ownerData !== undefined) queryClient.setQueryData(keyFor('getOwner'), ownerData)
+  if (wrapperData !== undefined) queryClient.setQueryData(keyFor('getWrapperData'), wrapperData)
+  if (expiryData !== undefined) queryClient.setQueryData(keyFor('getExpiry'), expiryData)
+  if (addrData !== undefined) queryClient.setQueryData(keyFor('getAddressRecord'), addrData)
+}
+
+// Every read a short name's row waits on, settled: no owner and no expiry make `12.eth` a name the
+// status model calls a dead end.
+const unregisteredShortChainData: SeededChainData = {
+  ownerData: null,
+  wrapperData: null,
+  expiryData: null,
+  addrData: null,
+}
+
+// on.eth predates the registrar's minimum length, so it is a real name with a real profile.
+const onEthExpiry = new Date('2036-03-08T00:00:00.000Z')
+const registeredShortChainData: SeededChainData = {
+  ownerData: {
+    owner: '0xb6E040C9ECAaE172a89bD561c5F73e1C48d28cd9',
+    registrant: '0xb6E040C9ECAaE172a89bD561c5F73e1C48d28cd9',
+    ownershipLevel: 'registrar',
+  },
+  wrapperData: null,
+  expiryData: {
+    expiry: { date: onEthExpiry, value: BigInt(onEthExpiry.getTime()) },
+    gracePeriod: 60 * 60 * 24 * 90,
+    status: 'active',
+  },
+  addrData: null,
+}
+
+const getQueryClient = () => renderHook(() => useQueryClient()).result.current
+
 describe('SearchInput', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUseLocalStorage.mockReturnValue([[]])
+    mockRouter.setCurrentUrl('/')
+    mockUseLocalStorage.mockReturnValue([[], vi.fn()])
+    mockSearchResult.mockImplementation(({ clickCallback, index, searchItem }) => (
+      <button type="button" data-testid="search-result-text" onClick={() => clickCallback(index)}>
+        {searchItem.text}
+      </button>
+    ))
     window.ResizeObserver = vi.fn()
     ;(window.ResizeObserver as Mock).mockImplementation(() => ({
       observe: vi.fn(),
@@ -264,6 +339,131 @@ describe('SearchInput', () => {
     })
     await userEvent.type(screen.getByTestId('search-input-box'), '.')
     await waitFor(() => expect(screen.queryByText(`Invalid name`)).toBeInTheDocument())
+  })
+  it('should not navigate while a short .eth result has no ownership answer yet', async () => {
+    mockUseBreakpoint.mockReturnValue(desktopBreakpoints)
+    render(<SearchInput />)
+
+    const input = screen.getByTestId('search-input-box')
+    await userEvent.click(input)
+    await userEvent.type(input, '12')
+    await userEvent.click(await screen.findByRole('button', { name: '12.eth' }))
+
+    expect(mockRouter.asPath).toBe('/')
+  })
+  it('should not navigate while Enter selects a short .eth result with no ownership answer yet', async () => {
+    mockUseBreakpoint.mockReturnValue(desktopBreakpoints)
+    render(<SearchInput />)
+
+    const input = screen.getByTestId('search-input-box')
+    await userEvent.click(input)
+    await userEvent.type(input, '12')
+    await screen.findByRole('button', { name: '12.eth' })
+    await userEvent.keyboard('{Enter}')
+
+    expect(mockRouter.asPath).toBe('/')
+  })
+  it('should not navigate when an unregistered short .eth result is clicked', async () => {
+    mockUseBreakpoint.mockReturnValue(desktopBreakpoints)
+    seedChainData(getQueryClient(), '12.eth', unregisteredShortChainData)
+    render(<SearchInput />)
+
+    const input = screen.getByTestId('search-input-box')
+    await userEvent.click(input)
+    await userEvent.type(input, '12')
+    await userEvent.click(await screen.findByRole('button', { name: '12.eth' }))
+
+    expect(mockRouter.asPath).toBe('/')
+  })
+  it('should not navigate when Enter selects an unregistered short .eth result', async () => {
+    mockUseBreakpoint.mockReturnValue(desktopBreakpoints)
+    seedChainData(getQueryClient(), '12.eth', unregisteredShortChainData)
+    render(<SearchInput />)
+
+    const input = screen.getByTestId('search-input-box')
+    await userEvent.click(input)
+    await userEvent.type(input, '12')
+    await screen.findByRole('button', { name: '12.eth' })
+    await userEvent.keyboard('{Enter}')
+
+    expect(mockRouter.asPath).toBe('/')
+  })
+  // The row itself stays inert until every read its status waits on has settled, so Enter must not
+  // jump ahead of the mouse on a half-warm cache — here the owner and expiry answers have landed
+  // but the wrapper and addr ones have not.
+  it('should not navigate when Enter selects a short .eth result that is only partly cached', async () => {
+    mockUseBreakpoint.mockReturnValue(desktopBreakpoints)
+    seedChainData(getQueryClient(), 'on.eth', {
+      ownerData: registeredShortChainData.ownerData,
+      expiryData: registeredShortChainData.expiryData,
+    })
+    render(<SearchInput />)
+
+    const input = screen.getByTestId('search-input-box')
+    await userEvent.click(input)
+    await userEvent.type(input, 'on')
+    await screen.findByRole('button', { name: 'on.eth' })
+    await userEvent.keyboard('{Enter}')
+
+    expect(mockRouter.asPath).toBe('/')
+  })
+  // This is also the positive control for the seeding above: it proves the guard reads the cache.
+  it('should navigate to the profile when a registered short .eth result is clicked', async () => {
+    mockUseBreakpoint.mockReturnValue(desktopBreakpoints)
+    seedChainData(getQueryClient(), 'on.eth', registeredShortChainData)
+    render(<SearchInput />)
+
+    const input = screen.getByTestId('search-input-box')
+    await userEvent.click(input)
+    await userEvent.type(input, 'on')
+    await userEvent.click(await screen.findByRole('button', { name: 'on.eth' }))
+
+    // `/profile/on.eth` is flattened to the app's canonical profile route.
+    await waitFor(() => expect(mockRouter.asPath).toBe('/on.eth'))
+  })
+  it('should navigate to the profile when Enter selects a fully cached registered short .eth result', async () => {
+    mockUseBreakpoint.mockReturnValue(desktopBreakpoints)
+    seedChainData(getQueryClient(), 'on.eth', registeredShortChainData)
+    render(<SearchInput />)
+
+    const input = screen.getByTestId('search-input-box')
+    await userEvent.click(input)
+    await userEvent.type(input, 'on')
+    await screen.findByRole('button', { name: 'on.eth' })
+    await userEvent.keyboard('{Enter}')
+
+    await waitFor(() => expect(mockRouter.asPath).toBe('/on.eth'))
+  })
+  // An unhealed label reads as short to `parseInput`, and the row stays clickable anyway because the
+  // short-name predicate refuses to judge a label it cannot read. Enter has to agree: same name, same
+  // settled reads, so both paths land on the profile. `pathname` rather than `asPath` because
+  // next-router-mock reads the labelhash brackets as a dynamic segment and interpolates them away.
+  it('should navigate to the profile when Enter selects an unowned encoded-labelhash result', async () => {
+    mockUseBreakpoint.mockReturnValue(desktopBreakpoints)
+    const encodedName = `[${labelhash('nick').slice(2)}].eth`
+    seedChainData(getQueryClient(), encodedName, unregisteredShortChainData)
+    render(<SearchInput />)
+
+    const input = screen.getByTestId('search-input-box')
+    await userEvent.click(input)
+    await userEvent.paste(encodedName)
+    await screen.findByRole('button', { name: encodedName })
+    await userEvent.keyboard('{Enter}')
+
+    await waitFor(() => expect(mockRouter.pathname).toBe(`/${encodedName}`))
+  })
+  it('should navigate to the profile when an unowned encoded-labelhash result is clicked', async () => {
+    mockUseBreakpoint.mockReturnValue(desktopBreakpoints)
+    const encodedName = `[${labelhash('nick').slice(2)}].eth`
+    seedChainData(getQueryClient(), encodedName, unregisteredShortChainData)
+    render(<SearchInput />)
+
+    const input = screen.getByTestId('search-input-box')
+    await userEvent.click(input)
+    await userEvent.paste(encodedName)
+    await userEvent.click(await screen.findByRole('button', { name: encodedName }))
+
+    await waitFor(() => expect(mockRouter.pathname).toBe(`/${encodedName}`))
   })
   it('should debounce search input changes', async () => {
     mockUseBreakpoint.mockReturnValue({

--- a/src/components/@molecules/SearchInput/SearchInput.tsx
+++ b/src/components/@molecules/SearchInput/SearchInput.tsx
@@ -41,6 +41,7 @@ import { CreateQueryKey, GenericQueryKey } from '@app/types'
 import { sendEvent } from '@app/utils/analytics/events'
 import { useBreakpoint } from '@app/utils/BreakpointProvider'
 import { getRegistrationStatus } from '@app/utils/registrationStatus'
+import { isShortEth2LD } from '@app/utils/shortName'
 import { thread, yearsToSeconds } from '@app/utils/utils'
 
 import { FakeSearchInputBox, SearchInputBox } from './SearchInputBox'
@@ -240,6 +241,7 @@ const getRouteForSearchItem = ({
   const getCachedQueryData = createCachedQueryDataGetter({ queryClient, chainId, address })
 
   if (selectedItem.nameType === 'eth' || selectedItem.nameType === 'dns') {
+    const validation = validate(selectedItem.text)
     const ownerData = getCachedQueryData<UseOwnerReturnType, UseOwnerQueryKey>({
       functionName: 'getOwner',
       params: { name: selectedItem.text },
@@ -261,17 +263,32 @@ const getRouteForSearchItem = ({
       params: { name: selectedItem.text },
     })
 
+    // A short name's row is inert until `useBasicName` has settled every read its status waits
+    // on — owner, wrapper, expiry and addr — so Enter has to clear the same bar, or a partially
+    // warm cache lets the keyboard navigate a row the mouse ignores. Price is deliberately not
+    // among them: it is disabled for short names, so requiring it would never let Enter through.
+    if (
+      isShortEth2LD(validation) &&
+      [ownerData, wrapperData, expiryData, addrData].some((data) => typeof data === 'undefined')
+    )
+      return undefined
+
     if (typeof ownerData !== 'undefined') {
       const registrationStatus = getRegistrationStatus({
         timestamp: Date.now(),
-        validation: validate(selectedItem.text),
+        validation,
         ownerData,
         wrapperData,
         expiryData,
         priceData,
         addrData,
         supportedTLD: true,
+        // The status model refuses to judge registerability without the name the flags were measured
+        // from, so it has to be passed here as `useBasicName` passes it — otherwise a genuinely
+        // short name would read as available in the dropdown.
+        name: validation.name,
       })
+      if (registrationStatus === 'short') return undefined
       if (registrationStatus === 'available') return `/register/${selectedItem.text}`
       if (registrationStatus === 'notImported') return `/import/${selectedItem.text}`
     }
@@ -311,12 +328,13 @@ const createSearchHandler =
     const { text, nameType } = selectedItem
     if (nameType === 'error' || nameType === 'text') return
 
+    const path = getRouteForSearchItem({ address, chainId, queryClient, selectedItem })
+    if (!path) return
+
     setHistory((prev: HistoryItem[]) => [
       ...prev.filter((item) => !(item.text === text && item.nameType === nameType)),
       { lastAccessed: Date.now(), nameType, text, isValid: selectedItem.isValid },
     ])
-
-    const path = getRouteForSearchItem({ address, chainId, queryClient, selectedItem })
 
     const searchType = match(path)
       .with(`/register/${text}`, () => 'eth' as const)

--- a/src/components/@molecules/SearchInput/SearchResult.test.tsx
+++ b/src/components/@molecules/SearchInput/SearchResult.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, mockFunction, render, screen } from '@app/test-utils'
 
 import { ComponentProps } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { usePrimaryName } from '@app/hooks/ensjs/public/usePrimaryName'
 import { useBasicName } from '@app/hooks/useBasicName'
@@ -15,8 +15,6 @@ const mockUseBasicName = mockFunction(useBasicName)
 const mockUsePrimaryName = mockFunction(usePrimaryName)
 
 describe('SearchResult', () => {
-  mockUseBasicName.mockReturnValue({ registrationStatus: 'available', beautifiedName: 'nick.eth' })
-
   const baseMockData: SearchResultProps = {
     hoverCallback: vi.fn(),
     clickCallback: vi.fn(),
@@ -28,6 +26,13 @@ describe('SearchResult', () => {
     },
     usingPlaceholder: false,
   }
+
+  beforeEach(() => {
+    mockUseBasicName.mockReturnValue({
+      registrationStatus: 'available',
+      beautifiedName: 'nick.eth',
+    })
+  })
 
   it('should render with basic data', () => {
     render(<SearchResult {...baseMockData} />)
@@ -89,6 +94,109 @@ describe('SearchResult', () => {
     const element = screen.getByText('nick.eth')
     fireEvent.click(element)
     expect(baseMockData.clickCallback).toHaveBeenCalledWith(0)
+  })
+  it('should not allow an unregistered short .eth result to be clicked', () => {
+    const clickCallback = vi.fn()
+    mockUseBasicName.mockReturnValue({
+      registrationStatus: 'short',
+      beautifiedName: '12.eth',
+      name: '12.eth',
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      isLoading: false,
+    })
+
+    render(
+      <SearchResult
+        {...baseMockData}
+        clickCallback={clickCallback}
+        searchItem={{ nameType: 'eth', text: '12.eth' }}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('12.eth'))
+    expect(clickCallback).not.toHaveBeenCalled()
+    expect(screen.getByTestId('search-result-name')).toHaveStyle('pointer-events: none')
+    expect(screen.getByText('search.status.short')).toBeVisible()
+  })
+  it('should keep a registered on.eth-shaped short result clickable', () => {
+    const clickCallback = vi.fn()
+    mockUseBasicName.mockReturnValue({
+      registrationStatus: 'registered',
+      beautifiedName: 'on.eth',
+      name: 'on.eth',
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      isLoading: false,
+    })
+
+    render(
+      <SearchResult
+        {...baseMockData}
+        clickCallback={clickCallback}
+        searchItem={{ nameType: 'eth', text: 'on.eth' }}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('on.eth'))
+    expect(clickCallback).toHaveBeenCalledWith(0)
+    expect(screen.getByTestId('search-result-name')).toHaveStyle('cursor: pointer')
+  })
+  // The keyboard path in SearchInput only refuses a route for the `short` status, so a grace-period
+  // short must stay clickable here too — otherwise the row looks inert but Enter still navigates.
+  it('should keep a short result in its grace period clickable', () => {
+    const clickCallback = vi.fn()
+    mockUseBasicName.mockReturnValue({
+      registrationStatus: 'gracePeriod',
+      beautifiedName: 'on.eth',
+      name: 'on.eth',
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      isLoading: false,
+    })
+
+    render(
+      <SearchResult
+        {...baseMockData}
+        clickCallback={clickCallback}
+        searchItem={{ nameType: 'eth', text: 'on.eth' }}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('on.eth'))
+    expect(clickCallback).toHaveBeenCalledWith(0)
+    expect(screen.getByTestId('search-result-name')).toHaveStyle('cursor: pointer')
+  })
+  it('should not allow a short result to be clicked while its status is still loading', () => {
+    const clickCallback = vi.fn()
+    mockUseBasicName.mockReturnValue({
+      registrationStatus: undefined,
+      beautifiedName: '12.eth',
+      name: '12.eth',
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      isLoading: true,
+    })
+
+    render(
+      <SearchResult
+        {...baseMockData}
+        clickCallback={clickCallback}
+        searchItem={{ nameType: 'eth', text: '12.eth' }}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('12.eth'))
+    expect(clickCallback).not.toHaveBeenCalled()
+    expect(screen.getByTestId('search-result-name')).toHaveStyle('pointer-events: none')
   })
   it('should show address as clickable', () => {
     mockUsePrimaryName.mockReturnValue({

--- a/src/components/@molecules/SearchInput/SearchResult.tsx
+++ b/src/components/@molecules/SearchInput/SearchResult.tsx
@@ -17,6 +17,7 @@ import { usePrefetchProfile } from '@app/hooks/useProfile'
 import { useZorb } from '@app/hooks/useZorb'
 import { zorbImageDataURI } from '@app/utils/gradient'
 import type { RegistrationStatus } from '@app/utils/registrationStatus'
+import { getShortNameState } from '@app/utils/shortName'
 import { shortenAddress } from '@app/utils/utils'
 
 import type { SearchHandler, SearchItem } from './types'
@@ -354,10 +355,15 @@ const EthResultItem = ({
     enabled: !usingPlaceholder,
   })
   const zorb = useZorb(name, 'name')
-  const { registrationStatus, isLoading, beautifiedName } = useBasicName({
+  const basicName = useBasicName({
     name,
     enabled: !usingPlaceholder,
   })
+  const { registrationStatus, isLoading, beautifiedName } = basicName
+  // Bucketed through getShortNameState so this agrees with the keyboard path in SearchInput, which
+  // blocks a route only for the `short` status: a short name in grace has a legitimate profile.
+  const shortNameState = getShortNameState({ validation: basicName, registrationStatus })
+  const isClickable = shortNameState === 'notShort' || shortNameState === 'registered'
 
   const { avatarUri, avatarIsPlaceholder } = getAvatarUri({ ensAvatar, usingPlaceholder, zorb })
 
@@ -366,10 +372,10 @@ const EthResultItem = ({
   return (
     <SearchItemContainer
       data-testid="search-result-name"
-      onClick={() => clickCallback(index)}
+      onClick={isClickable ? () => clickCallback(index) : undefined}
       onMouseDown={(e) => e.preventDefault()}
       onMouseEnter={() => hoverCallback(index)}
-      $clickable
+      $clickable={isClickable}
       $selected={selected}
     >
       <LeadingSearchItem>

--- a/src/components/ProfileSnippet.tsx
+++ b/src/components/ProfileSnippet.tsx
@@ -14,6 +14,7 @@ import { useIsWrapped } from '@app/hooks/useIsWrapped'
 import { useNameDetails } from '@app/hooks/useNameDetails'
 import { useRouterWithHistory } from '@app/hooks/useRouterWithHistory'
 import { getTimezoneOffset } from '@app/utils/getTimezoneOffset'
+import { isShortEth2LD } from '@app/utils/shortName'
 
 import { useTransactionFlow } from '../transaction-flow/TransactionFlowProvider'
 import { NameAvatar } from './AvatarWithZorb'
@@ -246,7 +247,9 @@ export const ProfileSnippet = ({
   const router = useRouterWithHistory()
   const { t } = useTranslation('common')
 
-  const { registrationStatus } = useNameDetails({ name })
+  const nameDetails = useNameDetails({ name })
+  const { registrationStatus } = nameDetails
+  const isShortName = isShortEth2LD(nameDetails)
 
   const { usePreparedDataInput } = useTransactionFlow()
   const showExtendNamesInput = usePreparedDataInput('ExtendNames')
@@ -274,7 +277,7 @@ export const ProfileSnippet = ({
     !!registrationStatus && ['desynced', 'desynced:gracePeriod'].includes(registrationStatus)
 
   const ActionButton = useMemo(() => {
-    if (button === 'extend')
+    if (button === 'extend' && !isShortName)
       return (
         <Button
           size="small"
@@ -313,7 +316,7 @@ export const ProfileSnippet = ({
         </Button>
       )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [button, name, canSelfExtend, isWrapped])
+  }, [button, name, canSelfExtend, isShortName, isWrapped])
 
   return (
     <Container data-testid="profile-snippet">

--- a/src/components/pages/profile/[name]/Profile.test.tsx
+++ b/src/components/pages/profile/[name]/Profile.test.tsx
@@ -1,10 +1,20 @@
 import { mockFunction, render, screen } from '@app/test-utils'
 
-import { describe, expect, it, Mock, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import { labelhash } from 'viem'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
 
+import { useAbilities } from '@app/hooks/abilities/useAbilities'
+import { useIsOffchainName } from '@app/hooks/ensjs/dns/useIsOffchainName'
+import { usePrimaryName } from '@app/hooks/ensjs/public/usePrimaryName'
+import { useProfileActions } from '@app/hooks/pages/profile/[name]/profile/useProfileActions/useProfileActions'
 import { useBasicName } from '@app/hooks/useBasicName'
 import { useNameDetails } from '@app/hooks/useNameDetails'
+import { useOwners } from '@app/hooks/useOwners'
 import { useProfile } from '@app/hooks/useProfile'
+import { useVerifiedRecords } from '@app/hooks/verification/useVerifiedRecords/useVerifiedRecords'
+import { makeAppendVerificationProps } from '@app/hooks/verification/useVerifiedRecords/utils/makeAppendVerificationProps'
 import { useBreakpoint } from '@app/utils/BreakpointProvider'
 
 import ProfileContent, { NameAvailableBanner } from './Profile'
@@ -12,6 +22,51 @@ import ProfileContent, { NameAvailableBanner } from './Profile'
 vi.mock('@app/hooks/useBasicName')
 vi.mock('@app/hooks/useProfile')
 vi.mock('@app/hooks/useNameDetails')
+vi.mock('@app/hooks/abilities/useAbilities')
+vi.mock('@app/hooks/ensjs/dns/useIsOffchainName')
+vi.mock('@app/hooks/ensjs/public/usePrimaryName')
+vi.mock('@app/hooks/pages/profile/[name]/profile/useProfileActions/useProfileActions')
+vi.mock('@app/hooks/useOwners')
+vi.mock('@app/hooks/verification/useVerifiedRecords/useVerifiedRecords')
+vi.mock('@app/hooks/pages/profile/useRenew/useRenew')
+vi.mock('@app/components/ProfileSnippet', () => ({
+  ProfileSnippet: ({
+    button,
+    children,
+    name,
+  }: {
+    button?: string
+    children?: ReactNode
+    name: string
+  }) => (
+    <section aria-label="Name profile">
+      <h2>{name}</h2>
+      {button ? <button type="button">{button}</button> : null}
+      {children}
+    </section>
+  ),
+}))
+vi.mock('@app/components/pages/profile/ProfileDetails', () => ({
+  ProfileDetails: ({
+    addresses,
+    expiryDate,
+    owners,
+  }: {
+    addresses: { value: string }[]
+    expiryDate?: Date
+    owners: { address: string }[]
+  }) => (
+    <section aria-label="Profile details">
+      {owners.map(({ address }) => (
+        <div key={address}>Owner: {address}</div>
+      ))}
+      {addresses.map(({ value }) => (
+        <div key={value}>Address: {value}</div>
+      ))}
+      {expiryDate ? <div>Name expires: {expiryDate.toISOString()}</div> : null}
+    </section>
+  ),
+}))
 vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
 }))
@@ -31,6 +86,34 @@ const baseBreakpoints: ReturnType<typeof useBreakpoint> = {
 const mockUseBasicName = mockFunction(useBasicName)
 const mockUseProfile = mockFunction(useProfile)
 const mockUseNameDetails = mockFunction(useNameDetails)
+const mockUseAbilities = mockFunction(useAbilities)
+const mockUseIsOffchainName = mockFunction(useIsOffchainName)
+const mockUsePrimaryName = mockFunction(usePrimaryName)
+const mockUseProfileActions = mockFunction(useProfileActions)
+const mockUseOwners = mockFunction(useOwners)
+const mockUseVerifiedRecords = mockFunction(useVerifiedRecords)
+const appendVerificationProps = makeAppendVerificationProps([])
+
+const setupDesktopLayout = () => {
+  window.ResizeObserver = vi.fn()
+  ;(window.ResizeObserver as Mock).mockImplementation(() => ({
+    observe: vi.fn(),
+    disconnect: vi.fn(),
+  }))
+  mockUseBreakpoint.mockReturnValue({ ...baseBreakpoints, lg: true, xl: true })
+}
+
+beforeEach(() => {
+  mockUseAbilities.mockReturnValue({ data: {}, isLoading: false })
+  mockUseIsOffchainName.mockReturnValue(false)
+  mockUsePrimaryName.mockReturnValue({ data: undefined, isLoading: false })
+  mockUseProfileActions.mockReturnValue({ profileActions: undefined, isLoading: false })
+  mockUseOwners.mockReturnValue([])
+  mockUseVerifiedRecords.mockReturnValue({
+    data: [],
+    appendVerificationProps,
+  })
+})
 
 describe('ProfileContent - Unsupported TLDs', () => {
   it('should display the expiry date of the name', () => {
@@ -43,12 +126,7 @@ describe('ProfileContent - Unsupported TLDs', () => {
     ).toBeVisible()
   })
   it('should show only the "profile" tab for unsupported TLDs', () => {
-    window.ResizeObserver = vi.fn()
-    ;(window.ResizeObserver as Mock).mockImplementation(() => ({
-      observe: vi.fn(),
-      disconnect: vi.fn(),
-    }))
-    mockUseBreakpoint.mockReturnValue({ ...baseBreakpoints, lg: true, xl: true })
+    setupDesktopLayout()
     mockUseBasicName.mockReturnValue({
       isValid: true,
       name: 'test',
@@ -75,5 +153,222 @@ describe('ProfileContent - Unsupported TLDs', () => {
     expect(screen.queryByTestId('subnames-tab')).not.toBeInTheDocument()
     expect(screen.queryByTestId('permissions-tab')).not.toBeInTheDocument()
     expect(screen.queryByTestId('more-tab')).not.toBeInTheDocument()
+  })
+})
+
+describe('ProfileContent - short .eth names', () => {
+  it('should not flash an error or profile while short-name ownership is loading', () => {
+    setupDesktopLayout()
+    mockUseNameDetails.mockReturnValue({
+      unsupported: false,
+      error: null,
+      profile: undefined,
+      name: '12.eth',
+      normalisedName: '12.eth',
+      beautifiedName: '12.eth',
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      isCachedData: false,
+      isWrapped: false,
+      registrationStatus: undefined,
+      isBasicLoading: true,
+    })
+
+    render(<ProfileContent isSelf={false} isLoading name="12.eth" />)
+
+    expect(screen.queryByText('errors.shortName')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('profile-tab')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Name profile')).not.toBeInTheDocument()
+  })
+
+  it('should show only the minimum-length error for an unregistered short name', () => {
+    setupDesktopLayout()
+    mockUseNameDetails.mockReturnValue({
+      unsupported: false,
+      error: { content: 'errors.shortName', type: 'error' },
+      profile: undefined,
+      name: '12.eth',
+      normalisedName: '12.eth',
+      beautifiedName: '12.eth',
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      isCachedData: false,
+      isWrapped: false,
+      registrationStatus: 'short',
+      isBasicLoading: false,
+    })
+    mockUseAbilities.mockReturnValue({ data: { canExtend: false }, isLoading: false })
+
+    render(<ProfileContent isSelf={false} isLoading={false} name="12.eth" />)
+
+    expect(screen.getByText('errors.shortName')).toBeVisible()
+    expect(screen.queryByTestId('profile-tab')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /extend/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(/available/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Name profile')).not.toBeInTheDocument()
+  })
+
+  // on.eth has a real registrar expiry, so the profile shows it. Only the renewal affordances go,
+  // because the app deliberately does not offer to extend a short name.
+  it('should render an on.eth-shaped registered short profile with its expiry but no extend', () => {
+    setupDesktopLayout()
+    const owner = '0x1234567890123456789012345678901234567890'
+    const expiry = new Date('2036-03-08T00:00:00.000Z')
+    mockUseNameDetails.mockReturnValue({
+      unsupported: false,
+      error: null,
+      profile: {
+        texts: [],
+        coins: [{ id: 60, name: 'eth', value: owner }],
+      },
+      ownerData: {
+        owner,
+        registrant: owner,
+        ownershipLevel: 'registrar',
+      },
+      wrapperData: {
+        owner,
+        expiry: { date: expiry, value: BigInt(expiry.getTime()) },
+      },
+      expiryDate: expiry,
+      name: 'on.eth',
+      normalisedName: 'on.eth',
+      beautifiedName: 'on.eth',
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      isCachedData: false,
+      isWrapped: false,
+      registrationStatus: 'registered',
+      isBasicLoading: false,
+      pccExpired: false,
+    })
+    mockUseAbilities.mockReturnValue({ data: { canExtend: true }, isLoading: false })
+    mockUsePrimaryName.mockReturnValue({ data: undefined, isLoading: false })
+    mockUseOwners.mockReturnValue([
+      {
+        address: owner,
+        canTransfer: false,
+        transferType: 'owner',
+        label: 'name.owner',
+        description: 'details.descriptions.owner',
+        testId: 'owner-button-owner',
+      },
+    ])
+    mockUseProfileActions.mockReturnValue({ profileActions: undefined, isLoading: false })
+    mockUseVerifiedRecords.mockReturnValue({
+      data: [],
+      appendVerificationProps,
+    })
+    mockUseIsOffchainName.mockReturnValue(false)
+
+    render(<ProfileContent isSelf={false} isLoading={false} name="on.eth" />)
+
+    expect(screen.getByRole('heading', { name: 'on.eth' })).toBeVisible()
+    expect(screen.getByText(`Owner: ${owner}`)).toBeVisible()
+    expect(screen.getByText(`Address: ${owner}`)).toBeVisible()
+    expect(screen.getByText(`Name expires: ${expiry.toISOString()}`)).toBeVisible()
+    expect(screen.queryByRole('button', { name: /extend/i })).not.toBeInTheDocument()
+  })
+
+  // The status model gives an unhealed label no registerability answer, so an unowned one arrives
+  // here as `notOwned` with no error to show. The error and the hiding are decided separately — the
+  // error by the status, the hiding by the short-name state — and this is the case that told them
+  // apart: it used to render the whole profile underneath a minimum-length error meant for `12.eth`.
+  it('should render an unowned encoded-labelhash profile with no error and nothing hidden', () => {
+    setupDesktopLayout()
+    const encodedName = `[${labelhash('nick').slice(2)}].eth`
+    mockUseNameDetails.mockReturnValue({
+      unsupported: false,
+      error: null,
+      profile: {
+        texts: [],
+        coins: [],
+      },
+      ownerData: null,
+      name: encodedName,
+      normalisedName: encodedName,
+      beautifiedName: encodedName,
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      isCachedData: false,
+      isWrapped: false,
+      registrationStatus: 'notOwned',
+      isBasicLoading: false,
+      pccExpired: false,
+    })
+
+    render(<ProfileContent isSelf={false} isLoading={false} name={encodedName} />)
+
+    expect(screen.queryByText('errors.shortName')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Name profile')).toBeVisible()
+    expect(screen.getByTestId('profile-tab')).toBeVisible()
+  })
+
+  // A label the subgraph has not healed is reported short by `parseInput` because there is nothing
+  // to measure. The name behind it is an ordinary one and keeps an ordinary profile, extend and all.
+  it('should render an ordinary profile for a name whose label is still an encoded labelhash', () => {
+    setupDesktopLayout()
+    const encodedName = `[${labelhash('nick').slice(2)}].eth`
+    const owner = '0x1234567890123456789012345678901234567890'
+    const expiry = new Date('2036-03-08T00:00:00.000Z')
+    mockUseNameDetails.mockReturnValue({
+      unsupported: false,
+      error: null,
+      profile: {
+        texts: [],
+        coins: [{ id: 60, name: 'eth', value: owner }],
+      },
+      ownerData: {
+        owner,
+        registrant: owner,
+        ownershipLevel: 'registrar',
+      },
+      expiryDate: expiry,
+      name: encodedName,
+      normalisedName: encodedName,
+      beautifiedName: encodedName,
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      isCachedData: false,
+      isWrapped: false,
+      registrationStatus: 'registered',
+      isBasicLoading: false,
+      pccExpired: false,
+    })
+    mockUseAbilities.mockReturnValue({ data: { canExtend: true }, isLoading: false })
+    mockUsePrimaryName.mockReturnValue({ data: undefined, isLoading: false })
+    mockUseOwners.mockReturnValue([
+      {
+        address: owner,
+        canTransfer: false,
+        transferType: 'owner',
+        label: 'name.owner',
+        description: 'details.descriptions.owner',
+        testId: 'owner-button-owner',
+      },
+    ])
+    mockUseProfileActions.mockReturnValue({ profileActions: undefined, isLoading: false })
+    mockUseVerifiedRecords.mockReturnValue({
+      data: [],
+      appendVerificationProps,
+    })
+    mockUseIsOffchainName.mockReturnValue(false)
+
+    render(<ProfileContent isSelf={false} isLoading={false} name={encodedName} />)
+
+    expect(screen.getByRole('heading', { name: encodedName })).toBeVisible()
+    expect(screen.getByTestId('profile-tab')).toBeVisible()
+    expect(screen.queryByText('errors.shortName')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /extend/i })).toBeVisible()
   })
 })

--- a/src/components/pages/profile/[name]/Profile.tsx
+++ b/src/components/pages/profile/[name]/Profile.tsx
@@ -18,6 +18,7 @@ import { useQueryParameterState } from '@app/hooks/useQueryParameterState'
 import { useRouterWithHistory } from '@app/hooks/useRouterWithHistory'
 import { Content, ContentWarning } from '@app/layouts/Content'
 import { OG_IMAGE_URL } from '@app/utils/constants'
+import { getShortNameState } from '@app/utils/shortName'
 import { shouldRedirect } from '@app/utils/shouldRedirect'
 import { formatFullExpiry, makeEtherscanLink } from '@app/utils/utils'
 
@@ -126,6 +127,11 @@ const ProfileContent = ({ isSelf, isLoading: parentIsLoading, name }: Props) => 
     isBasicLoading,
     refetchIfEnabled,
   } = nameDetails
+  // `12.eth` is unregisterable and `on.eth` is a real name, and only the ownership and expiry
+  // lookups tell them apart — so a short name shows nothing but its warning until they answer.
+  const shortNameState = getShortNameState({ validation: nameDetails, registrationStatus })
+  const isShortName = shortNameState !== 'notShort'
+  const shouldHideProfileContent = shortNameState === 'pending' || shortNameState === 'unregistered'
 
   useProtectedRoute(
     '/',
@@ -170,13 +176,12 @@ const ProfileContent = ({ isSelf, isLoading: parentIsLoading, name }: Props) => 
   }
 
   const isWrappedOrLoading = isWrapped || isBasicLoading
-  const visibileTabs = useMemo(
-    () =>
-      (isWrappedOrLoading ? tabs : tabs.filter((_tab) => _tab !== 'permissions')).filter((_tab) =>
-        unsupported ? _tab === 'profile' : _tab,
-      ),
-    [isWrappedOrLoading, unsupported],
-  )
+  const visibileTabs = useMemo(() => {
+    if (shouldHideProfileContent) return []
+    return (isWrappedOrLoading ? tabs : tabs.filter((_tab) => _tab !== 'permissions')).filter(
+      (_tab) => (unsupported ? _tab === 'profile' : _tab),
+    )
+  }, [isWrappedOrLoading, shouldHideProfileContent, unsupported])
 
   const abilities = useAbilities({ name: normalisedName })
 
@@ -184,6 +189,7 @@ const ProfileContent = ({ isSelf, isLoading: parentIsLoading, name }: Props) => 
   // profile.decryptedName fetches labels from NW/subgraph
   // normalisedName fetches labels from localStorage
   useEffect(() => {
+    if (shouldHideProfileContent) return
     shouldRedirect(router, 'Profile.tsx', '/profile', {
       isSelf,
       name,
@@ -192,7 +198,16 @@ const ProfileContent = ({ isSelf, isLoading: parentIsLoading, name }: Props) => 
       visibileTabs,
       tab,
     })
-  }, [profile?.decodedName, normalisedName, name, isSelf, router, tab, visibileTabs])
+  }, [
+    profile?.decodedName,
+    normalisedName,
+    name,
+    isSelf,
+    router,
+    shouldHideProfileContent,
+    tab,
+    visibileTabs,
+  ])
 
   // useEffect(() => {
   //   if (shouldShowSuccessPage(transactions)) {
@@ -204,6 +219,7 @@ const ProfileContent = ({ isSelf, isLoading: parentIsLoading, name }: Props) => 
 
   const infoBanner = useMemo(() => {
     if (
+      !isShortName &&
       registrationStatus !== 'gracePeriod' &&
       gracePeriodEndDate &&
       gracePeriodEndDate < new Date()
@@ -211,7 +227,7 @@ const ProfileContent = ({ isSelf, isLoading: parentIsLoading, name }: Props) => 
       return <NameAvailableBanner {...{ normalisedName, expiryDate }} />
     }
     return undefined
-  }, [registrationStatus, gracePeriodEndDate, normalisedName, expiryDate])
+  }, [registrationStatus, gracePeriodEndDate, isShortName, normalisedName, expiryDate])
 
   const warning: ContentWarning = useMemo(() => {
     if (error)
@@ -246,9 +262,9 @@ const ProfileContent = ({ isSelf, isLoading: parentIsLoading, name }: Props) => 
         copyValue={beautifiedName}
       >
         {{
-          info: infoBanner,
+          info: shouldHideProfileContent ? undefined : infoBanner,
           warning,
-          header: (
+          header: shouldHideProfileContent ? null : (
             <>
               <TabButtonContainer>
                 {visibileTabs.map((tabItem) => (
@@ -267,49 +283,58 @@ const ProfileContent = ({ isSelf, isLoading: parentIsLoading, name }: Props) => 
               <ProfileEmptyBanner name={normalisedName} />
             </>
           ),
-          titleExtra: profile?.address ? (
-            <Outlink
-              fontVariant="bodyBold"
-              href={makeEtherscanLink(profile.address!, chainName, 'address')}
-            >
-              {t('etherscan', { ns: 'common' })}
-            </Outlink>
-          ) : null,
-          trailing: match(tab)
-            .with('records', () => (
-              <RecordsTab
-                name={normalisedName}
-                texts={profile?.texts || []}
-                addresses={profile?.coins || []}
-                contentHash={profile?.contentHash}
-                abi={profile?.abi}
-                resolverAddress={profile?.resolverAddress}
-                canEdit={abilities.data?.canEdit}
-                canEditRecords={abilities.data?.canEditRecords}
-                isCached={isCachedData}
-              />
-            ))
-            .with('ownership', () => <OwnershipTab name={normalisedName} details={nameDetails} />)
-            .with('subnames', () => (
-              <SubnamesTab
-                name={normalisedName}
-                isWrapped={isWrapped}
-                canEdit={!!abilities.data?.canEdit}
-                canCreateSubdomains={!!abilities.data?.canCreateSubdomains}
-                canCreateSubdomainsError={abilities.data?.canCreateSubdomainsError}
-              />
-            ))
-            .with('permissions', () => (
-              <PermissionsTab
-                name={normalisedName}
-                wrapperData={wrapperData}
-                isCached={isCachedData}
-              />
-            ))
-            .with('more', () => (
-              <MoreTab name={normalisedName} nameDetails={nameDetails} abilities={abilities.data} />
-            ))
-            .otherwise(() => <ProfileTab name={normalisedName} nameDetails={nameDetails} />),
+          titleExtra:
+            !shouldHideProfileContent && profile?.address ? (
+              <Outlink
+                fontVariant="bodyBold"
+                href={makeEtherscanLink(profile.address!, chainName, 'address')}
+              >
+                {t('etherscan', { ns: 'common' })}
+              </Outlink>
+            ) : null,
+          trailing: shouldHideProfileContent
+            ? null
+            : match(tab)
+                .with('records', () => (
+                  <RecordsTab
+                    name={normalisedName}
+                    texts={profile?.texts || []}
+                    addresses={profile?.coins || []}
+                    contentHash={profile?.contentHash}
+                    abi={profile?.abi}
+                    resolverAddress={profile?.resolverAddress}
+                    canEdit={abilities.data?.canEdit}
+                    canEditRecords={abilities.data?.canEditRecords}
+                    isCached={isCachedData}
+                  />
+                ))
+                .with('ownership', () => (
+                  <OwnershipTab name={normalisedName} details={nameDetails} />
+                ))
+                .with('subnames', () => (
+                  <SubnamesTab
+                    name={normalisedName}
+                    isWrapped={isWrapped}
+                    canEdit={!!abilities.data?.canEdit}
+                    canCreateSubdomains={!!abilities.data?.canCreateSubdomains}
+                    canCreateSubdomainsError={abilities.data?.canCreateSubdomainsError}
+                  />
+                ))
+                .with('permissions', () => (
+                  <PermissionsTab
+                    name={normalisedName}
+                    wrapperData={wrapperData}
+                    isCached={isCachedData}
+                  />
+                ))
+                .with('more', () => (
+                  <MoreTab
+                    name={normalisedName}
+                    nameDetails={nameDetails}
+                    abilities={abilities.data}
+                  />
+                ))
+                .otherwise(() => <ProfileTab name={normalisedName} nameDetails={nameDetails} />),
         }}
       </Content>
     </>

--- a/src/components/pages/profile/[name]/tabs/OwnershipTab/sections/ExpirySection/ExpirySection.tsx
+++ b/src/components/pages/profile/[name]/tabs/OwnershipTab/sections/ExpirySection/ExpirySection.tsx
@@ -7,6 +7,7 @@ import { Button, Card, Dropdown } from '@ensdomains/thorin'
 import { cacheableComponentStyles } from '@app/components/@atoms/CacheableComponent'
 import { useCalendarOptions } from '@app/hooks/useCalendarOptions'
 import { useNameDetails } from '@app/hooks/useNameDetails'
+import { isShortEth2LD } from '@app/utils/shortName'
 
 import { EarnifiDialog } from '../../../MoreTab/Miscellaneous/EarnifiDialog'
 import { ExpiryPanel } from './components/ExpiryPanel'
@@ -88,6 +89,7 @@ export const ExpirySection = ({ name, details }: Props) => {
     expiryDetails: expiry.data,
     ownerData: details.ownerData,
     wrapperData: details.wrapperData,
+    canExtend: !isShortEth2LD(details),
   })
   const { options: calendarOptions, makeEvent } = useCalendarOptions(`Renew ${name}`)
 

--- a/src/components/pages/profile/[name]/tabs/OwnershipTab/sections/ExpirySection/hooks/useExpiryActions.test.tsx
+++ b/src/components/pages/profile/[name]/tabs/OwnershipTab/sections/ExpirySection/hooks/useExpiryActions.test.tsx
@@ -27,6 +27,7 @@ describe('useExpiryActions', () => {
     const { result } = renderHook(() =>
       useExpiryActions({
         name: 'test.eth',
+        canExtend: true,
         expiryDetails: [{ type: 'expiry', date: new Date('3255803954000') }],
       }),
     )
@@ -40,6 +41,7 @@ describe('useExpiryActions', () => {
     const { result } = renderHook(() =>
       useExpiryActions({
         name: 'test.eth',
+        canExtend: true,
         expiryDetails: [{ type: 'expiry', date: new Date('3255803954000') }],
       }),
     )
@@ -55,16 +57,37 @@ describe('useExpiryActions', () => {
     const { result } = renderHook(() =>
       useExpiryActions({
         name: 'sub.test.eth',
+        canExtend: true,
         expiryDetails: [{ type: 'expiry', date: new Date('3255803954000') }],
       }),
     )
     expect(result.current).toEqual(null)
   })
 
+  // on.eth has a real registrar expiry worth reminding about, but the app does not offer to extend
+  // a short name, so the panel keeps its reminder and loses only the extend action.
+  it('should keep the expiry reminder but drop extend when the name cannot be extended', () => {
+    const { result } = renderHook(() =>
+      useExpiryActions({
+        name: 'on.eth',
+        canExtend: false,
+        expiryDetails: [{ type: 'expiry', date: new Date('3255803954000') }],
+      }),
+    )
+
+    expect(result.current).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'extend' })]),
+    )
+    expect(result.current).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'set-reminder' })]),
+    )
+  })
+
   it('should return null if expiryDetails contains a expiry type data but an invalid expiry date', () => {
     const { result } = renderHook(() =>
       useExpiryActions({
         name: 'test.eth',
+        canExtend: true,
         expiryDetails: [{ type: 'expiry', date: undefined as unknown as Date }],
       }),
     )
@@ -75,6 +98,7 @@ describe('useExpiryActions', () => {
     const { result } = renderHook(() =>
       useExpiryActions({
         name: 'test.eth',
+        canExtend: true,
         expiryDetails: [{ type: 'expiry', date: undefined as unknown as Date }],
       }),
     )
@@ -86,6 +110,7 @@ describe('useExpiryActions', () => {
     const { result } = renderHook(() =>
       useExpiryActions({
         name: 'test.eth',
+        canExtend: true,
         expiryDetails: [{ type: 'expiry', date: new Date('3255803954000') }],
       }),
     )

--- a/src/components/pages/profile/[name]/tabs/OwnershipTab/sections/ExpirySection/hooks/useExpiryActions.tsx
+++ b/src/components/pages/profile/[name]/tabs/OwnershipTab/sections/ExpirySection/hooks/useExpiryActions.tsx
@@ -46,11 +46,14 @@ export const useExpiryActions = ({
   expiryDetails,
   ownerData,
   wrapperData,
+  canExtend,
 }: {
   name: string
   expiryDetails: ReturnType<typeof useExpiryDetails>['data']
   ownerData?: GetOwnerReturnType
   wrapperData?: GetWrapperDataReturnType
+  /** Short .eth 2LDs keep their expiry panel, but the app does not offer to extend them. */
+  canExtend: boolean
 }): UseExpiryActionsReturnType | null => {
   const { t } = useTranslation('common')
   const { address, isConnected } = useAccount()
@@ -70,7 +73,7 @@ export const useExpiryActions = ({
       primary: false,
       expiryDate,
     },
-    ...(isConnected
+    ...(isConnected && canExtend
       ? [
           {
             label: t('action.extend'),

--- a/src/components/pages/profile/[name]/tabs/OwnershipTab/sections/ExpirySection/hooks/useExpiryDetails.test.ts
+++ b/src/components/pages/profile/[name]/tabs/OwnershipTab/sections/ExpirySection/hooks/useExpiryDetails.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@app/test-utils'
 
+import { labelhash } from 'viem'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { checkETH2LDFromName } from '@app/utils/utils'
@@ -143,5 +144,73 @@ describe('useExpiryDetails', () => {
         })
       },
     )
+  })
+
+  // The grace-period tooltip says the name "can still be extended", which the app does not offer
+  // for a short .eth 2LD.
+  describe('grace-period tooltip', () => {
+    const renderFor = (details: object) => {
+      mockUseNameType.mockReturnValue({ data: 'eth-unwrapped-2ld', isLoading: false })
+      return renderHook(() =>
+        useExpiryDetails({
+          name: 'test.eth',
+          details: { expiryDate: new Date(3255803954000), isLoading: false, ...details } as any,
+        }),
+      )
+    }
+
+    it('should keep the extendable tooltip for a normal name', () => {
+      const { result } = renderFor({
+        name: 'test.eth',
+        isValid: true,
+        isETH: true,
+        is2LD: true,
+        isShort: false,
+      })
+
+      expect(result.current.data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'grace-period',
+            tooltip: 'tabs.ownership.sections.expiry.panel.grace-period.tooltip',
+          }),
+        ]),
+      )
+    })
+
+    // An unhealed label reads as short, and the name behind it can in fact still be extended.
+    it('should keep the extendable tooltip for a name whose label is an encoded labelhash', () => {
+      const { result } = renderFor({
+        name: `[${labelhash('nick').slice(2)}].eth`,
+        isValid: true,
+        isETH: true,
+        is2LD: true,
+        isShort: true,
+      })
+
+      expect(result.current.data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'grace-period',
+            tooltip: 'tabs.ownership.sections.expiry.panel.grace-period.tooltip',
+          }),
+        ]),
+      )
+    })
+
+    it('should drop the extendable tooltip for a short name while keeping the date', () => {
+      const { result } = renderFor({
+        name: 'on.eth',
+        isValid: true,
+        isETH: true,
+        is2LD: true,
+        isShort: true,
+      })
+
+      const gracePeriod = result.current.data?.find(({ type }) => type === 'grace-period')
+      expect(gracePeriod).toBeDefined()
+      expect(gracePeriod).toEqual(expect.objectContaining({ tooltip: undefined }))
+      expect((gracePeriod as { date?: Date })?.date).toBeInstanceOf(Date)
+    })
   })
 })

--- a/src/components/pages/profile/[name]/tabs/OwnershipTab/sections/ExpirySection/hooks/useExpiryDetails.ts
+++ b/src/components/pages/profile/[name]/tabs/OwnershipTab/sections/ExpirySection/hooks/useExpiryDetails.ts
@@ -10,6 +10,7 @@ import useRegistrationData from '@app/hooks/useRegistrationData'
 import { GRACE_PERIOD } from '@app/utils/constants'
 import { safeDateObj } from '@app/utils/date'
 import { parentName } from '@app/utils/name'
+import { isShortEth2LD } from '@app/utils/shortName'
 import { getSupportLink } from '@app/utils/supportLinks'
 import { checkETH2LDFromName } from '@app/utils/utils'
 
@@ -44,6 +45,13 @@ export const useExpiryDetails = ({ name, details }: Input, options: Options = {}
   })
   const { buildTransactionUrl } = useBlockExplorer()
   const registrationData = useRegistrationData({ name, enabled: enabled && isETH2LD })
+
+  // The grace-period tooltip says the name "can still be extended", which the app does not offer
+  // for a short .eth 2LD — so it is dropped rather than shown untruthfully.
+  const isShortName = isShortEth2LD(details)
+  const isShortParentName = isShortEth2LD(parentData)
+  const graceTooltip = (isShort: boolean) =>
+    isShort ? undefined : t('tabs.ownership.sections.expiry.panel.grace-period.tooltip')
 
   const isLoading =
     nameType.isLoading || details.isLoading || parentData.isLoading || registrationData.isLoading
@@ -81,7 +89,7 @@ export const useExpiryDetails = ({ name, details }: Input, options: Options = {}
                   {
                     type: 'grace-period',
                     date: expiry ? new Date(expiry.getTime() + GRACE_PERIOD) : undefined,
-                    tooltip: t('tabs.ownership.sections.expiry.panel.grace-period.tooltip'),
+                    tooltip: graceTooltip(isShortName),
                     supportLink: getSupportLink('grace-period'),
                   },
                 ]
@@ -129,7 +137,7 @@ export const useExpiryDetails = ({ name, details }: Input, options: Options = {}
                     date: parentExpiry
                       ? new Date(parentExpiry.getTime() + GRACE_PERIOD)
                       : undefined,
-                    tooltip: t('tabs.ownership.sections.expiry.panel.grace-period.tooltip'),
+                    tooltip: graceTooltip(isShortParentName),
                     supportLink: getSupportLink('grace-period'),
                   },
                 ]
@@ -163,6 +171,8 @@ export const useExpiryDetails = ({ name, details }: Input, options: Options = {}
       parentData.expiryDate,
       registrationData.data,
       buildTransactionUrl,
+      isShortName,
+      isShortParentName,
     ],
   )
 

--- a/src/components/pages/profile/[name]/tabs/ProfileTab.tsx
+++ b/src/components/pages/profile/[name]/tabs/ProfileTab.tsx
@@ -18,6 +18,7 @@ import { useNameDetails } from '@app/hooks/useNameDetails'
 import { useOwners } from '@app/hooks/useOwners'
 import { useVerifiedRecords } from '@app/hooks/verification/useVerifiedRecords/useVerifiedRecords'
 import { categoriseAndTransformTextRecords } from '@app/utils/records/categoriseProfileTextRecords'
+import { isShortEth2LD } from '@app/utils/shortName'
 import { getSupportLink } from '@app/utils/supportLinks'
 import { validateExpiry } from '@app/utils/utils'
 import { getVerificationRecordItemProps } from '@app/utils/verification/getVerificationRecordItems'
@@ -59,6 +60,7 @@ const ProfileTab = ({ nameDetails, name }: Props) => {
     pccExpired,
     gracePeriodEndDate,
   } = nameDetails
+  const isShortName = isShortEth2LD(nameDetails)
 
   const abilities = useAbilities({ name })
 
@@ -93,9 +95,10 @@ const ProfileTab = ({ nameDetails, name }: Props) => {
     [gracePeriodEndDate],
   )
   const snippetButton = useMemo(() => {
+    if (isShortName) return undefined
     if (isExpired) return 'register'
     if (abilities.data?.canExtend) return 'extend'
-  }, [isExpired, abilities.data?.canExtend])
+  }, [isExpired, isShortName, abilities.data?.canExtend])
 
   const getTextRecord = (key: string) => profile?.texts?.find((x) => x.key === key)
 

--- a/src/hooks/abilities/useAbilities.test.ts
+++ b/src/hooks/abilities/useAbilities.test.ts
@@ -2,7 +2,7 @@ import { mockFunction, renderHook } from '@app/test-utils'
 
 import { dequal } from 'dequal'
 import { match, P } from 'ts-pattern'
-import { Address } from 'viem'
+import { Address, labelhash } from 'viem'
 // import { writeFileSync} from 'fs'
 import { afterAll, describe, expect, it, vi } from 'vitest'
 
@@ -93,6 +93,63 @@ describe('useAbilities', () => {
       const { result } = renderHook(() => useAbilities({ name }))
 
       expect(result.current.data?.canEditRecords).toBe(true)
+    })
+    it('should not allow an on.eth-shaped registered short name to be extended', () => {
+      mockUseAccountSafely.mockReturnValue({ address: account })
+      mockUseBasicName.mockReturnValue({
+        isValid: true,
+        isShort: true,
+        isETH: true,
+        is2LD: true,
+        name: 'on.eth',
+        ownerData: {
+          ownershipLevel: 'registrar',
+          owner: account,
+          registrant: account,
+        },
+        isLoading: false,
+      })
+      mockUseParentBasicName.mockReturnValue({ isLoading: false })
+      mockUseResolverIsAuthorised.mockReturnValue({
+        data: { isAuthorised: true, isValid: true },
+        isLoading: false,
+      })
+      mockUseHasSubnames.mockReturnValue({ data: false, isLoading: false })
+
+      const { result } = renderHook(() => useAbilities({ name: 'on.eth' }))
+
+      expect(result.current.data?.canExtend).toBe(false)
+      expect(result.current.data?.canSelfExtend).toBe(false)
+    })
+    // A name the subgraph has not healed looks short to `parseInput`, and extending it is the
+    // renewal path that would be lost most quietly.
+    it('should allow a name whose label is still an encoded labelhash to be extended', () => {
+      const encodedName = `[${labelhash('nick').slice(2)}].eth`
+      mockUseAccountSafely.mockReturnValue({ address: account })
+      mockUseBasicName.mockReturnValue({
+        isValid: true,
+        isShort: true,
+        isETH: true,
+        is2LD: true,
+        name: encodedName,
+        ownerData: {
+          ownershipLevel: 'registrar',
+          owner: account,
+          registrant: account,
+        },
+        isLoading: false,
+      })
+      mockUseParentBasicName.mockReturnValue({ isLoading: false })
+      mockUseResolverIsAuthorised.mockReturnValue({
+        data: { isAuthorised: true, isValid: true },
+        isLoading: false,
+      })
+      mockUseHasSubnames.mockReturnValue({ data: false, isLoading: false })
+
+      const { result } = renderHook(() => useAbilities({ name: encodedName }))
+
+      expect(result.current.data?.canExtend).toBe(true)
+      expect(result.current.data?.canSelfExtend).toBe(true)
     })
   })
 

--- a/src/hooks/abilities/useAbilities.ts
+++ b/src/hooks/abilities/useAbilities.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { isSelfExtendable } from '@app/components/pages/profile/[name]/tabs/OwnershipTab/sections/ExpirySection/hooks/useExpiryActions'
+import { isShortEth2LD } from '@app/utils/shortName'
 import { checkETH2LDFromName } from '@app/utils/utils'
 
 import { useAccountSafely } from '../account/useAccountSafely'
@@ -128,7 +129,7 @@ export const useAbilities = ({ name, enabled = true }: UseAbilitiesParameters) =
   const data: Abilities | undefined = useMemo(
     () => {
       if (!name || !address || isLoading) return DEFAULT_ABILITIES
-      const canExtend = !!name && checkETH2LDFromName(name)
+      const canExtend = !!name && checkETH2LDFromName(name) && !isShortEth2LD(basicNameData)
       return {
         canExtend,
         canSelfExtend: canExtend && isSelfExtendable({ ...basicNameData, address }),
@@ -166,6 +167,9 @@ export const useAbilities = ({ name, enabled = true }: UseAbilitiesParameters) =
       basicNameData.ownerData,
       basicNameData.wrapperData,
       basicNameData.pccExpired,
+      basicNameData.isETH,
+      basicNameData.is2LD,
+      basicNameData.isShort,
       parentBasicNameData.ownerData,
       parentBasicNameData.wrapperData,
       isLoading,

--- a/src/hooks/pages/profile/useRenew/useRenew.test.ts
+++ b/src/hooks/pages/profile/useRenew/useRenew.test.ts
@@ -4,6 +4,7 @@ import { mockFunction, renderHook, screen } from '@app/test-utils'
 import { useConnectModal } from '@getpara/rainbowkit'
 import mockRouter from 'next-router-mock'
 import { useSearchParams } from 'next/navigation'
+import { labelhash } from 'viem'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAccount, type UseAccountReturnType } from 'wagmi'
 
@@ -620,6 +621,46 @@ describe('useRenew', () => {
     renderHook(() => useRenew('test.eth'))
 
     expect(mockShowExtendNamesInput).not.toHaveBeenCalled()
+  })
+
+  it('should not open Extend Names for an on.eth-shaped registered short name', () => {
+    mockRouter.push('/on.eth?renew=123')
+    mockUseBasicName.mockReturnValue({
+      registrationStatus: 'registered',
+      isLoading: false,
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      name: 'on.eth',
+    })
+
+    renderHook(() => useRenew('on.eth'))
+
+    expect(mockShowExtendNamesInput).not.toHaveBeenCalled()
+  })
+
+  // `parseInput` calls an unhealed label short, so a renewal link for a normal-length name must
+  // not be turned away by the short-name policy while the subgraph catches up.
+  it('should open Extend Names for a name whose label is still an encoded labelhash', () => {
+    const encodedName = `[${labelhash('nick').slice(2)}].eth`
+    mockRouter.push(`/${encodedName}?renew=123`)
+    mockUseBasicName.mockReturnValue({
+      registrationStatus: 'registered',
+      isLoading: false,
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      name: encodedName,
+    })
+
+    renderHook(() => useRenew(encodedName))
+
+    expect(mockShowExtendNamesInput).toHaveBeenCalledWith(
+      `extend-names-${encodedName}`,
+      expect.objectContaining({ names: [encodedName] }),
+    )
   })
 
   it('should do nothing when registration status is loading', () => {

--- a/src/hooks/pages/profile/useRenew/useRenew.ts
+++ b/src/hooks/pages/profile/useRenew/useRenew.ts
@@ -10,6 +10,7 @@ import { useRouterWithHistory } from '@app/hooks/useRouterWithHistory'
 import { validateExtendNamesDuration } from '@app/transaction-flow/input/ExtendNames/utils/validateExtendNamesDuration'
 import { useTransactionFlow } from '@app/transaction-flow/TransactionFlowProvider'
 import { RegistrationStatus } from '@app/utils/registrationStatus'
+import { isShortEth2LD } from '@app/utils/shortName'
 
 type RenewStatus = 'connect-user' | 'display-extend-names' | 'idle'
 
@@ -68,7 +69,8 @@ export const removeRenewParam = ({
 
 export function useRenew(name: string) {
   const router = useRouterWithHistory()
-  const { registrationStatus, isLoading: isBasicNameLoading, isWrapped } = useBasicName({ name })
+  const basicName = useBasicName({ name })
+  const { registrationStatus, isLoading: isBasicNameLoading, isWrapped } = basicName
   const abilities = useAbilities({ name })
   const searchParams = useSearchParams()
   const { status } = useAccount()
@@ -84,7 +86,7 @@ export function useRenew(name: string) {
   const renewSeconds = validateExtendNamesDuration({ duration: searchParams.get('renew') })
 
   const renewState = calculateRenewState({
-    registrationStatus,
+    registrationStatus: isShortEth2LD(basicName) ? 'short' : registrationStatus,
     isRegistrationStatusLoading: isBasicNameLoading,
     renewSeconds,
     connectModalOpen,

--- a/src/hooks/useBasicName.test.ts
+++ b/src/hooks/useBasicName.test.ts
@@ -115,6 +115,54 @@ describe('useBasicName', () => {
       )
     })
   })
+  // `12.eth` and `on.eth` look identical until the chain answers, so a short .eth 2LD is looked up
+  // like any other name. Only the price is skipped: it can never be registered at any price.
+  describe('short 2LD .eth', () => {
+    beforeEach(() => {
+      mockUseValidate.mockReturnValue({
+        isValid: true,
+        is2LD: true,
+        isETH: true,
+        isShort: true,
+        name: 'on.eth',
+        labelCount: 2,
+      })
+    })
+
+    it('should query for the owner', () => {
+      renderHook(() => useBasicName({ name: 'on.eth' }))
+      expect(mockUseOwner).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }))
+    })
+
+    it('should query for the wrapper data', () => {
+      renderHook(() => useBasicName({ name: 'on.eth' }))
+      expect(mockUseWrapperData).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }))
+    })
+
+    it('should query for the expiry', () => {
+      renderHook(() => useBasicName({ name: 'on.eth' }))
+      expect(mockUseExpiry).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }))
+    })
+
+    it('should query for the address record', () => {
+      renderHook(() => useBasicName({ name: 'on.eth' }))
+      expect(mockUseAddressRecord).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }))
+    })
+
+    it('should not query for the price', () => {
+      renderHook(() => useBasicName({ name: 'on.eth' }))
+      expect(mockUsePrice).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }))
+    })
+
+    it('should not calculate a status while the owner lookup is loading', () => {
+      mockUseOwner.mockReturnValue({ data: undefined, isLoading: true })
+
+      const { result } = renderHook(() => useBasicName({ name: 'on.eth' }))
+
+      expect(result.current.registrationStatus).toBeUndefined()
+      expect(mockGetRegistrationStatus).not.toHaveBeenCalled()
+    })
+  })
   describe('2LD non .eth', () => {
     beforeEach(() => {
       mockUseValidate.mockReturnValue({

--- a/src/hooks/useBasicName.ts
+++ b/src/hooks/useBasicName.ts
@@ -4,6 +4,7 @@ import { getAddress } from 'viem'
 import { truncateFormat } from '@ensdomains/ensjs/utils'
 
 import { getRegistrationStatus } from '@app/utils/registrationStatus'
+import { isShortEth2LD } from '@app/utils/shortName'
 import { isLabelTooLong, yearsToSeconds } from '@app/utils/utils'
 
 import { useContractAddress } from './chain/useContractAddress'
@@ -35,13 +36,17 @@ export const useBasicName = ({
 }: UseBasicNameOptions) => {
   const validation = useValidate({ input: name!, enabled: enabled && !!name })
 
-  const { name: _normalisedName, isValid, isShort, isETH, is2LD } = validation
+  const { name: _normalisedName, isValid, isETH, is2LD } = validation
 
   const normalisedName = normalised ? name! : _normalisedName
 
   const { data: supportedTLD, isLoading: supportedTLDLoading } = useSupportsTLD(normalisedName)
 
-  const commonEnabled = enabled && !!name && isValid && !(isETH && isShort)
+  // Short .eth 2LDs are looked up like any other name: it takes the ownership and expiry reads to
+  // tell a real one (`on.eth`) from an unregisterable one (`12.eth`). Only the price is left out,
+  // since a short name can never be registered or hold a temporary premium.
+  const commonEnabled = enabled && !!name && isValid
+  const isShortEthName = isShortEth2LD(validation)
   const isRoot = name === '[root]'
 
   const {
@@ -70,7 +75,7 @@ export const useBasicName = ({
   } = usePrice({
     nameOrNames: normalisedName,
     duration: yearsToSeconds(1),
-    enabled: commonEnabled && !isRoot && isETH && is2LD,
+    enabled: commonEnabled && !isRoot && isETH && is2LD && !isShortEthName,
   })
   const {
     data: addrData,

--- a/src/hooks/useNameDetails.test.ts
+++ b/src/hooks/useNameDetails.test.ts
@@ -1,5 +1,6 @@
 import { mockFunction, renderHook } from '@app/test-utils'
 
+import { labelhash } from 'viem'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useDnsOwner } from './ensjs/dns/useDnsOwner'
@@ -44,5 +45,130 @@ describe('useNameDetails', () => {
     })
     renderHook(() => useNameDetails({ name: '[root]' }))
     expect(mockUseProfile).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }))
+  })
+  it('should return the minimum-length error for an unregistered short name', () => {
+    mockUseBasicName.mockReturnValue({
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      name: '12.eth',
+      normalisedName: '12.eth',
+      registrationStatus: 'short',
+      isLoading: false,
+    })
+
+    const { result } = renderHook(() => useNameDetails({ name: '12.eth' }))
+
+    expect(result.current.error).toEqual({
+      content: 'errors.shortName',
+      type: 'error',
+    })
+  })
+  it('should not report an error while short-name ownership is loading', () => {
+    mockUseBasicName.mockReturnValue({
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      name: '12.eth',
+      normalisedName: '12.eth',
+      registrationStatus: undefined,
+      isLoading: true,
+    })
+
+    const { result } = renderHook(() => useNameDetails({ name: '12.eth' }))
+
+    expect(result.current.error).toBeNull()
+  })
+  it('should warn about the grace period ending with the standard copy for a normal name', () => {
+    mockUseBasicName.mockReturnValue({
+      isValid: true,
+      isShort: false,
+      isETH: true,
+      is2LD: true,
+      name: 'test.eth',
+      normalisedName: 'test.eth',
+      registrationStatus: 'gracePeriod',
+      gracePeriodEndDate: new Date('2026-06-06T00:00:00.000Z'),
+      isLoading: false,
+    })
+
+    const { result } = renderHook(() => useNameDetails({ name: 'test.eth' }))
+
+    expect(result.current.error).toEqual(
+      expect.objectContaining({ content: 'errors.expiringSoon' }),
+    )
+  })
+  // The standard copy promises extension and then availability, and a short name gets neither.
+  it('should warn with short-name copy instead of expiringSoon for a grace-period short name', () => {
+    mockUseBasicName.mockReturnValue({
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      name: 'on.eth',
+      normalisedName: 'on.eth',
+      registrationStatus: 'gracePeriod',
+      gracePeriodEndDate: new Date('2036-06-06T00:00:00.000Z'),
+      isLoading: false,
+    })
+
+    const { result } = renderHook(() => useNameDetails({ name: 'on.eth' }))
+
+    expect(result.current.error).toEqual(
+      expect.objectContaining({
+        title: 'errors.hasExpired',
+        content: 'errors.expiringSoonShortName',
+      }),
+    )
+  })
+  // The minimum-length error is driven by the `short` status, and an unhealed label is never given
+  // one: with no readable label there is no registerability answer to give, so the status model
+  // reports `notOwned` and no error branch applies. Without that, a normal name whose label had not
+  // been healed was told it "is not available for .eth names under 3 characters".
+  it('should not report the minimum-length error for an unowned name whose label is an encoded labelhash', () => {
+    const encodedName = `[${labelhash('nick').slice(2)}].eth`
+    mockUseProfile.mockReturnValue({
+      data: { isMigrated: true },
+      isLoading: false,
+    })
+    mockUseBasicName.mockReturnValue({
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      name: encodedName,
+      normalisedName: encodedName,
+      registrationStatus: 'notOwned',
+      isLoading: false,
+    })
+
+    const { result } = renderHook(() => useNameDetails({ name: encodedName }))
+
+    expect(result.current.error).toBeNull()
+  })
+  // An unhealed label is reported as short by `parseInput` because there is nothing to measure, so
+  // a name of any length can arrive here looking short. It gets the standard copy, which promises
+  // the extension it can in fact have.
+  it('should keep the standard grace-period copy for a name whose label is still an encoded labelhash', () => {
+    const encodedName = `[${labelhash('nick').slice(2)}].eth`
+    mockUseBasicName.mockReturnValue({
+      isValid: true,
+      isShort: true,
+      isETH: true,
+      is2LD: true,
+      name: encodedName,
+      normalisedName: encodedName,
+      registrationStatus: 'gracePeriod',
+      gracePeriodEndDate: new Date('2036-06-06T00:00:00.000Z'),
+      isLoading: false,
+    })
+
+    const { result } = renderHook(() => useNameDetails({ name: encodedName }))
+
+    expect(result.current.error).toEqual(
+      expect.objectContaining({ content: 'errors.expiringSoon' }),
+    )
   })
 })

--- a/src/hooks/useNameDetails.tsx
+++ b/src/hooks/useNameDetails.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { DesyncedMessage } from '@app/components/@molecules/DesyncedMessage/DesyncedMessage'
+import { isShortEth2LD } from '@app/utils/shortName'
 import { formatFullExpiry } from '@app/utils/utils'
 
 import { useDnsOwner } from './ensjs/dns/useDnsOwner'
@@ -16,6 +17,7 @@ type UseNameDetailsParameters = {
 export const useNameDetails = ({ name, subgraphEnabled = true }: UseNameDetailsParameters) => {
   const { t } = useTranslation('profile')
 
+  const basicNameData = useBasicName({ name })
   const {
     isValid,
     normalisedName,
@@ -26,7 +28,9 @@ export const useNameDetails = ({ name, subgraphEnabled = true }: UseNameDetailsP
     gracePeriodEndDate,
     refetchIfEnabled: refetchBasicName,
     ...basicName
-  } = useBasicName({ name })
+  } = basicNameData
+
+  const isShortName = isShortEth2LD(basicNameData)
 
   const {
     data: profile,
@@ -53,6 +57,9 @@ export const useNameDetails = ({ name, subgraphEnabled = true }: UseNameDetailsP
   } | null = useMemo(() => {
     if (isValid === false) {
       return { content: t('errors.invalidName') }
+    }
+    if (registrationStatus === 'short') {
+      return { content: t('errors.shortName'), type: 'error' }
     }
     if (registrationStatus === 'unsupportedTLD') {
       return { content: t('errors.unsupportedTLD') }
@@ -88,7 +95,11 @@ export const useNameDetails = ({ name, subgraphEnabled = true }: UseNameDetailsP
     if (registrationStatus === 'gracePeriod') {
       return {
         title: t('errors.hasExpired', { name: normalisedName }),
-        content: t('errors.expiringSoon', { date: formatFullExpiry(gracePeriodEndDate) }),
+        // The usual copy promises extension and then availability, and a short name gets neither:
+        // the app does not offer to extend it, and the registrar will not re-register it.
+        content: isShortName
+          ? t('errors.expiringSoonShortName', { date: formatFullExpiry(gracePeriodEndDate) })
+          : t('errors.expiringSoon', { date: formatFullExpiry(gracePeriodEndDate) }),
       }
     }
     if (
@@ -96,6 +107,7 @@ export const useNameDetails = ({ name, subgraphEnabled = true }: UseNameDetailsP
       !!normalisedName &&
       normalisedName !== '[root]' &&
       !profile &&
+      !isBasicLoading &&
       !isProfileLoading
     ) {
       return {
@@ -105,13 +117,16 @@ export const useNameDetails = ({ name, subgraphEnabled = true }: UseNameDetailsP
     }
     return null
   }, [
+    expiryDate,
     gracePeriodEndDate,
     normalisedName,
     profile,
+    isBasicLoading,
     isProfileLoading,
     registrationStatus,
     t,
     isValid,
+    isShortName,
   ])
 
   const isLoading = isProfileLoading || isBasicLoading || isDnsOwnerLoading

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -7,6 +7,7 @@ import { useNameDetails } from '@app/hooks/useNameDetails'
 import { getSelectedIndex } from '@app/hooks/useRegistrationReducer'
 import { useRouterWithHistory } from '@app/hooks/useRouterWithHistory'
 import { ContentGrid } from '@app/layouts/ContentGrid'
+import { isShortEth2LD } from '@app/utils/shortName'
 
 export default function Page() {
   const router = useRouterWithHistory()
@@ -23,6 +24,13 @@ export default function Page() {
   const { isLoading: detailsLoading, registrationStatus } = nameDetails
 
   const isLoading = detailsLoading || initial
+
+  if (isShortEth2LD(nameDetails)) {
+    if (!nameDetails.isBasicLoading) {
+      router.replace(`/profile/${nameDetails.normalisedName || name}`)
+    }
+    return null
+  }
 
   if (!isLoading && registrationStatus !== 'available' && registrationStatus !== 'premium') {
     let redirect = true
@@ -47,6 +55,7 @@ export default function Page() {
 
     if (redirect) {
       router.push(`/profile/${name}`)
+      return null
     }
   }
 

--- a/src/transaction-flow/input/ExtendNames/ExtendNames-flow.test.tsx
+++ b/src/transaction-flow/input/ExtendNames/ExtendNames-flow.test.tsx
@@ -1,5 +1,6 @@
 import { mockFunction, render, screen } from '@app/test-utils'
 
+import { labelhash } from 'viem'
 import { describe, expect, it, vi } from 'vitest'
 import { useAccount, useBalance } from 'wagmi'
 
@@ -151,5 +152,82 @@ describe('Extendnames', () => {
     )
     expect(screen.getAllByText('input.extendNames.disabled.title').length).toBeGreaterThan(0)
     expect(screen.queryByText('action.next')).not.toBeInTheDocument()
+  })
+  it('should make a persisted on.eth renewal a dead end without registrar reads', () => {
+    render(
+      <ExtendNames
+        {...{
+          data: { names: ['on.eth'], isSelf: true, hasWrapped: false },
+          dispatch: () => null,
+          onDismiss: () => null,
+        }}
+      />,
+    )
+
+    expect(screen.getAllByText('input.extendNames.shortName.title').length).toBeGreaterThan(0)
+    expect(screen.getByText('input.extendNames.shortName.description')).toBeVisible()
+    expect(screen.queryByText('action.next')).not.toBeInTheDocument()
+    expect(mockUsePrice).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }))
+    expect(mockUseExpiry).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }))
+    expect(mockUseEstimateGasWithStateOverride).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    )
+  })
+  // `renew()` in the new Manager app carries no length minimum, so where renewals have moved there a
+  // short name is not a dead end — it just cannot be renewed here. The Manager link is the answer.
+  it('should prefer the disabled banner over the short-name view when the ETHRegistrarController has been removed', () => {
+    mockUseIsEthRegistrarControllerActive.mockReturnValueOnce({
+      data: false,
+      isLoading: false,
+    } as any)
+    render(
+      <ExtendNames
+        {...{
+          data: { names: ['on.eth'], isSelf: true, hasWrapped: false },
+          dispatch: () => null,
+          onDismiss: () => null,
+        }}
+      />,
+    )
+
+    expect(screen.getAllByText('input.extendNames.disabled.title').length).toBeGreaterThan(0)
+    expect(screen.queryByText('input.extendNames.shortName.description')).not.toBeInTheDocument()
+  })
+  // Which of the two dead ends a short name gets depends on that registrar read, so it waits for it
+  // rather than claiming the wrong one first.
+  it('should not show the short-name view while the registrar read is still in flight', () => {
+    mockUseIsEthRegistrarControllerActive.mockReturnValueOnce({
+      data: undefined,
+      isLoading: true,
+    } as any)
+    render(
+      <ExtendNames
+        {...{
+          data: { names: ['on.eth'], isSelf: true, hasWrapped: false },
+          dispatch: () => null,
+          onDismiss: () => null,
+        }}
+      />,
+    )
+
+    expect(screen.queryByText('input.extendNames.shortName.description')).not.toBeInTheDocument()
+  })
+  // An unhealed label is short only in the sense that nothing can measure it, so the flow has to
+  // price and offer the renewal exactly as it would for the decoded name.
+  it('should extend a name whose label is still an encoded labelhash', () => {
+    const encodedName = `[${labelhash('nick').slice(2)}].eth`
+    render(
+      <ExtendNames
+        {...{
+          data: { names: [encodedName], isSelf: true, hasWrapped: false },
+          dispatch: () => null,
+          onDismiss: () => null,
+        }}
+      />,
+    )
+
+    expect(screen.queryByText('input.extendNames.shortName.title')).not.toBeInTheDocument()
+    expect(screen.getByTestId('extend-names-confirm')).not.toHaveAttribute('disabled')
+    expect(mockUsePrice).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }))
   })
 })

--- a/src/transaction-flow/input/ExtendNames/ExtendNames-flow.tsx
+++ b/src/transaction-flow/input/ExtendNames/ExtendNames-flow.tsx
@@ -34,6 +34,7 @@ import { createTransactionItem } from '@app/transaction-flow/transaction'
 import { TransactionDialogPassthrough } from '@app/transaction-flow/types'
 import { CURRENCY_FLUCTUATION_BUFFER_PERCENTAGE } from '@app/utils/constants'
 import { getReferrerHex } from '@app/utils/referrer'
+import { isShortEth2LDName } from '@app/utils/shortName'
 import { ONE_DAY, ONE_YEAR, secondsToYears, yearsToSeconds } from '@app/utils/time'
 import useUserConfig from '@app/utils/useUserConfig'
 import { deriveYearlyFee, formatDurationOfDates } from '@app/utils/utils'
@@ -44,7 +45,7 @@ import { SearchViewLoadingView } from '../SendName/views/SearchView/views/Search
 import { getManagerRenewUrl } from './utils/getManagerRenewUrl'
 import { validateExtendNamesDuration } from './utils/validateExtendNamesDuration'
 
-type View = 'name-list' | 'no-ownership-warning' | 'registration' | 'disabled'
+type View = 'name-list' | 'no-ownership-warning' | 'registration' | 'disabled' | 'short-name'
 
 const DisabledContainer = styled.div(
   ({ theme }) => css`
@@ -219,6 +220,7 @@ const ExtendNames = ({
   )
   const years = secondsToYears(seconds)
   const [durationType, setDurationType] = useState<'years' | 'date'>('years')
+  const hasShortName = names.some(isShortEth2LDName)
 
   const referrer = useReferrer()
   const referrerHex = getReferrerHex(referrer)
@@ -237,6 +239,7 @@ const ExtendNames = ({
   const currencyDisplay = userConfig.currency === 'fiat' ? userConfig.fiat : 'eth'
 
   const { data: priceData, isLoading: isPriceLoading } = usePrice({
+    enabled: !hasShortName,
     nameOrNames: names,
     duration: seconds,
   })
@@ -246,7 +249,7 @@ const ExtendNames = ({
   const previousYearlyFee = usePreviousDistinct(yearlyFee) || 0n
   const isShowingPreviousYearlyFee = yearlyFee === 0n && previousYearlyFee > 0n
 
-  const isExpiryEnabled = names.length === 1
+  const isExpiryEnabled = names.length === 1 && !hasShortName
   const { data: expiryData, isLoading: isExpiryLoading } = useExpiry({
     enabled: isExpiryEnabled,
     name: names[0],
@@ -281,7 +284,7 @@ const ExtendNames = ({
         ],
       },
     ],
-    enabled: !!totalRentFee && !!address && seconds > 0 && totalRentFee > 0n,
+    enabled: !hasShortName && !!totalRentFee && !!address && seconds > 0 && totalRentFee > 0n,
   })
 
   const previousTransactionFee = usePreviousDistinct(transactionFee) || 0n
@@ -307,37 +310,43 @@ const ExtendNames = ({
   // post ENS v2 beta), short-circuit the whole flow with a disabled view
   // that points users to the new Manager app. The on-chain renew() call
   // would otherwise revert.
-  const flow: View[] = useMemo(
-    () =>
-      isRenewalDisabled
-        ? ['disabled']
-        : match([names.length, isSelf])
-            .with(
-              [P.when((length) => length > 1), true],
-              () => ['name-list', 'registration'] as View[],
-            )
-            .with(
-              [P.when((length) => length > 1), P._],
-              () => ['no-ownership-warning', 'name-list', 'registration'] as View[],
-            )
-            .with([P._, true], () => ['registration'] as View[])
-            .otherwise(() => ['no-ownership-warning', 'registration'] as View[]),
-    [names.length, isSelf, isRenewalDisabled],
-  )
+  const flow: View[] = useMemo(() => {
+    // Where renewals have moved to the new Manager app, the Manager link is the answer for every
+    // name: `renew()` carries no length minimum there, so a short name is not a dead end — this app
+    // simply is not the place to renew it. Hence disabled outranks the short-name view.
+    if (isRenewalDisabled) return ['disabled']
+    if (hasShortName) return ['short-name']
+    return match([names.length, isSelf])
+      .with([P.when((length) => length > 1), true], () => ['name-list', 'registration'] as View[])
+      .with(
+        [P.when((length) => length > 1), P._],
+        () => ['no-ownership-warning', 'name-list', 'registration'] as View[],
+      )
+      .with([P._, true], () => ['registration'] as View[])
+      .otherwise(() => ['no-ownership-warning', 'registration'] as View[])
+  }, [hasShortName, names.length, isSelf, isRenewalDisabled])
   const [viewIdx, setViewIdx] = useState(0)
   const incrementView = () => setViewIdx(() => Math.min(flow.length - 1, viewIdx + 1))
   const decrementView = () => (viewIdx <= 0 ? onDismiss() : setViewIdx(viewIdx - 1))
   const view = flow[viewIdx]
 
+  // A short name needs none of the pricing reads to reach its dead end, but it does need the
+  // registrar answer, since that is what now decides which of the two dead ends it gets.
   const isBaseDataLoading =
-    !isAccountConnected ||
-    isBalanceLoading ||
-    isExpiryEnabledAndLoading ||
-    isEthPriceLoading ||
-    isControllerActiveLoading
+    isControllerActiveLoading ||
+    (!hasShortName &&
+      (!isAccountConnected || isBalanceLoading || isExpiryEnabledAndLoading || isEthPriceLoading))
   const isRegisterLoading = isPriceLoading || (isEstimateGasLoading && !estimateGasLimitError)
 
   const { title, alert, buttonProps } = match(view)
+    .with('short-name', () => ({
+      title: t('input.extendNames.shortName.title'),
+      alert: 'warning' as const,
+      buttonProps: {
+        onClick: onDismiss,
+        children: t('action.close', { ns: 'common' }),
+      },
+    }))
     .with('disabled', () => ({
       title: t('input.extendNames.disabled.title'),
       alert: 'warning' as const,
@@ -399,6 +408,9 @@ const ExtendNames = ({
       <Dialog.Content data-testid="extend-names-modal">
         {match([view, isBaseDataLoading])
           .with([P._, true], () => <SearchViewLoadingView />)
+          .with(['short-name', false], () => (
+            <CenteredMessage>{t('input.extendNames.shortName.description')}</CenteredMessage>
+          ))
           .with(['disabled', false], () => (
             <DisabledContainer>
               <Banner alert="warning" title={t('input.extendNames.disabled.title')}>

--- a/src/transaction-flow/transaction/extendNames.test.ts
+++ b/src/transaction-flow/transaction/extendNames.test.ts
@@ -1,11 +1,11 @@
 import { mockFunction } from '@app/test-utils'
 
+import { labelhash, type Address, type Hex } from 'viem'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Address, Hex } from 'viem'
 
 import { getPrice } from '@ensdomains/ensjs/public'
-import * as  renewNames from '@app/overrides/ensjs/renewNames'
 
+import * as renewNames from '@app/overrides/ensjs/renewNames'
 import { ClientWithEns, ConnectorClientWithEns } from '@app/types'
 
 import extendNamesTransaction from './extendNames'
@@ -40,7 +40,7 @@ describe('extendNamesTransaction', () => {
         duration: ONE_YEAR_SECONDS,
         startDateTimestamp: JAN_1_2022_TIMESTAMP,
         displayPrice: '0.1 ETH',
-        hasWrapped: false
+        hasWrapped: false,
       }
 
       const result = extendNamesTransaction.displayItems(data, mockT)
@@ -79,7 +79,7 @@ describe('extendNamesTransaction', () => {
         duration: ONE_YEAR_SECONDS,
         startDateTimestamp: JAN_1_2022_TIMESTAMP,
         displayPrice: '0.2 ETH',
-        hasWrapped: false
+        hasWrapped: false,
       }
 
       const result = extendNamesTransaction.displayItems(data, mockT)
@@ -232,6 +232,55 @@ describe('extendNamesTransaction', () => {
           data,
         }),
       ).rejects.toThrow('No price found')
+    })
+
+    it('should reject a persisted on.eth renewal before requesting a price or transaction', async () => {
+      await expect(
+        extendNamesTransaction.transaction({
+          client: mockClient,
+          connectorClient: mockConnectorClient,
+          data: {
+            names: ['on.eth'],
+            duration: 31536000,
+            hasWrapped: false,
+          },
+        }),
+      ).rejects.toThrow('Extending is not available for short .eth names')
+
+      expect(mockGetPrice).not.toHaveBeenCalled()
+      expect(mockRenewNames).not.toHaveBeenCalled()
+    })
+
+    // An unhealed label reads as short to `parseInput`, which must not turn a renewal the user
+    // already paid attention to into an error at the last step.
+    it('should renew a name whose label is still an encoded labelhash', async () => {
+      const encodedName = `[${labelhash('nick').slice(2)}].eth`
+
+      mockGetPrice.mockResolvedValue({ base: BigInt('1000000000000000000'), premium: 0n } as any)
+      mockRenewNames.mockResolvedValue({
+        to: '0x123' as Address,
+        data: '0x456' as Hex,
+        value: BigInt('1020000000000000000'),
+      } as any)
+
+      await extendNamesTransaction.transaction({
+        client: mockClient,
+        connectorClient: mockConnectorClient,
+        data: {
+          names: [encodedName],
+          duration: 31536000,
+          hasWrapped: false,
+        },
+      })
+
+      expect(mockGetPrice).toHaveBeenCalledWith(mockClient, {
+        nameOrNames: [encodedName],
+        duration: 31536000,
+      })
+      expect(mockRenewNames).toHaveBeenCalledWith(
+        mockConnectorClient,
+        expect.objectContaining({ nameOrNames: [encodedName] }),
+      )
     })
   })
 })

--- a/src/transaction-flow/transaction/extendNames.ts
+++ b/src/transaction-flow/transaction/extendNames.ts
@@ -5,6 +5,7 @@ import { getPrice } from '@ensdomains/ensjs/public'
 
 import renewNames from '@app/overrides/ensjs/renewNames'
 import { Transaction, TransactionDisplayItem, TransactionFunctionParameters } from '@app/types'
+import { isShortEth2LDName } from '@app/utils/shortName'
 
 import { calculateValueWithBuffer, formatDurationOfDates, formatExpiry } from '../../utils/utils'
 
@@ -61,6 +62,10 @@ const transaction = async ({
   data,
 }: TransactionFunctionParameters<Data>) => {
   const { names, duration, referrer, hasWrapped } = data
+  if (names.some(isShortEth2LDName)) {
+    throw new Error('Extending is not available for short .eth names')
+  }
+
   const price = await getPrice(client, {
     nameOrNames: names,
     duration,

--- a/src/utils/registrationStatus.test.ts
+++ b/src/utils/registrationStatus.test.ts
@@ -1,3 +1,4 @@
+import { labelhash } from 'viem'
 import { describe, expect, it } from 'vitest'
 
 import { GetOwnerReturnType, GetWrapperDataReturnType } from '@ensdomains/ensjs/public'
@@ -35,16 +36,185 @@ const wrapperData: GetWrapperDataReturnType = {
   owner: '0x123',
 }
 
+const YEAR_IN_MS = 1000 * 60 * 60 * 24 * 365
+const GRACE_PERIOD_IN_SECONDS = 60 * 60 * 24 * 90
+
 describe('getRegistrationStatus', () => {
-  describe('2LD .eth', () => {
-    it('should return short if a name is short', async () => {
+  // A .eth 2LD below the registrar's three character minimum. `getOwner` and `getExpiry` both
+  // return null for a label the registrar has never issued, which is how `12.eth` arrives here.
+  describe('short 2LD .eth', () => {
+    const validation = { isETH: true, is2LD: true, isShort: true } as const
+
+    it('should return short for a short name that has never been registered', () => {
       const result = getRegistrationStatus({
         timestamp: Date.now(),
-        validation: { isETH: true, is2LD: true, isShort: true },
+        validation,
+        ownerData: null,
+        wrapperData: null,
+        expiryData: null,
+        name: '12.eth',
       })
       expect(result).toBe('short')
     })
 
+    // on.eth is a two character name registered before the minimum was enforced. It is a real,
+    // owned name with a real registrar expiry, so it must read as registered, not as a dead end.
+    it('should return registered for a short name that predates the minimum length (on.eth)', () => {
+      const result = getRegistrationStatus({
+        timestamp: Date.now(),
+        validation,
+        ownerData,
+        wrapperData: null,
+        expiryData: {
+          expiry: createDateWithValue(Date.now() + 10 * YEAR_IN_MS),
+          gracePeriod: GRACE_PERIOD_IN_SECONDS,
+          status: 'active',
+        },
+        name: 'on.eth',
+      })
+      expect(result).toBe('registered')
+    })
+
+    it('should return gracePeriod for a short name whose registration has just lapsed', () => {
+      const result = getRegistrationStatus({
+        timestamp: Date.now(),
+        validation,
+        ownerData,
+        wrapperData: null,
+        expiryData: {
+          expiry: createDateWithValue(Date.now() - 1000),
+          gracePeriod: GRACE_PERIOD_IN_SECONDS,
+          status: 'gracePeriod',
+        },
+        name: 'on.eth',
+      })
+      expect(result).toBe('gracePeriod')
+    })
+
+    // The registry owner outlives the registration, so a stale non-empty ownerData must not keep
+    // an expired short name looking registered — nor make it look registerable.
+    it('should return short rather than available once a short name is out of its grace period', () => {
+      const result = getRegistrationStatus({
+        timestamp: Date.now(),
+        validation,
+        ownerData,
+        wrapperData: null,
+        expiryData: {
+          expiry: createDateWithValue(Date.now() - 1000),
+          gracePeriod: 0,
+          status: 'expired',
+        },
+        priceData: { base: 1n, premium: 0n },
+        name: '12.eth',
+      })
+      expect(result).toBe('short')
+    })
+
+    it('should return short rather than premium for an expired short name with a premium', () => {
+      const result = getRegistrationStatus({
+        timestamp: Date.now(),
+        validation,
+        ownerData,
+        wrapperData: null,
+        expiryData: {
+          expiry: createDateWithValue(Date.now() - 1000),
+          gracePeriod: 0,
+          status: 'expired',
+        },
+        priceData: { base: 1n, premium: 1n },
+        name: '12.eth',
+      })
+      expect(result).toBe('short')
+    })
+  })
+
+  // A label the subgraph has not healed arrives as an encoded labelhash, which `parseInput` reports
+  // as short because there is no output to measure. Shortness is not the only thing unknown about
+  // it: registering it would register the bracket string rather than the name behind it, so none of
+  // the registerability answers apply, and the name gets the same bland status as any other name the
+  // app holds no claim for. The lifecycle answers still apply, because they are keyed by labelhash.
+  describe('unhealed label (encoded labelhash) 2LD .eth', () => {
+    const encodedName = `[${labelhash('nick').slice(2)}].eth`
+    const validation = { isETH: true, is2LD: true, isShort: true } as const
+
+    it('should return notOwned rather than short for an unowned encoded label', () => {
+      const result = getRegistrationStatus({
+        timestamp: Date.now(),
+        validation,
+        ownerData: null,
+        wrapperData: null,
+        expiryData: null,
+        name: encodedName,
+      })
+      expect(result).toBe('notOwned')
+    })
+
+    it('should return notOwned rather than premium for an encoded label past its grace period', () => {
+      const result = getRegistrationStatus({
+        timestamp: Date.now(),
+        validation,
+        ownerData,
+        wrapperData: null,
+        expiryData: {
+          expiry: createDateWithValue(Date.now() - 1000),
+          gracePeriod: 0,
+          status: 'expired',
+        },
+        priceData: { base: 1n, premium: 1n },
+        name: encodedName,
+      })
+      expect(result).toBe('notOwned')
+    })
+
+    it('should still return registered for an owned encoded label', () => {
+      const result = getRegistrationStatus({
+        timestamp: Date.now(),
+        validation,
+        ownerData,
+        wrapperData: null,
+        expiryData: {
+          expiry: createDateWithValue(Date.now() + 10 * YEAR_IN_MS),
+          gracePeriod: GRACE_PERIOD_IN_SECONDS,
+          status: 'active',
+        },
+        name: encodedName,
+      })
+      expect(result).toBe('registered')
+    })
+
+    it('should still return gracePeriod for an encoded label whose registration has just lapsed', () => {
+      const result = getRegistrationStatus({
+        timestamp: Date.now(),
+        validation,
+        ownerData,
+        wrapperData: null,
+        expiryData: {
+          expiry: createDateWithValue(Date.now() - 1000),
+          gracePeriod: GRACE_PERIOD_IN_SECONDS,
+          status: 'gracePeriod',
+        },
+        name: encodedName,
+      })
+      expect(result).toBe('gracePeriod')
+    })
+
+    // The name is what the check is made of, so a caller that does not pass one gets no
+    // registerability answer either. This is the opposite default from `isShortEth2LD`, which fails
+    // open to not-short: there the harm is dead-ending a normal name, here it is offering a name the
+    // app cannot identify.
+    it('should return notOwned when no name is passed at all', () => {
+      const result = getRegistrationStatus({
+        timestamp: Date.now(),
+        validation: { isETH: true, is2LD: true, isShort: false },
+        ownerData: null,
+        wrapperData: null,
+        expiryData: null,
+      })
+      expect(result).toBe('notOwned')
+    })
+  })
+
+  describe('2LD .eth', () => {
     it('should return invalid if no values are provided', async () => {
       const result = getRegistrationStatus({ timestamp: Date.now(), validation: {} })
       expect(result).toBe('invalid')
@@ -101,6 +271,7 @@ describe('getRegistrationStatus', () => {
         wrapperData,
         expiryData,
         priceData,
+        name: 'nick.eth',
       })
       expect(result).toBe('premium')
     })
@@ -123,6 +294,7 @@ describe('getRegistrationStatus', () => {
         wrapperData,
         expiryData,
         priceData,
+        name: 'nick.eth',
       })
 
       expect(result).toBe('available')

--- a/src/utils/registrationStatus.ts
+++ b/src/utils/registrationStatus.ts
@@ -10,6 +10,7 @@ import { ParsedInputResult } from '@ensdomains/ensjs/utils'
 import { getChainsFromUrl } from '@app/constants/chains'
 
 import { emptyAddress } from './constants'
+import { isKnownLabel } from './shortName'
 
 export type RegistrationStatus =
   | 'invalid'
@@ -50,10 +51,6 @@ export const getRegistrationStatus = ({
 }): RegistrationStatus => {
   if (name === '[root]') return 'owned'
 
-  if (isETH && is2LD && isShort) {
-    return 'short'
-  }
-
   if (!ownerData && ownerData !== null && !wrapperData) return 'invalid'
 
   if (!isETH && !supportedTLD) {
@@ -89,12 +86,22 @@ export const getRegistrationStatus = ({
         }
         return 'gracePeriod'
       }
-      const { premium } = priceData || { premium: 0n }
-      if (premium > 0n) {
-        return 'premium'
-      }
     }
-    return 'available'
+    // Nothing above claimed the name, so everything left is a judgement about registering it — and
+    // that cannot be made for a label the app cannot read. Registering an encoded labelhash would
+    // register the bracket string itself, i.e. the wrong name; `isShort` is a statement about the
+    // missing label rather than about its length; and a premium implies the name is registerable. So
+    // an unhealed label is none of short, available or premium — it is simply not ours to offer.
+    if (!isKnownLabel(name)) return 'notOwned'
+
+    const { premium } = priceData || { premium: 0n }
+    // A short name can never be re-registered, so it never enters the premium window.
+    if (expiryData?.expiry && premium > 0n && !isShort) {
+      return 'premium'
+    }
+    // Otherwise the name is registerable — unless its label is below the registrar's minimum, in
+    // which case it is a dead end rather than an available name.
+    return isShort ? 'short' : 'available'
   }
   if (ownerData && ownerData.owner !== emptyAddress) {
     if (is2LD) {

--- a/src/utils/shortName.test.ts
+++ b/src/utils/shortName.test.ts
@@ -1,0 +1,188 @@
+import { labelhash } from 'viem'
+import { describe, expect, it } from 'vitest'
+
+import { parseInput } from '@ensdomains/ensjs/utils'
+
+import { getShortNameState, isShortEth2LD, isShortEth2LDName } from './shortName'
+
+const encodedLabelhash = (label: string) => `[${labelhash(label).slice(2)}].eth`
+
+describe('isShortEth2LD', () => {
+  it('requires all validation flags to be exactly true', () => {
+    expect(
+      isShortEth2LD({ name: '12.eth', isValid: true, isETH: true, is2LD: true, isShort: true }),
+    ).toBe(true)
+    expect(isShortEth2LD({ name: '12.eth', isValid: true, isETH: true, is2LD: true })).toBe(false)
+    expect(
+      isShortEth2LD({
+        name: '12.nick.eth',
+        isValid: true,
+        isETH: true,
+        is2LD: false,
+        isShort: true,
+      }),
+    ).toBe(false)
+  })
+
+  // A name that failed validation must keep taking the invalid-name path, not the short-name one.
+  it.each([
+    [
+      'a name that failed validation',
+      { name: '12.eth', isValid: false, isETH: true, is2LD: true, isShort: true },
+    ],
+    [
+      'a name whose validation has not resolved',
+      { name: '12.eth', isETH: true, is2LD: true, isShort: true },
+    ],
+    ['an empty validation result', { name: '' }],
+  ])('is false for %s', (_label, validation) => {
+    expect(isShortEth2LD(validation)).toBe(false)
+  })
+
+  // `parseInput` reports `isShort: true` for an unhealed label because there is no output to
+  // measure. Trusting it would dead-end every normal-length name the subgraph has not healed yet.
+  it('is false for an encoded labelhash, whose label length is not knowable', () => {
+    expect(
+      isShortEth2LD({
+        name: encodedLabelhash('alice'),
+        isValid: true,
+        isETH: true,
+        is2LD: true,
+        isShort: true,
+      }),
+    ).toBe(false)
+  })
+
+  // Every call site passes a validation object that carries the name, but one that somehow does
+  // not must fail towards leaving a normal name alone rather than towards dead-ending it.
+  it('is false when there is no name to check the label of', () => {
+    const validationWithoutName = {
+      isValid: true,
+      isETH: true,
+      is2LD: true,
+      isShort: true,
+    } as Parameters<typeof isShortEth2LD>[0]
+
+    expect(isShortEth2LD(validationWithoutName)).toBe(false)
+  })
+})
+
+describe('isShortEth2LDName', () => {
+  it.each(['a.eth', '12.eth', 'AB.ETH', '%31%32.eth', '💩.eth'])(
+    'recognises a normalised short .eth 2LD from %s',
+    (name) => {
+      expect(isShortEth2LDName(name)).toBe(true)
+    },
+  )
+
+  it.each(['abc.eth', 'ab.example.eth', 'ab.com', 'bad%name.eth'])(
+    'does not classify %s as a short .eth 2LD',
+    (name) => {
+      expect(isShortEth2LDName(name)).toBe(false)
+    },
+  )
+
+  it('returns the same answer when the same input is checked repeatedly', () => {
+    expect(isShortEth2LDName('on.eth')).toBe(true)
+    expect(isShortEth2LDName('on.eth')).toBe(true)
+    expect(isShortEth2LDName('nick.eth')).toBe(false)
+    expect(isShortEth2LDName('nick.eth')).toBe(false)
+  })
+
+  // An encoded labelhash is a label nobody has healed yet, so its length is unknown rather than
+  // short — otherwise a normal-length name would lose bulk extension and its renewal flows.
+  it('does not classify an encoded labelhash as short, before or after its label is learned', () => {
+    const encodedTest = encodedLabelhash('test')
+
+    expect(isShortEth2LDName(encodedTest)).toBe(false)
+
+    // Something else parses `test.eth`, which writes the label into the ensjs store.
+    parseInput('test.eth')
+
+    expect(isShortEth2LDName(encodedTest)).toBe(false)
+  })
+
+  // The brackets are looked for in the decoded input, so a URL-encoded labelhash — the form a
+  // route parameter actually arrives in — is refused the same way.
+  it('does not classify a percent-encoded labelhash as short, before or after its label is learned', () => {
+    const encodedAlice = `%5B${labelhash('alice').slice(2)}%5D.eth`
+
+    expect(isShortEth2LDName(encodedAlice)).toBe(false)
+
+    parseInput('alice.eth')
+
+    expect(isShortEth2LDName(encodedAlice)).toBe(false)
+  })
+
+  // The deliberate cost of that rule: an encoded form of a genuinely short label reads as normal.
+  // It fails open — towards the behaviour every other name gets — and the decoded form the app
+  // displays and passes around once the label is known is still short.
+  it('leaves an encoded short label not-short while its decoded form is short', () => {
+    const encodedZq = encodedLabelhash('zq')
+
+    expect(isShortEth2LDName(encodedZq)).toBe(false)
+
+    parseInput('zq.eth')
+
+    expect(isShortEth2LDName(encodedZq)).toBe(false)
+    expect(isShortEth2LDName('zq.eth')).toBe(true)
+  })
+
+  // Same answer for an input first seen after its label was learned, so what the label store knows
+  // when a name is first checked cannot change what any caller is told about it.
+  it('leaves an encoded short label not-short when its label was already known', () => {
+    parseInput('qy.eth')
+    const encodedQy = encodedLabelhash('qy')
+
+    // ensjs can measure this one and calls it short; the encoded form still does not.
+    expect(parseInput(encodedQy).isShort).toBe(true)
+    expect(isShortEth2LDName(encodedQy)).toBe(false)
+  })
+})
+
+describe('getShortNameState', () => {
+  const validation = {
+    name: 'on.eth',
+    isValid: true,
+    isETH: true,
+    is2LD: true,
+    isShort: true,
+  } as const
+
+  it('should be notShort for any name at or above the minimum length', () => {
+    expect(
+      getShortNameState({
+        validation: { ...validation, name: 'nick.eth', isShort: false },
+        registrationStatus: 'available',
+      }),
+    ).toBe('notShort')
+  })
+
+  it('should be notShort for a name whose label has not been healed', () => {
+    expect(
+      getShortNameState({
+        validation: { ...validation, name: encodedLabelhash('alice') },
+        registrationStatus: 'registered',
+      }),
+    ).toBe('notShort')
+  })
+
+  it('should be pending while the ownership lookup has not answered', () => {
+    expect(getShortNameState({ validation, registrationStatus: undefined })).toBe('pending')
+  })
+
+  it('should be pending when the status only reflects missing ownership data', () => {
+    expect(getShortNameState({ validation, registrationStatus: 'invalid' })).toBe('pending')
+  })
+
+  it('should be unregistered for a short name the registrar has never issued', () => {
+    expect(getShortNameState({ validation, registrationStatus: 'short' })).toBe('unregistered')
+  })
+
+  it.each(['registered', 'gracePeriod', 'desynced'] as const)(
+    'should be registered for a short name reported as %s',
+    (registrationStatus) => {
+      expect(getShortNameState({ validation, registrationStatus })).toBe('registered')
+    },
+  )
+})

--- a/src/utils/shortName.ts
+++ b/src/utils/shortName.ts
@@ -1,0 +1,98 @@
+import { checkIsDecrypted, parseInput } from '@ensdomains/ensjs/utils'
+
+import type { RegistrationStatus } from './registrationStatus'
+
+type ShortEthNameValidation = {
+  isETH?: boolean
+  is2LD?: boolean
+  isShort?: boolean
+  isValid?: boolean
+  /**
+   * The name the other flags were measured from — `useValidate`'s `name`, which `useBasicName` and
+   * `useNameDetails` both spread into their results. Required so that no call site can drop the
+   * unknown-label check by accident.
+   */
+  name: string
+}
+
+/**
+ * Whether the app can read the labels of the name it is holding. A label the subgraph has not healed
+ * arrives as an encoded labelhash (`[<64 hex chars>].eth`), and an unhealed label has no output to
+ * measure, which `parseInput` reports as `isShort: true`. That is a statement about what is known,
+ * not about the label's length, so shortness is only ever asserted for a label the app can actually
+ * read: an unknown one keeps normal-name behaviour — including every renewal path — until
+ * `useDecodedName` heals it, which is the same condition this asks.
+ *
+ * `getRegistrationStatus` asks it too, for the stronger reason that an unknown label cannot be
+ * judged registerable at all.
+ */
+export const isKnownLabel = (name: string | undefined) => !!name && checkIsDecrypted(name)
+
+/**
+ * The `.eth` registrar enforces a three character minimum label in `register()`, so a shorter 2LD
+ * can never be registered. A handful predate that rule and are real, owned names (`on.eth`), which
+ * is why this is only a statement about the label, never about whether the name exists. `renew()`
+ * carries no such minimum — renewal is deliberately not offered in the app for these names as
+ * product policy, see WEB-1235.
+ */
+export const isShortEth2LD = ({ isETH, is2LD, isShort, isValid, name }: ShortEthNameValidation) =>
+  isValid === true && isETH === true && is2LD === true && isShort === true && isKnownLabel(name)
+
+/**
+ * Memoised because `parseInput` normalises the label and writes it into the `ensjs:labels`
+ * localStorage store on every call, which is far too costly for a per-row, per-render check. Every
+ * answer is a pure function of the input string — an encoded labelhash answers the same whether or
+ * not its label is known — so nothing cached here can go stale as the label store learns labels.
+ */
+const shortEth2LDNameCache = new Map<string, boolean>()
+
+const parseIsShortEth2LDName = (input: string) => {
+  let decodedInput: string
+  try {
+    decodedInput = decodeURIComponent(input)
+  } catch {
+    return false
+  }
+
+  try {
+    const { isShort, isValid, is2LD, isETH } = parseInput(decodedInput)
+    // The name judged is the one the caller passed rather than what `parseInput` resolved it to:
+    // an encoded labelhash whose label is later learned to be `on` still answers not-short in that
+    // form, because nothing that held that form could have known. Its decoded `on.eth` — the form
+    // the app displays and passes here once the label is known — is short by the ordinary rule.
+    return isShortEth2LD({ isShort, isValid, is2LD, isETH, name: decodedInput })
+  } catch {
+    return false
+  }
+}
+
+export const isShortEth2LDName = (input: string) => {
+  const cached = shortEth2LDNameCache.get(input)
+  if (cached !== undefined) return cached
+
+  const result = parseIsShortEth2LDName(input)
+  shortEth2LDNameCache.set(input, result)
+  return result
+}
+
+/**
+ * What a short `.eth` 2LD is, from the app's point of view. `12.eth` and `on.eth` are
+ * indistinguishable until the ownership and expiry lookups resolve, so `pending` exists to stop
+ * surfaces flashing either a profile or a dead-end error before that answer arrives.
+ */
+export type ShortNameState = 'notShort' | 'pending' | 'unregistered' | 'registered'
+
+export const getShortNameState = ({
+  validation,
+  registrationStatus,
+}: {
+  validation: ShortEthNameValidation
+  registrationStatus?: RegistrationStatus
+}): ShortNameState => {
+  if (!isShortEth2LD(validation)) return 'notShort'
+  if (registrationStatus === 'short') return 'unregistered'
+  // `invalid` is what the status model reports while the ownership lookup is disabled or has not
+  // been made — no answer yet, rather than evidence that the name is real.
+  if (!registrationStatus || registrationStatus === 'invalid') return 'pending'
+  return 'registered'
+}


### PR DESCRIPTION
Fixes how the app handles 1- and 2-character `.eth` names.

The `.eth` registrar's controller enforces a 3-character minimum in `register()`, so a shorter 2LD can never be (re-)registered — but a handful of such names predate the rule and are real, owned names (`on.eth`, held by the ENS DAO). The app previously returned `short` for every short `.eth` 2LD before consulting ownership and disabled all chain reads for them, so `12.eth` and `on.eth` were indistinguishable: both rendered a full profile from the search dropdown, with an Extend button that produced broken output.

Registration status is now derived from the registrar lifecycle for short names:

- **Unregistered short names (`12.eth`) are dead ends.** The search row is inert for both mouse and keyboard, `/12.eth` shows a minimum-length error with no tabs or actions, and `/12.eth/register` redirects to that error.
- **Registered short names (`on.eth`) keep an honest profile**: owner, records, subnames, and the name's real expiry are shown. Every renewal entry point is closed for them as deliberate app policy: the profile and ownership-tab extend buttons, `useAbilities.canExtend`, the `?renew=` deep link, bulk selection in the names list, persisted ExtendNames flows (a dedicated dialog view), and a final guard in the extendNames transaction. Grace-period copy for short names states the dead end honestly instead of promising re-registration.
- **Names with unhealed (encoded-labelhash) labels are never classified by length** — shortness is only asserted for a label the app can read, and an unknown label can never reach `short`, `available`, or `premium`. This keeps normal-length names with unhealed labels fully functional and stops the app from ever offering to register a literal bracket-string.

Status derivation waits for the ownership lookup, so neither the profile nor the error flashes while short-name data loads. Non-short names, DNS names, subnames with short labels, and `[root]` behave exactly as before.

Test suite and typecheck are at exact parity with the branch point: the 8 pre-existing test failures (6 `useBasicName` fixture mismatches, 2 ICU date formats) and 46 pre-existing type errors in test/e2e files are unchanged; the change adds 96 passing tests and zero new type errors. Lint and knip are clean.

Ref: WEB-1235
